### PR TITLE
005: MCP specification 2026 baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,14 +77,14 @@ The first implementation slices must convert this bootstrap list into a machine-
 - `C:\Projects\doc-solution` — harvest deterministic documentation/knowledge patterns, normalized governance models, provenance, lookup/filter/trace/impact/health/compare contracts, architecture/governance views, project-documentation build/publication, and human-doc generation lessons.
 - `C:\Projects\GPT-OS` — harvest machine-readable governance sources, generated governance/documentation views, authority routing, module-boundary contracts, publication packages, integrity checks, and source-to-view verification patterns.
 - `C:\Projects\supervox` — harvest MRD taxonomy, metadata envelopes, stable IDs, binding semantics, template inheritance, modular contracts, validation gates, cross-reference discipline, and MRD-to-document-type patterns such as specifications, procedures, and decision records.
-- `C:\Projects\References\mcp-specification\mcp-spec-2025-11-25-direct-md-clean` — target/reference corpus for the first specification-generation mandate while FastMCP 4.x remains a transitional implementation target; use its layout, navigation feel, section decomposition, normative presentation, and MCP specification corpus as parity evidence, not as KIS authority.
+- `C:\Projects\References\mcp-specification\mcp-docs-2026-07-28-direct-md-clean` — captured MCP `2026-07-28` reference corpus for the specification-generation mandate; use its `/specification/2026-07-28/` subset, including the schema reference, for layout, navigation feel, section decomposition, normative presentation, and specification parity evidence, not as KIS authority.
 - DeepWiki/Litho and Graphify — keep as paired external reference candidates during Knowledge architecture development. Continuously compare their repository-understanding, graph, wiki/document generation, retrieval, MCP/tool exposure, and agent-processing patterns against the native KIS Knowledge design. Prefer selective adoption or composition over wholesale replacement unless later evidence justifies a different decision.
 
 Pin harvest evidence to concrete revisions/hashes whenever the source supports them. Never silently harvest a moving source and present the result as reproducible.
 
 ## First product mandate — generated `kis-op` Governance Specification
 
-The first delivery target is the generated human-reviewable `kis-op` Governance Specification, derived from governed machine-readable authority and presented with conventions comparable to the captured MCP 2025 specification set.
+The first delivery target is the generated human-reviewable `kis-op` Governance Specification, derived from governed machine-readable authority and presented with conventions comparable to the captured MCP 2026-07-28 specification set.
 
 Until that governance specification is complete, keep implementation scope on prescribing the `kis-op` governance model: the 47-MRD baseline, applicability and selection, lifecycle, ownership, relationships and bindings, validation and enforcement, extensibility, and the behavior expected from `kis-op`. Broader Knowledge/Docs platform work remains future scope unless it is strictly required to generate or validate this governance specification.
 
@@ -92,7 +92,7 @@ Build the bridge in slices from governed governance authority to normalized mode
 
 The required progression for this first mandate is:
 
-1. Use the MCP 2025 corpus as presentation and specification-structure evidence, not as KIS authority.
+1. Use the MCP 2026-07-28 specification corpus as presentation and specification-structure evidence, not as KIS authority.
 2. Preserve the existing 47-MRD classification baseline and prescribe explicit applicability and minimum-sufficient selection rules for every type.
 3. Prescribe canonical fact ownership, governed relationships and bindings, authority layering, provenance, lifecycle, extensibility, and `kis-op` operating behavior as machine-readable MRDs.
 4. Make deterministic portions machine-enforceable through schemas, validators, workflow contracts, generated-view checks, and stable diagnostics; label review-based enforcement distinctly.

--- a/contracts/publication/v2/governance-spec.schema.json
+++ b/contracts/publication/v2/governance-spec.schema.json
@@ -66,7 +66,7 @@
       }
     },
     "layout_profile": {
-      "const": "mcp-spec-2025"
+      "const": "mcp-spec"
     }
   }
 }

--- a/contracts/publication/v2/manifest.schema.json
+++ b/contracts/publication/v2/manifest.schema.json
@@ -53,7 +53,7 @@
           "minLength": 1
         },
         "layout_profile": {
-          "const": "mcp-spec-2025"
+          "const": "mcp-spec"
         }
       }
     },

--- a/generated/governance-spec/000-index.md
+++ b/generated/governance-spec/000-index.md
@@ -1,7 +1,7 @@
 <!-- GENERATED — DO NOT EDIT -->
 # kis-op Governance Specification — documentation index
 
-This generated collection follows the `mcp-spec-2025` publication profile. Source MRDs remain authoritative; these pages are review projections.
+This generated collection follows the `mcp-spec` publication profile. Source MRDs remain authoritative; these pages are review projections.
 
 ## Specification pages
 

--- a/generated/governance-spec/manifest.json
+++ b/generated/governance-spec/manifest.json
@@ -1,14 +1,14 @@
 {
-  "bundle_sha256": "96294952c41cd2b1da4989dd6fd747d67ca6a5d9075fa0c82a1f28e58c1b9e50",
+  "bundle_sha256": "49350d5e19d90806245a02d0ee57ab2d1ced3c8693d87ccb6d2ebad9e0d62eed",
   "contract": {
     "name": "kis-governance-spec-build",
     "version": 2
   },
   "files": [
     {
-      "bytes": 927,
+      "bytes": 922,
       "path": "000-index.md",
-      "sha256": "94037cde8645131ee05d39dd3ac4c2d51d5708354710247319e16091be72941e"
+      "sha256": "3b3f604e9be788a136387387531e77e14ac48492a5bae80595429f47f0d87b22"
     },
     {
       "bytes": 2130,
@@ -94,15 +94,15 @@
       },
       {
         "path": "src/kis_mcp_doc/render.py",
-        "sha256": "43be87d12c4e44987f748303a86b2a8ab8eb8d77ccd898a49794816c3f52d911"
+        "sha256": "ef384525c9df22274287f5ea6613cc410824ca3e54c5bcaa88101cac8e1a6744"
       },
       {
         "path": "contracts/publication/v2/governance-spec.schema.json",
-        "sha256": "93984b913e43a999b394aaecf78a7fb2a5279be6822140fd1d3b076b9b0e8ae3"
+        "sha256": "fcdb9e7ee3343939cff0b16fff93d9ddd08e51c30e0dee2ffd2bc7c944e7e92b"
       },
       {
         "path": "contracts/publication/v2/manifest.schema.json",
-        "sha256": "60c9ea6039c5e25b56e423ec3b7be40de700b8c8028e35aeabba35aadc7954b4"
+        "sha256": "8994c0cd43063d3c9d44056bdd9339ffed431c251768eaa8697fe2c3fbfa34a0"
       },
       {
         "path": "contracts/documentation/harvest/v1/registry.schema.json",
@@ -119,7 +119,7 @@
     "external_evidence": [],
     "harvest_registry": {
       "path": "publication/harvest-sources.json",
-      "sha256": "e16c07d1c8c9bff849432623accf87a5caf3405866187da03f13efc88b2c77b0",
+      "sha256": "c95235389e40f4761f345225db13a4465d16d4024f029858206571b6bd6ab4a7",
       "version": "1.0.0"
     },
     "mrds": [
@@ -180,7 +180,7 @@
     ],
     "publication": {
       "path": "publication/governance-spec.json",
-      "sha256": "3b01c61afe2e78d939c96a9fea4e3a1ff3b478db42990b71c8bb64ccdfc41651"
+      "sha256": "cf20f156b64dcb50440cedb71033a9829f5e363e90ccc8d1076d1554052771ad"
     },
     "source_files": [
       {
@@ -202,7 +202,7 @@
     "source_set_sha256": "c169f1ed844a2a7da0029656f1371a2e8e787cf48d369bfa304380c4ed990fe7"
   },
   "specification": {
-    "layout_profile": "mcp-spec-2025",
+    "layout_profile": "mcp-spec",
     "status": "draft",
     "title": "kis-op Governance Specification",
     "version": "2.0.0"

--- a/publication/governance-spec.json
+++ b/publication/governance-spec.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "layout_profile": "mcp-spec-2025",
+  "layout_profile": "mcp-spec",
   "title": "kis-op Governance Specification",
   "subtitle": "Governance contract for MRD selection, authority, lifecycle, enforcement, and kis-op behavior",
   "version": "2.0.0",

--- a/publication/harvest-sources.json
+++ b/publication/harvest-sources.json
@@ -1,5 +1,8 @@
 {
-  "contract": {"name": "harvest-source-registry", "version": 1},
+  "contract": {
+    "name": "harvest-source-registry",
+    "version": 1
+  },
   "registry_version": "1.0.0",
   "sources": [
     {
@@ -11,7 +14,9 @@
       "content_sha256": null,
       "trust_classification": "parent_governing_reference",
       "acquisition_method": "registered_local_checkout",
-      "applicable_contracts": ["harvest-source-registry/v1"],
+      "applicable_contracts": [
+        "harvest-source-registry/v1"
+      ],
       "status": "active_reference"
     },
     {
@@ -23,7 +28,9 @@
       "content_sha256": null,
       "trust_classification": "harvest_reference",
       "acquisition_method": "registered_local_checkout",
-      "applicable_contracts": ["harvest-source-registry/v1"],
+      "applicable_contracts": [
+        "harvest-source-registry/v1"
+      ],
       "status": "active_reference"
     },
     {
@@ -35,7 +42,9 @@
       "content_sha256": null,
       "trust_classification": "harvest_reference",
       "acquisition_method": "registered_local_checkout",
-      "applicable_contracts": ["harvest-source-registry/v1"],
+      "applicable_contracts": [
+        "harvest-source-registry/v1"
+      ],
       "status": "active_reference"
     },
     {
@@ -47,19 +56,24 @@
       "content_sha256": null,
       "trust_classification": "harvest_reference",
       "acquisition_method": "registered_local_checkout",
-      "applicable_contracts": ["harvest-source-registry/v1"],
+      "applicable_contracts": [
+        "harvest-source-registry/v1"
+      ],
       "status": "active_reference"
     },
     {
-      "id": "mcp-spec-2025-11-25",
-      "source_role": "MCP specification presentation and corpus-structure parity reference",
-      "identity": "modelcontextprotocol/specification@2025-11-25",
-      "revision_strategy": "captured_corpus_content_hash",
-      "pinned_revision": "2025-11-25",
-      "content_sha256": "2fe1f78c929deba4597c69d2c8adef57280666c6bba7b9587bcc4b53c89f0944",
+      "id": "mcp-spec-2026-07-28",
+      "source_role": "MCP 2026-07-28 specification presentation and corpus-structure parity reference",
+      "identity": "modelcontextprotocol/specification@2026-07-28",
+      "revision_strategy": "captured_specification_content_set_hash",
+      "pinned_revision": "2026-07-28",
+      "content_sha256": "8d5af577abff93b6c3a62419f146345f3387550e22255cf81004080e87a761e2",
       "trust_classification": "presentation_reference",
       "acquisition_method": "pinned_markdown_corpus",
-      "applicable_contracts": ["mcp-spec-2025", "harvest-source-registry/v1"],
+      "applicable_contracts": [
+        "mcp-spec",
+        "harvest-source-registry/v1"
+      ],
       "status": "active_reference"
     },
     {
@@ -71,7 +85,10 @@
       "content_sha256": null,
       "trust_classification": "advisory_external_evidence",
       "acquisition_method": "validated_litho_evidence_package",
-      "applicable_contracts": ["litho-evidence-package/v1", "harvest-source-registry/v1"],
+      "applicable_contracts": [
+        "litho-evidence-package/v1",
+        "harvest-source-registry/v1"
+      ],
       "status": "candidate"
     },
     {
@@ -83,7 +100,9 @@
       "content_sha256": null,
       "trust_classification": "advisory_external_candidate",
       "acquisition_method": "resolve_before_use",
-      "applicable_contracts": ["harvest-source-registry/v1"],
+      "applicable_contracts": [
+        "harvest-source-registry/v1"
+      ],
       "status": "unresolved"
     }
   ]

--- a/src/kis_mcp_doc/render.py
+++ b/src/kis_mcp_doc/render.py
@@ -484,7 +484,7 @@ def _render_corpus_index(
         "<!-- GENERATED — DO NOT EDIT -->",
         f"# {config['title']} — documentation index",
         "",
-        "This generated collection follows the `mcp-spec-2025` publication profile. Source MRDs remain authoritative; these pages are review projections.",
+        "This generated collection follows the `mcp-spec` publication profile. Source MRDs remain authoritative; these pages are review projections.",
         "",
         "## Specification pages",
         "",

--- a/tests/test_docs_backend.py
+++ b/tests/test_docs_backend.py
@@ -73,7 +73,7 @@ def test_litho_package_hash_tampering_fails_closed(tmp_path: Path) -> None:
         load_litho_evidence(ROOT, package)
 
 
-def test_governance_build_uses_mcp_spec_2025_multi_page_profile(tmp_path: Path) -> None:
+def test_governance_build_uses_mcp_spec_multi_page_profile(tmp_path: Path) -> None:
     output = tmp_path / "build"
 
     manifest = build_governance_spec(_repo(), PUBLICATION, output)
@@ -95,7 +95,7 @@ def test_governance_build_uses_mcp_spec_2025_multi_page_profile(tmp_path: Path) 
     actual_pages = {path.name for path in output.glob("*.md")}
     assert expected_pages == actual_pages
     assert manifest["contract"]["version"] == 2
-    assert manifest["specification"]["layout_profile"] == "mcp-spec-2025"
+    assert manifest["specification"]["layout_profile"] == "mcp-spec"
     root = (output / "001-specification.md").read_text(encoding="utf-8")
     assert '<div id="enable-section-numbers" />' in root
     assert "BCP 14" in root and "RFC2119" in root and "RFC8174" in root
@@ -156,7 +156,7 @@ def test_harvest_registry_pins_adopted_sources_without_machine_paths() -> None:
 
     assert sources["doc-solution"]["identity"] == "NielPieterse0/doc-solution"
     assert sources["doc-solution"]["pinned_revision"] == "acf9ffd139ee009d3b921d5cd7c24691bb1c4737"
-    assert sources["mcp-spec-2025-11-25"]["content_sha256"] == "2fe1f78c929deba4597c69d2c8adef57280666c6bba7b9587bcc4b53c89f0944"
+    assert sources["mcp-spec-2026-07-28"]["content_sha256"] == "8d5af577abff93b6c3a62419f146345f3387550e22255cf81004080e87a761e2"
     assert sources["litho"]["identity"] == "sopaco/deepwiki-rs"
     assert sources["litho"]["trust_classification"] == "advisory_external_evidence"
     serialized = json.dumps(registry, sort_keys=True)


### PR DESCRIPTION
## Outcome
005: MCP specification 2026 baseline

## Summary
Publishes the verified MCP 2026 baseline update after 004. The source commit is stacked on 004; publication reconciles the exact 005 tree onto the landed 004 state on main.

## Change metadata
- Complexity: `medium`
- Risk triggers: `none`
- Branch: `change/005-mcp-spec-2026-baseline`
- Scope: exact source commit
- Source commit: `f791758b9b13f207958b4fc7a860f3d753c4c27c`
- Published head: `50b439faf361f03c39f27bab7231d3dce96ba36d`
- Verification: powershell-verify-script:passed, python-pytest:passed
- Review: code-quality:completed
- Documentation impact: `not_assessed`
- Reconciliation base: `tree_equivalent`
- Residual state: none declared
