### PR TITLE
Implement Work Management specification

### DIFF
--- a/evidence/work-management/canonical-snapshot.json
+++ b/evidence/work-management/canonical-snapshot.json
@@ -1,0 +1,2558 @@
+{
+  "captured_at": "2026-08-26",
+  "live_project_observation": {
+    "project": "NielPieterse0/1",
+    "status": "observed",
+    "observed_at": "2026-08-26T01:36:19Z",
+    "authority": "configured_work_management_backend",
+    "inventory_complete": true,
+    "schema_status": {
+      "ready": true,
+      "fields_ready": true,
+      "views_ready": true,
+      "missing_fields": [],
+      "type_mismatches": [],
+      "missing_options": [],
+      "missing_views": [],
+      "unverified_views": [],
+      "view_mismatches": []
+    },
+    "note": "Live Project inventory and schema comparison were observed after the initial provider failure; no drift was reported."
+  },
+  "schema_version": 1,
+  "source_repository": "NielPieterse0/kis-mcp",
+  "source_revision": "b1c7f00a90c063c6cae287669035e358a04295e0",
+  "sources": [
+    {
+      "bytes": 4837,
+      "json": {
+        "claim": {
+          "auto_expiry": false,
+          "execution_owner_field": "Execution Owner"
+        },
+        "completion": {
+          "require_no_active_claim_after_close": false,
+          "terminal_state": "done"
+        },
+        "delivery": {
+          "change_created_stage": "change_created",
+          "change_id_field": "Change ID",
+          "complete_stage": "complete",
+          "complexity_field": "Complexity",
+          "risk_triggers_field": "Risk Triggers",
+          "stage_field": "Delivery Stage"
+        },
+        "delivery_stages": [
+          "none",
+          "change_created",
+          "implementing",
+          "pr_open",
+          "review",
+          "ci_pending",
+          "ci_failed",
+          "ci_passed",
+          "merged",
+          "documentation",
+          "commissioning",
+          "complete"
+        ],
+        "field_authority": {
+          "Authority Revision": {
+            "authority": "git",
+            "direction": "evidence"
+          },
+          "Blocked By": {
+            "authority": "github",
+            "direction": "evidence"
+          },
+          "Change ID": {
+            "authority": "repository_change",
+            "direction": "evidence"
+          },
+          "Commissioning Key": {
+            "authority": "derived",
+            "direction": "evidence"
+          },
+          "Complexity": {
+            "authority": "repository_change",
+            "direction": "evidence"
+          },
+          "Confidence": {
+            "authority": "work_management",
+            "direction": "command"
+          },
+          "Created": {
+            "authority": "github",
+            "direction": "evidence"
+          },
+          "Delivery Stage": {
+            "authority": "derived",
+            "direction": "evidence"
+          },
+          "Disposition": {
+            "authority": "work_management",
+            "direction": "command"
+          },
+          "Documentation Impact": {
+            "authority": "work_management_then_repository_change",
+            "direction": "handoff"
+          },
+          "Effort": {
+            "authority": "work_management",
+            "direction": "command"
+          },
+          "Execution Owner": {
+            "authority": "work_management",
+            "direction": "command"
+          },
+          "External Link": {
+            "authority": "work_management",
+            "direction": "command"
+          },
+          "Iteration": {
+            "authority": "work_management",
+            "direction": "command"
+          },
+          "Live Verification": {
+            "authority": "derived",
+            "direction": "evidence"
+          },
+          "Live Verification Evidence": {
+            "authority": "derived",
+            "direction": "evidence"
+          },
+          "Module": {
+            "authority": "work_management_then_repository_change",
+            "direction": "handoff"
+          },
+          "Origin": {
+            "authority": "work_management",
+            "direction": "command"
+          },
+          "Priority": {
+            "authority": "work_management",
+            "direction": "command"
+          },
+          "Project ID": {
+            "authority": "derived",
+            "direction": "evidence"
+          },
+          "Record Type": {
+            "authority": "work_management",
+            "direction": "command"
+          },
+          "Repository": {
+            "authority": "github",
+            "direction": "evidence"
+          },
+          "Review Trigger": {
+            "authority": "work_management",
+            "direction": "command"
+          },
+          "Risk Triggers": {
+            "authority": "repository_change",
+            "direction": "evidence"
+          },
+          "Severity": {
+            "authority": "work_management",
+            "direction": "command"
+          },
+          "Source Review": {
+            "authority": "work_management",
+            "direction": "command"
+          },
+          "Status": {
+            "authority": "work_management",
+            "direction": "command"
+          },
+          "Target Date": {
+            "authority": "work_management",
+            "direction": "command"
+          },
+          "Verification": {
+            "authority": "actions",
+            "direction": "evidence"
+          }
+        },
+        "intake_aliases": {
+          "todo": "inbox"
+        },
+        "queue": {
+          "blocked_by_field": "Blocked By",
+          "created_field": "Created",
+          "effort_field": "Effort",
+          "effort_order": [
+            "tiny",
+            "small",
+            "medium",
+            "large"
+          ],
+          "eligible_states": [
+            "ready"
+          ],
+          "priority_field": "Priority",
+          "priority_order": [
+            "critical",
+            "high",
+            "medium",
+            "low"
+          ],
+          "ranking": [
+            "priority",
+            "effort",
+            "created_order",
+            "record_id"
+          ],
+          "state_field": "Status"
+        },
+        "readiness": {
+          "required_issue_sections": [
+            "Outcome",
+            "Acceptance criteria"
+          ],
+          "required_project_fields": [
+            "Record Type",
+            "Priority",
+            "Effort",
+            "Documentation Impact"
+          ],
+          "requires_dependencies_understood": true
+        },
+        "schema_version": 1,
+        "transition_requirements": {
+          "deferred": [
+            "Review Trigger"
+          ],
+          "on_hold": [
+            "Review Trigger"
+          ]
+        },
+        "transitions": {
+          "active": [
+            "ready",
+            "review",
+            "blocked",
+            "on_hold",
+            "deferred",
+            "done",
+            "superseded"
+          ],
+          "approved": [
+            "ready",
+            "active",
+            "on_hold",
+            "deferred",
+            "superseded"
+          ],
+          "blocked": [
+            "ready",
+            "active",
+            "on_hold",
+            "deferred",
+            "superseded"
+          ],
+          "deferred": [
+            "triage",
+            "proposed",
+            "approved",
+            "rejected",
+            "superseded"
+          ],
+          "documentation": [
+            "done",
+            "active",
+            "blocked",
+            "superseded"
+          ],
+          "done": [],
+          "inbox": [
+            "triage",
+            "deferred",
+            "rejected",
+            "superseded"
+          ],
+          "on_hold": [
+            "ready",
+            "active",
+            "deferred",
+            "rejected",
+            "superseded"
+          ],
+          "proposed": [
+            "approved",
+            "deferred",
+            "rejected",
+            "superseded"
+          ],
+          "ready": [
+            "active",
+            "on_hold",
+            "deferred",
+            "superseded"
+          ],
+          "rejected": [
+            "triage",
+            "superseded"
+          ],
+          "review": [
+            "active",
+            "verification",
+            "blocked",
+            "on_hold",
+            "superseded"
+          ],
+          "superseded": [],
+          "triage": [
+            "proposed",
+            "approved",
+            "deferred",
+            "rejected",
+            "superseded"
+          ],
+          "verification": [
+            "active",
+            "documentation",
+            "blocked",
+            "superseded"
+          ]
+        },
+        "work_states": [
+          "inbox",
+          "triage",
+          "proposed",
+          "approved",
+          "ready",
+          "active",
+          "blocked",
+          "on_hold",
+          "deferred",
+          "rejected",
+          "superseded",
+          "done"
+        ]
+      },
+      "path": "settings/work-management/command-plane.settings.json",
+      "sha256": "4af984b02bbfedc49234d52a4e803c92099f4d70dde7401441773f158386254d"
+    },
+    {
+      "bytes": 31293,
+      "json": {
+        "contexts": [
+          {
+            "definition": "Fields required before work is executable from Ready.",
+            "id": "ready_metadata",
+            "kind": "state_in",
+            "values": [
+              "ready"
+            ]
+          },
+          {
+            "definition": "Fields required for work represented as actively executing.",
+            "id": "active_claim",
+            "kind": "state_in",
+            "values": [
+              "active"
+            ]
+          },
+          {
+            "definition": "Fields required when work is paused or deferred.",
+            "id": "hold_or_defer",
+            "kind": "state_in",
+            "values": [
+              "on_hold",
+              "deferred"
+            ]
+          },
+          {
+            "definition": "Fields required for finding and risk records.",
+            "id": "finding_or_risk",
+            "kind": "record_type_in",
+            "values": [
+              "finding",
+              "security_finding",
+              "risk"
+            ]
+          },
+          {
+            "definition": "Fields required for finding and assumption records.",
+            "id": "finding_or_assumption",
+            "kind": "record_type_in",
+            "values": [
+              "finding",
+              "security_finding",
+              "assumption"
+            ]
+          },
+          {
+            "definition": "Fields required once authoritative governed change identity exists.",
+            "id": "governed_change",
+            "kind": "signal",
+            "values": [
+              "governed_change_exists"
+            ]
+          }
+        ],
+        "contract_id": "work-item-semantics",
+        "fields": [
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "work_management",
+            "definition": "Operational Work lifecycle status.",
+            "direction": "command",
+            "id": "status",
+            "managed": true,
+            "name": "Status",
+            "population": "Set by explicit Work lifecycle operations.",
+            "provider_type": "single_select",
+            "required_contexts": [],
+            "vocabulary": "status"
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "work_management",
+            "definition": "Purpose classification of the Work record.",
+            "direction": "command",
+            "id": "record_type",
+            "managed": true,
+            "name": "Record Type",
+            "population": "Set during intake/triage and changed only by explicit Work authority.",
+            "provider_type": "single_select",
+            "required_contexts": [
+              "ready_metadata"
+            ],
+            "vocabulary": "record_type"
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "work_management",
+            "definition": "Relative scheduling importance.",
+            "direction": "command",
+            "id": "priority",
+            "managed": true,
+            "name": "Priority",
+            "population": "Set by Work Management and consumed by selection ranking.",
+            "provider_type": "single_select",
+            "required_contexts": [
+              "ready_metadata"
+            ],
+            "vocabulary": "priority"
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "work_management",
+            "definition": "Relative implementation or coordination effort.",
+            "direction": "command",
+            "id": "effort",
+            "managed": true,
+            "name": "Effort",
+            "population": "Set by Work Management and consumed by selection ranking.",
+            "provider_type": "single_select",
+            "required_contexts": [
+              "ready_metadata"
+            ],
+            "vocabulary": "effort"
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "derived",
+            "definition": "Evidence-derived governed delivery stage.",
+            "direction": "evidence",
+            "id": "delivery_stage",
+            "managed": true,
+            "name": "Delivery Stage",
+            "population": "Projected from repository/GitHub delivery evidence.",
+            "provider_type": "single_select",
+            "required_contexts": [],
+            "vocabulary": "delivery_stage"
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "work_management",
+            "definition": "Stable identity of the current execution claimant.",
+            "direction": "command",
+            "id": "execution_owner",
+            "managed": true,
+            "name": "Execution Owner",
+            "population": "Set and cleared only by claim/release lifecycle operations.",
+            "provider_type": "text",
+            "required_contexts": [
+              "active_claim"
+            ],
+            "vocabulary": null
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "github",
+            "definition": "Provider-observed dependency or blocker reference; explicit empty differs from unavailable evidence.",
+            "direction": "evidence",
+            "id": "blocked_by",
+            "managed": true,
+            "name": "Blocked By",
+            "population": "Read from GitHub Project dependency evidence.",
+            "provider_type": "text",
+            "required_contexts": [],
+            "vocabulary": null
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "work_management_then_repository_change",
+            "definition": "Expected or completed documentation impact for the work/change.",
+            "direction": "handoff",
+            "id": "documentation_impact",
+            "managed": true,
+            "name": "Documentation Impact",
+            "population": "Starts as Work command data and becomes governed change evidence.",
+            "provider_type": "single_select",
+            "required_contexts": [
+              "ready_metadata"
+            ],
+            "vocabulary": "documentation_impact"
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "repository_change",
+            "definition": "Repository change-governance complexity projected into Work.",
+            "direction": "evidence",
+            "id": "complexity",
+            "managed": true,
+            "name": "Complexity",
+            "population": "Projected from authoritative schema-v4 governed change scope.",
+            "provider_type": "single_select",
+            "required_contexts": [],
+            "vocabulary": "complexity"
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "repository_change",
+            "definition": "Comma-separated repository change-governance risk-trigger tokens.",
+            "direction": "evidence",
+            "id": "risk_triggers",
+            "managed": true,
+            "name": "Risk Triggers",
+            "population": "Projected from authoritative governed change scope.",
+            "provider_type": "text",
+            "required_contexts": [],
+            "vocabulary": null
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "derived",
+            "definition": "Stable KIS project registry identity for the work item.",
+            "direction": "evidence",
+            "id": "project_id",
+            "managed": true,
+            "name": "Project ID",
+            "population": "Derived from the registered repository-to-project mapping.",
+            "provider_type": "text",
+            "required_contexts": [],
+            "vocabulary": null
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "github",
+            "definition": "GitHub repository identity of the source item.",
+            "direction": "evidence",
+            "id": "repository",
+            "managed": true,
+            "name": "Repository",
+            "population": "Read from the GitHub source item/provider binding.",
+            "provider_type": "repository",
+            "required_contexts": [],
+            "vocabulary": null
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "work_management_then_repository_change",
+            "definition": "Optional bounded module or subsystem context for the work.",
+            "direction": "handoff",
+            "id": "module",
+            "managed": true,
+            "name": "Module",
+            "population": "Set by Work and handed to governed change planning when applicable.",
+            "provider_type": "text",
+            "required_contexts": [],
+            "vocabulary": null
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "repository_change",
+            "definition": "Canonical governed repository change ID once one exists.",
+            "direction": "evidence",
+            "id": "change_id",
+            "managed": true,
+            "name": "Change ID",
+            "population": "Projected from authoritative local change scope.",
+            "provider_type": "text",
+            "required_contexts": [
+              "governed_change"
+            ],
+            "vocabulary": null
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "work_management",
+            "definition": "Context that originated the record.",
+            "direction": "command",
+            "id": "origin",
+            "managed": true,
+            "name": "Origin",
+            "population": "Set when the Work record is created or classified.",
+            "provider_type": "single_select",
+            "required_contexts": [],
+            "vocabulary": "origin"
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "work_management",
+            "definition": "Explicit decision disposition for records that use disposition semantics.",
+            "direction": "command",
+            "id": "disposition",
+            "managed": true,
+            "name": "Disposition",
+            "population": "Set by explicit Work decision/review operations.",
+            "provider_type": "single_select",
+            "required_contexts": [],
+            "vocabulary": "disposition"
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "actions",
+            "definition": "Repository/source verification state; never live-runtime commissioning state.",
+            "direction": "evidence",
+            "id": "verification",
+            "managed": true,
+            "name": "Verification",
+            "population": "Projected from provider-native or governed verification evidence.",
+            "provider_type": "single_select",
+            "required_contexts": [],
+            "vocabulary": "verification"
+          },
+          {
+            "applicable_record_types": [
+              "finding",
+              "security_finding",
+              "risk"
+            ],
+            "authority": "work_management",
+            "definition": "Relative material impact for finding/risk records.",
+            "direction": "command",
+            "id": "severity",
+            "managed": true,
+            "name": "Severity",
+            "population": "Set when a finding or risk is classified.",
+            "provider_type": "single_select",
+            "required_contexts": [
+              "finding_or_risk"
+            ],
+            "vocabulary": "severity"
+          },
+          {
+            "applicable_record_types": [
+              "finding",
+              "security_finding",
+              "assumption"
+            ],
+            "authority": "work_management",
+            "definition": "Evidence confidence for finding/assumption records.",
+            "direction": "command",
+            "id": "confidence",
+            "managed": true,
+            "name": "Confidence",
+            "population": "Set from the evidence quality supporting the record.",
+            "provider_type": "single_select",
+            "required_contexts": [
+              "finding_or_assumption"
+            ],
+            "vocabulary": "confidence"
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "work_management",
+            "definition": "Condition or date/event trigger for reconsidering paused work.",
+            "direction": "command",
+            "id": "review_trigger",
+            "managed": true,
+            "name": "Review Trigger",
+            "population": "Required when work enters On Hold or Deferred.",
+            "provider_type": "text",
+            "required_contexts": [
+              "hold_or_defer"
+            ],
+            "vocabulary": null
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "work_management",
+            "definition": "Optional target date for planned work or reconsideration.",
+            "direction": "command",
+            "id": "target_date",
+            "managed": true,
+            "name": "Target Date",
+            "population": "Set explicitly by Work Management.",
+            "provider_type": "date",
+            "required_contexts": [],
+            "vocabulary": null
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "work_management",
+            "definition": "Optional provider iteration assignment.",
+            "direction": "command",
+            "id": "iteration",
+            "managed": true,
+            "name": "Iteration",
+            "population": "Set explicitly by Work Management.",
+            "provider_type": "iteration",
+            "required_contexts": [],
+            "vocabulary": null
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "work_management",
+            "definition": "Reference to the review source that produced or governs the record.",
+            "direction": "command",
+            "id": "source_review",
+            "managed": true,
+            "name": "Source Review",
+            "population": "Set when review-derived records are captured.",
+            "provider_type": "text",
+            "required_contexts": [],
+            "vocabulary": null
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "git",
+            "definition": "Revision identity of the authority evidence used for the Work record.",
+            "direction": "evidence",
+            "id": "authority_revision",
+            "managed": true,
+            "name": "Authority Revision",
+            "population": "Projected from Git/provider revision evidence.",
+            "provider_type": "text",
+            "required_contexts": [],
+            "vocabulary": null
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "work_management",
+            "definition": "Optional bounded external reference associated with the work.",
+            "direction": "command",
+            "id": "external_link",
+            "managed": true,
+            "name": "External Link",
+            "population": "Set explicitly by Work Management.",
+            "provider_type": "text",
+            "required_contexts": [],
+            "vocabulary": null
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "github",
+            "definition": "Provider-native creation timestamp used as deterministic age evidence.",
+            "direction": "evidence",
+            "id": "created",
+            "managed": false,
+            "name": "Created",
+            "population": "Read from GitHub native item metadata.",
+            "provider_type": "native_datetime",
+            "required_contexts": [],
+            "vocabulary": null
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "derived",
+            "definition": "Post-merge live runtime verification state, distinct from source Verification.",
+            "direction": "evidence",
+            "id": "live_verification",
+            "managed": true,
+            "name": "Live Verification",
+            "population": "Projected by the deterministic commissioning lifecycle under #419.",
+            "provider_type": "single_select",
+            "required_contexts": [],
+            "vocabulary": "live_verification"
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "derived",
+            "definition": "Deterministic commissioning identity: the exact obligation key for one required surface, or the deterministic set key for a source merge with multiple required surfaces.",
+            "direction": "evidence",
+            "id": "commissioning_key",
+            "managed": true,
+            "name": "Commissioning Key",
+            "population": "Derived by the commissioning classifier/runner under #419; source projection uses a set-<digest24> key when multiple obligations must be aggregated.",
+            "provider_type": "text",
+            "required_contexts": [],
+            "vocabulary": null
+          },
+          {
+            "applicable_record_types": [
+              "*"
+            ],
+            "authority": "derived",
+            "definition": "Compact reference to durable live-verification evidence or linked commissioning work; never free-form logs.",
+            "direction": "evidence",
+            "id": "live_verification_evidence",
+            "managed": true,
+            "name": "Live Verification Evidence",
+            "population": "Projected from commissioning evidence under #419.",
+            "provider_type": "text",
+            "required_contexts": [],
+            "vocabulary": null
+          }
+        ],
+        "schema_version": 1,
+        "vocabularies": [
+          {
+            "definition": "Operational Work lifecycle status projected to GitHub Project Status.",
+            "id": "status",
+            "values": [
+              {
+                "definition": "Captured work not yet triaged.",
+                "label": "Inbox",
+                "token": "inbox"
+              },
+              {
+                "definition": "Work being classified and prepared for a disposition.",
+                "label": "Triage",
+                "token": "triage"
+              },
+              {
+                "definition": "Work proposed for acceptance but not yet approved.",
+                "label": "Proposed",
+                "token": "proposed"
+              },
+              {
+                "definition": "Accepted work that is not yet admitted to the executable queue.",
+                "label": "Approved",
+                "token": "approved"
+              },
+              {
+                "definition": "Work admitted for deterministic next-work eligibility subject to readiness, claim, and dependency guards.",
+                "label": "Ready",
+                "token": "ready"
+              },
+              {
+                "definition": "Work currently claimed for execution.",
+                "label": "Active",
+                "token": "active"
+              },
+              {
+                "definition": "Work that cannot proceed because a blocking condition is present.",
+                "label": "Blocked",
+                "token": "blocked"
+              },
+              {
+                "definition": "Work intentionally paused pending a declared review trigger.",
+                "label": "On Hold",
+                "token": "on_hold"
+              },
+              {
+                "definition": "Work postponed for later reconsideration with a declared review trigger.",
+                "label": "Deferred",
+                "token": "deferred"
+              },
+              {
+                "definition": "Work explicitly not accepted for execution in its current form.",
+                "label": "Rejected",
+                "token": "rejected"
+              },
+              {
+                "definition": "Work replaced by a newer authoritative record or outcome.",
+                "label": "Superseded",
+                "token": "superseded"
+              },
+              {
+                "definition": "Work whose required completion and closeout gates are satisfied.",
+                "label": "Done",
+                "token": "done"
+              }
+            ]
+          },
+          {
+            "definition": "Classification of the purpose of a Work record.",
+            "id": "record_type",
+            "values": [
+              {
+                "definition": "Uncommitted candidate work requiring triage before it becomes actionable.",
+                "label": "Idea",
+                "token": "idea"
+              },
+              {
+                "definition": "A bounded actionable unit of work.",
+                "label": "Task",
+                "token": "task"
+              },
+              {
+                "definition": "A bounded specification or delivery slice tracked as work.",
+                "label": "Specification Slice",
+                "token": "specification_slice"
+              },
+              {
+                "definition": "A record representing one review execution and its evidence.",
+                "label": "Review Run",
+                "token": "review_run"
+              },
+              {
+                "definition": "An actionable observation produced by review, verification, audit, or commissioning.",
+                "label": "Finding",
+                "token": "finding"
+              },
+              {
+                "definition": "A record of an explicit authoritative choice.",
+                "label": "Decision",
+                "token": "decision"
+              },
+              {
+                "definition": "A proposition tracked because later evidence may validate or invalidate it.",
+                "label": "Assumption",
+                "token": "assumption"
+              },
+              {
+                "definition": "A potential adverse condition tracked for mitigation or disposition.",
+                "label": "Risk",
+                "token": "risk"
+              },
+              {
+                "definition": "A record of an explicit approval decision.",
+                "label": "Approval",
+                "token": "approval"
+              },
+              {
+                "definition": "A record whose purpose is to track a pause or hold condition.",
+                "label": "Hold",
+                "token": "hold"
+              },
+              {
+                "definition": "A bounded investigation intended to produce evidence or a decision.",
+                "label": "Research",
+                "token": "research"
+              },
+              {
+                "definition": "A known incorrect or broken product or system behavior requiring correction.",
+                "label": "Defect",
+                "token": "defect"
+              },
+              {
+                "definition": "A finding whose material impact is security-related.",
+                "label": "Security Finding",
+                "token": "security_finding"
+              }
+            ]
+          },
+          {
+            "definition": "Relative scheduling importance used by the current deterministic Work queue.",
+            "id": "priority",
+            "values": [
+              {
+                "definition": "Highest configured scheduling importance.",
+                "label": "Critical",
+                "token": "critical"
+              },
+              {
+                "definition": "High scheduling importance below Critical.",
+                "label": "High",
+                "token": "high"
+              },
+              {
+                "definition": "Normal scheduling importance below High.",
+                "label": "Medium",
+                "token": "medium"
+              },
+              {
+                "definition": "Lowest configured scheduling importance.",
+                "label": "Low",
+                "token": "low"
+              }
+            ]
+          },
+          {
+            "definition": "Relative implementation or coordination size used by the current deterministic Work queue.",
+            "id": "effort",
+            "values": [
+              {
+                "definition": "Smallest configured relative effort.",
+                "label": "Tiny",
+                "token": "tiny"
+              },
+              {
+                "definition": "Small relative effort.",
+                "label": "Small",
+                "token": "small"
+              },
+              {
+                "definition": "Moderate relative effort.",
+                "label": "Medium",
+                "token": "medium"
+              },
+              {
+                "definition": "Largest configured relative effort.",
+                "label": "Large",
+                "token": "large"
+              }
+            ]
+          },
+          {
+            "definition": "Evidence-derived stage of governed repository delivery.",
+            "id": "delivery_stage",
+            "values": [
+              {
+                "definition": "No governed delivery stage has been established.",
+                "label": "None",
+                "token": "none"
+              },
+              {
+                "definition": "A governed repository change has been created.",
+                "label": "Change Created",
+                "token": "change_created"
+              },
+              {
+                "definition": "Implementation is in progress.",
+                "label": "Implementing",
+                "token": "implementing"
+              },
+              {
+                "definition": "A pull request is open for the governed change.",
+                "label": "PR Open",
+                "token": "pr_open"
+              },
+              {
+                "definition": "The governed change is in review.",
+                "label": "Review",
+                "token": "review"
+              },
+              {
+                "definition": "Provider-native verification is pending.",
+                "label": "CI Pending",
+                "token": "ci_pending"
+              },
+              {
+                "definition": "Provider-native verification failed.",
+                "label": "CI Failed",
+                "token": "ci_failed"
+              },
+              {
+                "definition": "Provider-native verification passed for the applicable head.",
+                "label": "CI Passed",
+                "token": "ci_passed"
+              },
+              {
+                "definition": "The governed change has been observed merged.",
+                "label": "Merged",
+                "token": "merged"
+              },
+              {
+                "definition": "Post-merge documentation reconciliation is due or in progress.",
+                "label": "Documentation",
+                "token": "documentation"
+              },
+              {
+                "definition": "Live verification or commissioning is pending or in progress.",
+                "label": "Commissioning",
+                "token": "commissioning"
+              },
+              {
+                "definition": "Delivery and required closeout evidence are complete.",
+                "label": "Complete",
+                "token": "complete"
+              }
+            ]
+          },
+          {
+            "definition": "Repository documentation impact projected from Work to governed change and back as evidence.",
+            "id": "documentation_impact",
+            "values": [
+              {
+                "definition": "Documentation impact has not yet been assessed.",
+                "label": "Not Assessed",
+                "token": "not_assessed"
+              },
+              {
+                "definition": "No documentation change is required, with rationale recorded where required.",
+                "label": "None",
+                "token": "none"
+              },
+              {
+                "definition": "Documentation changes are planned.",
+                "label": "Planned",
+                "token": "planned"
+              },
+              {
+                "definition": "Documentation changes are being implemented.",
+                "label": "In Progress",
+                "token": "in_progress"
+              },
+              {
+                "definition": "Required pre-merge documentation work is complete.",
+                "label": "Pre-merge Complete",
+                "token": "pre_merge_complete"
+              },
+              {
+                "definition": "Required post-merge documentation reconciliation is complete.",
+                "label": "Post-merge Complete",
+                "token": "post_merge_complete"
+              }
+            ]
+          },
+          {
+            "definition": "Projection of repository change-governance complexity; detailed classification criteria remain owned by change-governance settings.",
+            "id": "complexity",
+            "values": [
+              {
+                "definition": "Repository change-governance Small classification.",
+                "label": "Small",
+                "token": "small"
+              },
+              {
+                "definition": "Repository change-governance Medium classification.",
+                "label": "Medium",
+                "token": "medium"
+              },
+              {
+                "definition": "Repository change-governance Large classification.",
+                "label": "Large",
+                "token": "large"
+              }
+            ]
+          },
+          {
+            "definition": "Source context that caused a Work record to be created.",
+            "id": "origin",
+            "values": [
+              {
+                "definition": "Created directly from operator intent.",
+                "label": "Operator",
+                "token": "operator"
+              },
+              {
+                "definition": "Created from review evidence.",
+                "label": "Review",
+                "token": "review"
+              },
+              {
+                "definition": "Created from verification evidence.",
+                "label": "Verification",
+                "token": "verification"
+              },
+              {
+                "definition": "Created from implementation activity or discovery.",
+                "label": "Implementation",
+                "token": "implementation"
+              },
+              {
+                "definition": "Created from research activity or evidence.",
+                "label": "Research",
+                "token": "research"
+              }
+            ]
+          },
+          {
+            "definition": "Current decision disposition for records that require an explicit disposition.",
+            "id": "disposition",
+            "values": [
+              {
+                "definition": "No terminal disposition has been selected.",
+                "label": "Open",
+                "token": "open"
+              },
+              {
+                "definition": "The record or proposition is accepted.",
+                "label": "Accepted",
+                "token": "accepted"
+              },
+              {
+                "definition": "The record or proposition is rejected.",
+                "label": "Rejected",
+                "token": "rejected"
+              },
+              {
+                "definition": "A newer authoritative record replaces this one.",
+                "label": "Superseded",
+                "token": "superseded"
+              },
+              {
+                "definition": "The tracked risk or finding has been mitigated.",
+                "label": "Mitigated",
+                "token": "mitigated"
+              },
+              {
+                "definition": "Disposition is intentionally postponed.",
+                "label": "Deferred",
+                "token": "deferred"
+              }
+            ]
+          },
+          {
+            "definition": "Repository/source verification state; it does not represent post-merge live runtime proof.",
+            "id": "verification",
+            "values": [
+              {
+                "definition": "Repository/source verification has not run.",
+                "label": "Not Run",
+                "token": "not_run"
+              },
+              {
+                "definition": "Repository/source verification is pending or running.",
+                "label": "Pending",
+                "token": "pending"
+              },
+              {
+                "definition": "Repository/source verification passed for the applicable evidence identity.",
+                "label": "Passed",
+                "token": "passed"
+              },
+              {
+                "definition": "Repository/source verification failed.",
+                "label": "Failed",
+                "token": "failed"
+              },
+              {
+                "definition": "Repository/source verification cannot currently complete.",
+                "label": "Blocked",
+                "token": "blocked"
+              }
+            ]
+          },
+          {
+            "definition": "Relative material impact of a finding or risk.",
+            "id": "severity",
+            "values": [
+              {
+                "definition": "Highest material impact requiring urgent attention.",
+                "label": "Critical",
+                "token": "critical"
+              },
+              {
+                "definition": "High material impact.",
+                "label": "High",
+                "token": "high"
+              },
+              {
+                "definition": "Moderate material impact.",
+                "label": "Medium",
+                "token": "medium"
+              },
+              {
+                "definition": "Limited material impact.",
+                "label": "Low",
+                "token": "low"
+              }
+            ]
+          },
+          {
+            "definition": "Relative confidence classification for finding and assumption evidence; current Work authority does not define quantitative or qualitative thresholds.",
+            "id": "confidence",
+            "values": [
+              {
+                "definition": "Highest configured confidence label; no additional threshold is defined by current Work authority.",
+                "label": "High",
+                "token": "high"
+              },
+              {
+                "definition": "Middle configured confidence label; no additional threshold is defined by current Work authority.",
+                "label": "Medium",
+                "token": "medium"
+              },
+              {
+                "definition": "Lowest configured confidence label; no additional threshold is defined by current Work authority.",
+                "label": "Low",
+                "token": "low"
+              }
+            ]
+          },
+          {
+            "definition": "Post-merge live runtime verification state, distinct from repository/source Verification.",
+            "id": "live_verification",
+            "values": [
+              {
+                "definition": "The need for live verification has not yet been classified.",
+                "label": "Not Assessed",
+                "token": "not_assessed"
+              },
+              {
+                "definition": "Deterministic classification found no live verification obligation.",
+                "label": "Not Required",
+                "token": "not_required"
+              },
+              {
+                "definition": "Live verification is required and has not yet completed.",
+                "label": "Pending",
+                "token": "pending"
+              },
+              {
+                "definition": "Required live verification passed against the actual exposed capability or runtime path.",
+                "label": "Passed",
+                "token": "passed"
+              },
+              {
+                "definition": "Required live verification ran and failed its expected invariant.",
+                "label": "Failed",
+                "token": "failed"
+              },
+              {
+                "definition": "Required live verification cannot currently complete.",
+                "label": "Blocked",
+                "token": "blocked"
+              }
+            ]
+          }
+        ]
+      },
+      "path": "settings/work-management/contracts/work-item-semantics.json",
+      "sha256": "e0bb2ee1a088f5ed052a84a392511712460119301f7ef8dca9c656a8feb422b4"
+    },
+    {
+      "bytes": 11411,
+      "json": {
+        "claim": {
+          "auto_expiry": false,
+          "execution_owner_field": "Execution Owner"
+        },
+        "completion": {
+          "require_no_active_claim_after_close": false,
+          "terminal_state": "done"
+        },
+        "contract_id": "work-lifecycle-operations",
+        "delivery": {
+          "change_created_stage": "change_created",
+          "change_id_field": "Change ID",
+          "complete_stage": "complete",
+          "complexity_field": "Complexity",
+          "risk_triggers_field": "Risk Triggers",
+          "stage_field": "Delivery Stage",
+          "stages": [
+            "none",
+            "change_created",
+            "implementing",
+            "pr_open",
+            "review",
+            "ci_pending",
+            "ci_failed",
+            "ci_passed",
+            "merged",
+            "documentation",
+            "commissioning",
+            "complete"
+          ]
+        },
+        "guards": [
+          {
+            "condition": "approval_required_and_incomplete",
+            "definition": "Reject activation when the record requires approval and approval is incomplete.",
+            "disposition": "reject",
+            "id": "approval-before-active",
+            "reason_code": "approval_incomplete",
+            "target": "active"
+          },
+          {
+            "condition": "completion_requires_no_active_claim_and_claim_present",
+            "definition": "When configured, reject completion while an execution claim remains.",
+            "disposition": "reject",
+            "id": "completion-no-active-claim",
+            "reason_code": "active_claim_present",
+            "target": "done"
+          },
+          {
+            "condition": "required_documentation_reconciliation_due",
+            "definition": "Required post-merge documentation reconciliation must be completed before Done.",
+            "disposition": "reject",
+            "id": "completion-documentation-due",
+            "reason_code": "documentation_reconciliation_due",
+            "target": "done"
+          },
+          {
+            "condition": "advisory_documentation_reconciliation_due",
+            "definition": "Advisory post-merge documentation reconciliation may complete with an explicit advisory reason.",
+            "disposition": "allow_with_reason",
+            "id": "completion-documentation-due-advisory",
+            "reason_code": "documentation_reconciliation_advisory_due",
+            "target": "done"
+          },
+          {
+            "condition": "required_documentation_reconciliation_unrecorded",
+            "definition": "Required post-merge documentation milestone must be recorded before Done.",
+            "disposition": "reject",
+            "id": "completion-documentation-unrecorded",
+            "reason_code": "documentation_reconciliation_unrecorded",
+            "target": "done"
+          },
+          {
+            "condition": "advisory_documentation_reconciliation_unrecorded",
+            "definition": "Advisory documentation reconciliation may complete without a recorded post-merge milestone, with an explicit advisory reason.",
+            "disposition": "allow_with_reason",
+            "id": "completion-documentation-unrecorded-advisory",
+            "reason_code": "documentation_reconciliation_advisory_incomplete",
+            "target": "done"
+          },
+          {
+            "condition": "required_documentation_incomplete",
+            "definition": "Required documentation impact must be complete before Done.",
+            "disposition": "reject",
+            "id": "completion-documentation-incomplete",
+            "reason_code": "documentation_incomplete",
+            "target": "done"
+          },
+          {
+            "condition": "advisory_documentation_incomplete",
+            "definition": "Advisory documentation may complete while incomplete, with an explicit advisory reason.",
+            "disposition": "allow_with_reason",
+            "id": "completion-documentation-incomplete-advisory",
+            "reason_code": "documentation_advisory_incomplete",
+            "target": "done"
+          }
+        ],
+        "intake_aliases": {
+          "todo": "inbox"
+        },
+        "operations": [
+          {
+            "definition": "Capture one bounded source record into Work without duplicating source identity.",
+            "effect": "external_or_local_change",
+            "id": "capture_work",
+            "implementation_surface": "project_management_reconcile"
+          },
+          {
+            "definition": "Create or reconcile one new Work record through the configured provider boundary.",
+            "effect": "external_or_local_change",
+            "id": "create_work",
+            "implementation_surface": "project_management_reconcile"
+          },
+          {
+            "definition": "Select the next eligible Ready item and establish its execution claim.",
+            "effect": "external_or_local_change",
+            "id": "take_next_work",
+            "implementation_surface": "project_management_take_next_work"
+          },
+          {
+            "definition": "Establish one execution owner after revision and state guards pass.",
+            "effect": "external_or_local_change",
+            "id": "claim_work",
+            "implementation_surface": "project_management_claim_work"
+          },
+          {
+            "definition": "Clear an execution claim through the bounded command plane.",
+            "effect": "external_or_local_change",
+            "id": "release_work",
+            "implementation_surface": "project_management_release_work"
+          },
+          {
+            "definition": "Move work to On Hold only with the required review trigger.",
+            "effect": "external_or_local_change",
+            "id": "hold_work",
+            "implementation_surface": "project_management_hold_work"
+          },
+          {
+            "definition": "Move work to Deferred only with the required review trigger.",
+            "effect": "external_or_local_change",
+            "id": "defer_work",
+            "implementation_surface": "project_management_defer_work"
+          },
+          {
+            "definition": "Complete work only after configured completion and evidence guards pass.",
+            "effect": "external_or_local_change",
+            "id": "complete_work",
+            "implementation_surface": "project_management_complete_work"
+          },
+          {
+            "definition": "Evaluate deterministic queue eligibility and readiness evidence.",
+            "effect": "read_only",
+            "id": "readiness",
+            "implementation_surface": "project_management_next_work"
+          },
+          {
+            "definition": "Bind execution to a generation-specific work packet and reservation fence.",
+            "effect": "local_change",
+            "id": "assignment_packet",
+            "implementation_surface": "coordinator_work_packet"
+          },
+          {
+            "definition": "Evaluate repository/source verification evidence for the exact delivery identity.",
+            "effect": "read_only_or_external_evidence",
+            "id": "verification",
+            "implementation_surface": "project_management_merge_readiness"
+          },
+          {
+            "definition": "Track post-merge live verification separately from source verification.",
+            "effect": "external_or_local_change",
+            "id": "commissioning",
+            "implementation_surface": "issue_419_commissioning"
+          },
+          {
+            "definition": "Retain provider/Git revision evidence used for optimistic concurrency and traceability.",
+            "effect": "read_only",
+            "id": "authority_revision",
+            "implementation_surface": "project_management_inventory"
+          }
+        ],
+        "readiness": {
+          "required_issue_sections": [
+            "Outcome",
+            "Acceptance criteria"
+          ],
+          "required_project_fields": [
+            "Record Type",
+            "Priority",
+            "Effort",
+            "Documentation Impact"
+          ],
+          "requires_dependencies_understood": true
+        },
+        "schema_version": 1,
+        "states": [
+          {
+            "definition": "Captured work not yet triaged.",
+            "label": "Inbox",
+            "project_status": true,
+            "token": "inbox"
+          },
+          {
+            "definition": "Work being classified.",
+            "label": "Triage",
+            "project_status": true,
+            "token": "triage"
+          },
+          {
+            "definition": "Work proposed for approval.",
+            "label": "Proposed",
+            "project_status": true,
+            "token": "proposed"
+          },
+          {
+            "definition": "Accepted work not yet admitted to Ready.",
+            "label": "Approved",
+            "project_status": true,
+            "token": "approved"
+          },
+          {
+            "definition": "Executable queue state subject to readiness guards.",
+            "label": "Ready",
+            "project_status": true,
+            "token": "ready"
+          },
+          {
+            "definition": "Claimed execution state.",
+            "label": "Active",
+            "project_status": true,
+            "token": "active"
+          },
+          {
+            "definition": "Internal delivery state for review activity.",
+            "label": "Review",
+            "project_status": false,
+            "token": "review"
+          },
+          {
+            "definition": "Internal delivery state for verification activity.",
+            "label": "Verification",
+            "project_status": false,
+            "token": "verification"
+          },
+          {
+            "definition": "Internal delivery state for documentation reconciliation.",
+            "label": "Documentation",
+            "project_status": false,
+            "token": "documentation"
+          },
+          {
+            "definition": "Execution cannot proceed because a blocker is present.",
+            "label": "Blocked",
+            "project_status": true,
+            "token": "blocked"
+          },
+          {
+            "definition": "Intentionally paused pending a review trigger.",
+            "label": "On Hold",
+            "project_status": true,
+            "token": "on_hold"
+          },
+          {
+            "definition": "Postponed for later reconsideration.",
+            "label": "Deferred",
+            "project_status": true,
+            "token": "deferred"
+          },
+          {
+            "definition": "Not accepted for execution in current form.",
+            "label": "Rejected",
+            "project_status": true,
+            "token": "rejected"
+          },
+          {
+            "definition": "Replaced by newer authoritative work.",
+            "label": "Superseded",
+            "project_status": true,
+            "token": "superseded"
+          },
+          {
+            "definition": "Required completion gates are satisfied.",
+            "label": "Done",
+            "project_status": true,
+            "token": "done"
+          }
+        ],
+        "transition_requirements": {
+          "deferred": [
+            "Review Trigger"
+          ],
+          "on_hold": [
+            "Review Trigger"
+          ]
+        },
+        "transitions": {
+          "active": [
+            "ready",
+            "review",
+            "blocked",
+            "on_hold",
+            "deferred",
+            "done",
+            "superseded"
+          ],
+          "approved": [
+            "ready",
+            "active",
+            "on_hold",
+            "deferred",
+            "superseded"
+          ],
+          "blocked": [
+            "ready",
+            "active",
+            "on_hold",
+            "deferred",
+            "superseded"
+          ],
+          "deferred": [
+            "triage",
+            "proposed",
+            "approved",
+            "rejected",
+            "superseded"
+          ],
+          "documentation": [
+            "done",
+            "active",
+            "blocked",
+            "superseded"
+          ],
+          "done": [],
+          "inbox": [
+            "triage",
+            "deferred",
+            "rejected",
+            "superseded"
+          ],
+          "on_hold": [
+            "ready",
+            "active",
+            "deferred",
+            "rejected",
+            "superseded"
+          ],
+          "proposed": [
+            "approved",
+            "deferred",
+            "rejected",
+            "superseded"
+          ],
+          "ready": [
+            "active",
+            "on_hold",
+            "deferred",
+            "superseded"
+          ],
+          "rejected": [
+            "triage",
+            "superseded"
+          ],
+          "review": [
+            "active",
+            "verification",
+            "blocked",
+            "on_hold",
+            "superseded"
+          ],
+          "superseded": [],
+          "triage": [
+            "proposed",
+            "approved",
+            "deferred",
+            "rejected",
+            "superseded"
+          ],
+          "verification": [
+            "active",
+            "documentation",
+            "blocked",
+            "superseded"
+          ]
+        },
+        "verification_domains": [
+          {
+            "definition": "Repository/source verification evidence tied to the delivery identity.",
+            "field": "Verification",
+            "id": "source_verification"
+          },
+          {
+            "definition": "Post-merge runtime proof tied to the actual exposed capability or runtime path.",
+            "field": "Live Verification",
+            "id": "live_verification"
+          }
+        ]
+      },
+      "path": "settings/work-management/contracts/work-lifecycle-operations.json",
+      "sha256": "48b804f074cddb0139bec44498a89adc207addb061aeb3ebd2945bbaa2d40281"
+    },
+    {
+      "bytes": 3944,
+      "json": {
+        "contract_id": "work-selection",
+        "dependency_evidence": [
+          "unavailable",
+          "partial",
+          "observed"
+        ],
+        "effort_order": [
+          "tiny",
+          "small",
+          "medium",
+          "large"
+        ],
+        "eligible_states": [
+          "ready"
+        ],
+        "fields": {
+          "blocked_by": "Blocked By",
+          "created": "Created",
+          "effort": "Effort",
+          "execution_owner": "Execution Owner",
+          "priority": "Priority",
+          "state": "Status"
+        },
+        "priority_order": [
+          "critical",
+          "high",
+          "medium",
+          "low"
+        ],
+        "profiles": {
+          "normalized_domain": {
+            "reason_overrides": {
+              "dependencies_clear": "dependency_incomplete:{dependency_id}",
+              "eligible_state": "state_not_executable"
+            },
+            "rules": [
+              "project_match",
+              "eligible_state",
+              "unclaimed",
+              "approval_complete",
+              "dependencies_clear"
+            ]
+          },
+          "provider_project": {
+            "reason_overrides": {
+              "dependencies_clear": "native_dependency_blocking",
+              "eligible_state": "state_not_ready"
+            },
+            "rules": [
+              "source_issue",
+              "source_open",
+              "eligible_state",
+              "valid_priority",
+              "valid_effort",
+              "required_fields",
+              "unclaimed",
+              "dependency_evidence",
+              "dependencies_clear"
+            ]
+          }
+        },
+        "ranking": [
+          "priority",
+          "effort",
+          "created_order",
+          "record_id"
+        ],
+        "rules": [
+          {
+            "definition": "Only issue records are eligible in the provider-backed next-work queue.",
+            "id": "SEL-001",
+            "kind": "source_issue",
+            "reason_code": "not_issue"
+          },
+          {
+            "definition": "Provider-backed source issues must remain open.",
+            "id": "SEL-002",
+            "kind": "source_open",
+            "reason_code": "source_not_open"
+          },
+          {
+            "definition": "Normalized-domain selection respects an explicit project scope.",
+            "id": "SEL-003",
+            "kind": "project_match",
+            "reason_code": "project_mismatch"
+          },
+          {
+            "definition": "Candidate state must be one of the configured eligible states; domain adapters may preserve their existing equivalent reason code.",
+            "id": "SEL-004",
+            "kind": "eligible_state",
+            "reason_code": "state_not_ready"
+          },
+          {
+            "definition": "Priority must be present in the canonical priority order.",
+            "id": "SEL-005",
+            "kind": "valid_priority",
+            "reason_code": "missing_or_invalid:{field}"
+          },
+          {
+            "definition": "Effort must be present in the canonical effort order.",
+            "id": "SEL-006",
+            "kind": "valid_effort",
+            "reason_code": "missing_or_invalid:{field}"
+          },
+          {
+            "definition": "Configured readiness fields must be present before provider-backed selection.",
+            "id": "SEL-007",
+            "kind": "required_fields",
+            "reason_code": "missing_required:{field}"
+          },
+          {
+            "definition": "Already claimed work is excluded from next-work selection.",
+            "id": "SEL-008",
+            "kind": "unclaimed",
+            "reason_code": "already_claimed:{owner}"
+          },
+          {
+            "definition": "Normalized-domain records that require approval must have completed approval.",
+            "id": "SEL-009",
+            "kind": "approval_complete",
+            "reason_code": "approval_incomplete"
+          },
+          {
+            "definition": "Required provider dependency evidence must be observable.",
+            "id": "SEL-010",
+            "kind": "dependency_evidence",
+            "reason_code": "dependency_evidence_unavailable"
+          },
+          {
+            "definition": "Provider-native blocker evidence must be empty; normalized-domain adapters preserve dependency-specific reason codes.",
+            "id": "SEL-011",
+            "kind": "dependencies_clear",
+            "reason_code": "native_dependency_blocking"
+          },
+          {
+            "definition": "Eligible candidates rank by Priority, Effort, creation order, then stable record identity.",
+            "id": "SEL-012",
+            "kind": "ranking",
+            "reason_code": null
+          }
+        ],
+        "schema_version": 1
+      },
+      "path": "settings/work-management/contracts/work-selection.json",
+      "sha256": "a38024a9f5a9abd3b12baa348b672a77dbec973cf4a78b4be7662f771241935f"
+    },
+    {
+      "bytes": 7216,
+      "json": {
+        "fields": [
+          {
+            "name": "Status",
+            "options": [
+              "Inbox",
+              "Triage",
+              "Proposed",
+              "Approved",
+              "Ready",
+              "Active",
+              "Blocked",
+              "On Hold",
+              "Deferred",
+              "Rejected",
+              "Superseded",
+              "Done"
+            ],
+            "type": "single_select"
+          },
+          {
+            "name": "Record Type",
+            "options": [
+              "Idea",
+              "Task",
+              "Specification Slice",
+              "Review Run",
+              "Finding",
+              "Decision",
+              "Assumption",
+              "Risk",
+              "Approval",
+              "Hold",
+              "Research",
+              "Defect",
+              "Security Finding"
+            ],
+            "type": "single_select"
+          },
+          {
+            "name": "Priority",
+            "options": [
+              "Critical",
+              "High",
+              "Medium",
+              "Low"
+            ],
+            "type": "single_select"
+          },
+          {
+            "name": "Effort",
+            "options": [
+              "Tiny",
+              "Small",
+              "Medium",
+              "Large"
+            ],
+            "type": "single_select"
+          },
+          {
+            "name": "Delivery Stage",
+            "options": [
+              "None",
+              "Change Created",
+              "Implementing",
+              "PR Open",
+              "Review",
+              "CI Pending",
+              "CI Failed",
+              "CI Passed",
+              "Merged",
+              "Documentation",
+              "Commissioning",
+              "Complete"
+            ],
+            "type": "single_select"
+          },
+          {
+            "name": "Execution Owner",
+            "options": [],
+            "type": "text"
+          },
+          {
+            "name": "Blocked By",
+            "options": [],
+            "type": "text"
+          },
+          {
+            "name": "Documentation Impact",
+            "options": [
+              "Not Assessed",
+              "None",
+              "Planned",
+              "In Progress",
+              "Pre-merge Complete",
+              "Post-merge Complete"
+            ],
+            "type": "single_select"
+          },
+          {
+            "name": "Complexity",
+            "options": [
+              "Small",
+              "Medium",
+              "Large"
+            ],
+            "type": "single_select"
+          },
+          {
+            "name": "Risk Triggers",
+            "options": [],
+            "type": "text"
+          },
+          {
+            "name": "Project ID",
+            "options": [],
+            "type": "text"
+          },
+          {
+            "name": "Repository",
+            "options": [],
+            "type": "repository"
+          },
+          {
+            "name": "Module",
+            "options": [],
+            "type": "text"
+          },
+          {
+            "name": "Change ID",
+            "options": [],
+            "type": "text"
+          },
+          {
+            "name": "Origin",
+            "options": [
+              "Operator",
+              "Review",
+              "Verification",
+              "Implementation",
+              "Research"
+            ],
+            "type": "single_select"
+          },
+          {
+            "name": "Disposition",
+            "options": [
+              "Open",
+              "Accepted",
+              "Rejected",
+              "Superseded",
+              "Mitigated",
+              "Deferred"
+            ],
+            "type": "single_select"
+          },
+          {
+            "name": "Verification",
+            "options": [
+              "Not Run",
+              "Pending",
+              "Passed",
+              "Failed",
+              "Blocked"
+            ],
+            "type": "single_select"
+          },
+          {
+            "name": "Severity",
+            "options": [
+              "Critical",
+              "High",
+              "Medium",
+              "Low"
+            ],
+            "type": "single_select"
+          },
+          {
+            "name": "Confidence",
+            "options": [
+              "High",
+              "Medium",
+              "Low"
+            ],
+            "type": "single_select"
+          },
+          {
+            "name": "Review Trigger",
+            "options": [],
+            "type": "text"
+          },
+          {
+            "name": "Target Date",
+            "options": [],
+            "type": "date"
+          },
+          {
+            "name": "Iteration",
+            "options": [],
+            "type": "iteration"
+          },
+          {
+            "name": "Source Review",
+            "options": [],
+            "type": "text"
+          },
+          {
+            "name": "Authority Revision",
+            "options": [],
+            "type": "text"
+          },
+          {
+            "name": "External Link",
+            "options": [],
+            "type": "text"
+          },
+          {
+            "name": "Live Verification",
+            "options": [
+              "Not Assessed",
+              "Not Required",
+              "Pending",
+              "Passed",
+              "Failed",
+              "Blocked"
+            ],
+            "type": "single_select"
+          },
+          {
+            "name": "Commissioning Key",
+            "options": [],
+            "type": "text"
+          },
+          {
+            "name": "Live Verification Evidence",
+            "options": [],
+            "type": "text"
+          }
+        ],
+        "portfolio_id": "default",
+        "schema_version": 1,
+        "views": [
+          {
+            "filter": "status:Inbox",
+            "group_by": [],
+            "layout": "table",
+            "name": "01 Inbox",
+            "purpose": "Untriaged ideas and tasks",
+            "sort_by": [],
+            "vertical_group_by": [],
+            "visible_fields": [
+              "Title",
+              "Status",
+              "Record Type",
+              "Priority",
+              "Effort",
+              "Repository"
+            ]
+          },
+          {
+            "filter": "status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred",
+            "group_by": [],
+            "layout": "table",
+            "name": "02 Programme Table",
+            "purpose": "All active records and key fields",
+            "sort_by": [],
+            "vertical_group_by": [],
+            "visible_fields": [
+              "Title",
+              "Status",
+              "Record Type",
+              "Priority",
+              "Effort",
+              "Execution Owner",
+              "Repository",
+              "Change ID",
+              "Delivery Stage"
+            ]
+          },
+          {
+            "filter": "status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred",
+            "group_by": [],
+            "layout": "board",
+            "name": "03 Delivery Board",
+            "purpose": "Delivery flow grouped by lifecycle status",
+            "sort_by": [],
+            "vertical_group_by": [
+              "Status"
+            ],
+            "visible_fields": [
+              "Title",
+              "Priority",
+              "Effort",
+              "Execution Owner",
+              "Repository",
+              "Delivery Stage"
+            ]
+          },
+          {
+            "filter": "record-type:\"Specification Slice\",Task status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred,Rejected,Superseded,Done",
+            "group_by": [],
+            "layout": "roadmap",
+            "name": "04 Roadmap",
+            "purpose": "Dated or iterated specification and implementation slices",
+            "sort_by": [],
+            "vertical_group_by": [],
+            "visible_fields": []
+          },
+          {
+            "filter": "record-type:\"Specification Slice\" status:Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred,Rejected,Superseded,Done",
+            "group_by": [],
+            "layout": "table",
+            "name": "05 Specification Slices",
+            "purpose": "Proposed through completed specification records",
+            "sort_by": [],
+            "vertical_group_by": [],
+            "visible_fields": [
+              "Title",
+              "Status",
+              "Priority",
+              "Change ID",
+              "Delivery Stage",
+              "Repository"
+            ]
+          },
+          {
+            "filter": "record-type:Decision status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred,Rejected,Superseded,Done",
+            "group_by": [],
+            "layout": "table",
+            "name": "06 Decisions",
+            "purpose": "Proposed, accepted, rejected, and superseded decisions",
+            "sort_by": [],
+            "vertical_group_by": [],
+            "visible_fields": [
+              "Title",
+              "Status",
+              "Disposition",
+              "Review Trigger",
+              "Authority Revision",
+              "Repository"
+            ]
+          },
+          {
+            "filter": "record-type:Assumption,Risk status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred",
+            "group_by": [],
+            "layout": "table",
+            "name": "07 Assumptions and Risks",
+            "purpose": "Open validation and mitigation work",
+            "sort_by": [],
+            "vertical_group_by": [],
+            "visible_fields": [
+              "Title",
+              "Status",
+              "Severity",
+              "Confidence",
+              "Review Trigger",
+              "Disposition",
+              "Repository"
+            ]
+          },
+          {
+            "filter": "status:\"On Hold\",Deferred",
+            "group_by": [],
+            "layout": "table",
+            "name": "08 Holds and Deferred",
+            "purpose": "Paused items with review triggers",
+            "sort_by": [],
+            "vertical_group_by": [],
+            "visible_fields": [
+              "Title",
+              "Status",
+              "Review Trigger",
+              "Execution Owner",
+              "Blocked By",
+              "Target Date",
+              "Repository"
+            ]
+          },
+          {
+            "filter": "record-type:\"Review Run\",Finding,\"Security Finding\" status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred,Rejected,Superseded,Done",
+            "group_by": [],
+            "layout": "table",
+            "name": "09 Reviews and Findings",
+            "purpose": "Review runs and extracted records",
+            "sort_by": [],
+            "vertical_group_by": [],
+            "visible_fields": [
+              "Title",
+              "Status",
+              "Severity",
+              "Confidence",
+              "Source Review",
+              "Verification",
+              "Disposition",
+              "Repository"
+            ]
+          },
+          {
+            "filter": "verification:Pending,Failed,Blocked status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred,Rejected,Superseded,Done",
+            "group_by": [],
+            "layout": "table",
+            "name": "10 Verification",
+            "purpose": "Work awaiting or failing verification",
+            "sort_by": [],
+            "vertical_group_by": [],
+            "visible_fields": [
+              "Title",
+              "Status",
+              "Verification",
+              "Change ID",
+              "Delivery Stage",
+              "Repository"
+            ]
+          },
+          {
+            "filter": "delivery-stage:Documentation,Commissioning status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred,Rejected,Superseded,Done",
+            "group_by": [],
+            "layout": "table",
+            "name": "11 Documentation and Closeout",
+            "purpose": "Records awaiting documentation reconciliation or final closeout",
+            "sort_by": [],
+            "vertical_group_by": [],
+            "visible_fields": [
+              "Title",
+              "Status",
+              "Documentation Impact",
+              "Change ID",
+              "Delivery Stage",
+              "Repository"
+            ]
+          },
+          {
+            "filter": "status:Done",
+            "group_by": [],
+            "layout": "table",
+            "name": "12 Completed",
+            "purpose": "Closed records retained for history",
+            "sort_by": [],
+            "vertical_group_by": [],
+            "visible_fields": [
+              "Title",
+              "Record Type",
+              "Repository",
+              "Change ID",
+              "Delivery Stage",
+              "Verification",
+              "Authority Revision"
+            ]
+          }
+        ]
+      },
+      "path": "settings/work-management/github-project-schema.json",
+      "sha256": "d5b67f32be55b37f0ab38f1015eb086dfea57a5a05f771ef4cd75b44177a3282"
+    },
+    {
+      "bytes": 2179,
+      "json": {
+        "backend_bindings": [
+          {
+            "binding_id": "github-default",
+            "owner": "NielPieterse0",
+            "owner_type": "user",
+            "project_number": 1,
+            "provider": "github-mcp"
+          }
+        ],
+        "enabled": true,
+        "evidence": {
+          "max_file_bytes": 1048576,
+          "max_total_bytes": 4194304
+        },
+        "features": {
+          "intake": "read_only",
+          "programme_status": "enabled",
+          "reconciliation": "enabled",
+          "review_import": "read_only"
+        },
+        "gates": {
+          "change_traceability": "required",
+          "decision_authority": "advisory",
+          "hold_integrity": "advisory",
+          "programme_drift": "advisory",
+          "project_schema_drift": "advisory",
+          "project_settings": "required",
+          "review_disposition": "advisory",
+          "verification_evidence": "required"
+        },
+        "managed_projects": [
+          {
+            "backend_binding": "github-default",
+            "display_name": "ChatGPT-skill",
+            "local_root": "C:\\Projects\\ChatGPT-skill",
+            "project_id": "chatgpt-skill",
+            "repository": "NielPieterse0/chatgpt-skill"
+          },
+          {
+            "backend_binding": "github-default",
+            "display_name": "college",
+            "local_root": "C:\\Projects\\college",
+            "project_id": "college",
+            "repository": "NielPieterse0/college"
+          },
+          {
+            "backend_binding": "github-default",
+            "display_name": "commodity",
+            "local_root": "C:\\Projects\\commodity",
+            "project_id": "commodity",
+            "repository": "NielPieterse0/commodity"
+          },
+          {
+            "backend_binding": "github-default",
+            "display_name": "import-isolate",
+            "local_root": "C:\\Projects\\import-isolate",
+            "project_id": "import-isolate",
+            "repository": "NielPieterse0/import-isolate"
+          },
+          {
+            "backend_binding": "github-default",
+            "display_name": "kis-mcp",
+            "local_root": "C:\\Projects\\kis-mcp",
+            "project_id": "kis-mcp",
+            "repository": "NielPieterse0/kis-mcp"
+          },
+          {
+            "backend_binding": "github-default",
+            "display_name": "kis-mcp-doc",
+            "local_root": "C:\\Projects\\kis-mcp-doc",
+            "project_id": "kis-mcp-doc",
+            "repository": "NielPieterse0/kis-mcp-doc"
+          }
+        ],
+        "portfolio_id": "default",
+        "schema_version": 1
+      },
+      "path": "settings/work-management/github-projects.settings.json",
+      "sha256": "5ef32b8222ff079445e3337f322fd1d96c49c13472207af90d9d9e801a0b2256"
+    },
+    {
+      "bytes": 2993,
+      "json": {
+        "complexities": {
+          "large": {
+            "artifacts": [
+              "scope.json",
+              "spec.md",
+              "plan.md",
+              "tasks.md",
+              "closeout.md"
+            ],
+            "base_reviews": [
+              "code-quality"
+            ],
+            "description": "Work spanning components or system boundaries, independently reviewable subwork, substantial state or architecture change, a new integration, or significant release or commissioning coordination.",
+            "max_verifications": 20
+          },
+          "medium": {
+            "artifacts": [
+              "scope.json",
+              "spec.md",
+              "plan.md",
+              "tasks.md",
+              "closeout.md"
+            ],
+            "base_reviews": [
+              "code-quality"
+            ],
+            "description": "Several dependent steps or bounded design/shared-interface work in one contained area.",
+            "max_verifications": 20
+          },
+          "small": {
+            "artifacts": [
+              "scope.json",
+              "change.md"
+            ],
+            "base_reviews": [],
+            "description": "One bounded straightforward outcome with no material design or interface redesign.",
+            "max_verifications": 6
+          }
+        },
+        "review_types": [
+          "code-quality",
+          "safety-security",
+          "architecture",
+          "performance",
+          "test-quality",
+          "documentation",
+          "api-contracts"
+        ],
+        "risk_triggers": {
+          "architecture_boundary": {
+            "description": "A module, provider, subsystem, ownership, dependency-direction, or system-boundary contract changes.",
+            "reviews": [
+              "architecture"
+            ]
+          },
+          "deployment": {
+            "description": "Deployment, release, environment promotion, or commissioning behavior changes.",
+            "reviews": []
+          },
+          "destructive": {
+            "description": "The change can remove, replace, invalidate, or irreversibly transform durable resources or state.",
+            "reviews": []
+          },
+          "external_action": {
+            "description": "The change can cause externally observable actions through an approved provider or integration.",
+            "reviews": []
+          },
+          "migration": {
+            "description": "Existing state, schema, configuration, or users require migration or compatibility handling.",
+            "reviews": []
+          },
+          "money": {
+            "description": "Payments, balances, billing, settlement, or other monetary-value behavior changes.",
+            "reviews": []
+          },
+          "persistent_state": {
+            "description": "Durable state, stored records, or persistence semantics change.",
+            "reviews": []
+          },
+          "public_contract": {
+            "description": "A public or externally consumed interface, schema, command, tool, API, or contract changes.",
+            "reviews": [
+              "api-contracts"
+            ]
+          },
+          "secrets": {
+            "description": "Secret material, credentials, key handling, or secret-storage behavior changes.",
+            "reviews": [
+              "safety-security"
+            ]
+          },
+          "security": {
+            "description": "Authentication, authorization, trust-boundary, or security-control behavior changes.",
+            "reviews": [
+              "safety-security"
+            ]
+          },
+          "sensitive_data": {
+            "description": "Personal, regulated, confidential, or otherwise sensitive data handling changes.",
+            "reviews": [
+              "safety-security"
+            ]
+          }
+        },
+        "schema_version": 1
+      },
+      "path": "settings/change-governance.settings.json",
+      "sha256": "af8f3ea88f11c8fcd30d43a7e057d8275337c08eb97adcce32ee2d773b305383"
+    }
+  ]
+}

--- a/generated/work-management-spec/000-index.md
+++ b/generated/work-management-spec/000-index.md
@@ -1,0 +1,19 @@
+<!-- GENERATED — DO NOT EDIT -->
+# KIS Work Management Specification — documentation index
+
+The validated Work Management MRDs are authoritative. These pages are deterministic review projections.
+
+## Specification pages
+
+- [Specification](001-specification.md)
+- [Work Management domain model](002-work-management-domain-model.md)
+- [Work lifecycle](003-work-lifecycle.md)
+- [Work operations](004-work-operations.md)
+- [Next-work selection](005-next-work-selection.md)
+- [Authority and reconciliation policy](006-authority-and-reconciliation-policy.md)
+- [Provider and command-plane boundary](007-provider-and-command-plane-boundary.md)
+- [Work Management conformance](008-work-management-conformance.md)
+
+## Traceability
+
+- [Build manifest](manifest.json)

--- a/generated/work-management-spec/001-specification.md
+++ b/generated/work-management-spec/001-specification.md
@@ -1,0 +1,28 @@
+<!-- GENERATED — DO NOT EDIT -->
+# KIS Work Management Specification
+
+<div id="enable-section-numbers" />
+
+Governed operating specification for work intake, state, selection, delivery, reconciliation, and GitHub Project integration.
+
+The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", and "OPTIONAL" are normative when they appear in all capitals.
+
+## Overview
+
+Work Management separates command authority from evidence. It governs work-item semantics, lifecycle state, deterministic selection, provider reconciliation, delivery evidence, and closeout while keeping repository change governance authoritative for governed change facts.
+
+The specification is generated from seven prescriptive MRDs harvested from the pinned `kis-mcp` implementation contracts. Live GitHub Project evidence that could not be observed remains explicitly unavailable rather than inferred.
+
+## Detailed specification
+
+- [Work Management domain model](002-work-management-domain-model.md)
+- [Work lifecycle](003-work-lifecycle.md)
+- [Work operations](004-work-operations.md)
+- [Next-work selection](005-next-work-selection.md)
+- [Authority and reconciliation policy](006-authority-and-reconciliation-policy.md)
+- [Provider and command-plane boundary](007-provider-and-command-plane-boundary.md)
+- [Work Management conformance](008-work-management-conformance.md)
+
+## Traceability
+
+See the [documentation index](000-index.md) and [build manifest](manifest.json) for source identities and hashes.

--- a/generated/work-management-spec/002-work-management-domain-model.md
+++ b/generated/work-management-spec/002-work-management-domain-model.md
@@ -1,0 +1,1260 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Work Management domain model
+
+<div id="enable-section-numbers" />
+
+[Specification](001-specification.md) | [Documentation index](000-index.md)
+
+Define canonical Work Management entities, fields, vocabularies, and authority directions.
+
+## Fields
+
+### Status
+
+**Applicable record types:** *
+
+**Authority:** work_management
+
+**Definition:** Operational Work lifecycle status.
+
+**Direction:** command
+
+**Id:** status
+
+**Managed:** Yes
+
+**Population:** Set by explicit Work lifecycle operations.
+
+**Provider type:** single_select
+
+**Required contexts:** None
+
+**Vocabulary:** status
+
+### Record Type
+
+**Applicable record types:** *
+
+**Authority:** work_management
+
+**Definition:** Purpose classification of the Work record.
+
+**Direction:** command
+
+**Id:** record_type
+
+**Managed:** Yes
+
+**Population:** Set during intake/triage and changed only by explicit Work authority.
+
+**Provider type:** single_select
+
+**Required contexts:** ready_metadata
+
+**Vocabulary:** record_type
+
+### Priority
+
+**Applicable record types:** *
+
+**Authority:** work_management
+
+**Definition:** Relative scheduling importance.
+
+**Direction:** command
+
+**Id:** priority
+
+**Managed:** Yes
+
+**Population:** Set by Work Management and consumed by selection ranking.
+
+**Provider type:** single_select
+
+**Required contexts:** ready_metadata
+
+**Vocabulary:** priority
+
+### Effort
+
+**Applicable record types:** *
+
+**Authority:** work_management
+
+**Definition:** Relative implementation or coordination effort.
+
+**Direction:** command
+
+**Id:** effort
+
+**Managed:** Yes
+
+**Population:** Set by Work Management and consumed by selection ranking.
+
+**Provider type:** single_select
+
+**Required contexts:** ready_metadata
+
+**Vocabulary:** effort
+
+### Delivery Stage
+
+**Applicable record types:** *
+
+**Authority:** derived
+
+**Definition:** Evidence-derived governed delivery stage.
+
+**Direction:** evidence
+
+**Id:** delivery_stage
+
+**Managed:** Yes
+
+**Population:** Projected from repository/GitHub delivery evidence.
+
+**Provider type:** single_select
+
+**Required contexts:** None
+
+**Vocabulary:** delivery_stage
+
+### Execution Owner
+
+**Applicable record types:** *
+
+**Authority:** work_management
+
+**Definition:** Stable identity of the current execution claimant.
+
+**Direction:** command
+
+**Id:** execution_owner
+
+**Managed:** Yes
+
+**Population:** Set and cleared only by claim/release lifecycle operations.
+
+**Provider type:** text
+
+**Required contexts:** active_claim
+
+**Vocabulary:** None
+
+### Blocked By
+
+**Applicable record types:** *
+
+**Authority:** github
+
+**Definition:** Provider-observed dependency or blocker reference; explicit empty differs from unavailable evidence.
+
+**Direction:** evidence
+
+**Id:** blocked_by
+
+**Managed:** Yes
+
+**Population:** Read from GitHub Project dependency evidence.
+
+**Provider type:** text
+
+**Required contexts:** None
+
+**Vocabulary:** None
+
+### Documentation Impact
+
+**Applicable record types:** *
+
+**Authority:** work_management_then_repository_change
+
+**Definition:** Expected or completed documentation impact for the work/change.
+
+**Direction:** handoff
+
+**Id:** documentation_impact
+
+**Managed:** Yes
+
+**Population:** Starts as Work command data and becomes governed change evidence.
+
+**Provider type:** single_select
+
+**Required contexts:** ready_metadata
+
+**Vocabulary:** documentation_impact
+
+### Complexity
+
+**Applicable record types:** *
+
+**Authority:** repository_change
+
+**Definition:** Repository change-governance complexity projected into Work.
+
+**Direction:** evidence
+
+**Id:** complexity
+
+**Managed:** Yes
+
+**Population:** Projected from authoritative schema-v4 governed change scope.
+
+**Provider type:** single_select
+
+**Required contexts:** None
+
+**Vocabulary:** complexity
+
+### Risk Triggers
+
+**Applicable record types:** *
+
+**Authority:** repository_change
+
+**Definition:** Comma-separated repository change-governance risk-trigger tokens.
+
+**Direction:** evidence
+
+**Id:** risk_triggers
+
+**Managed:** Yes
+
+**Population:** Projected from authoritative governed change scope.
+
+**Provider type:** text
+
+**Required contexts:** None
+
+**Vocabulary:** None
+
+### Project ID
+
+**Applicable record types:** *
+
+**Authority:** derived
+
+**Definition:** Stable KIS project registry identity for the work item.
+
+**Direction:** evidence
+
+**Id:** project_id
+
+**Managed:** Yes
+
+**Population:** Derived from the registered repository-to-project mapping.
+
+**Provider type:** text
+
+**Required contexts:** None
+
+**Vocabulary:** None
+
+### Repository
+
+**Applicable record types:** *
+
+**Authority:** github
+
+**Definition:** GitHub repository identity of the source item.
+
+**Direction:** evidence
+
+**Id:** repository
+
+**Managed:** Yes
+
+**Population:** Read from the GitHub source item/provider binding.
+
+**Provider type:** repository
+
+**Required contexts:** None
+
+**Vocabulary:** None
+
+### Module
+
+**Applicable record types:** *
+
+**Authority:** work_management_then_repository_change
+
+**Definition:** Optional bounded module or subsystem context for the work.
+
+**Direction:** handoff
+
+**Id:** module
+
+**Managed:** Yes
+
+**Population:** Set by Work and handed to governed change planning when applicable.
+
+**Provider type:** text
+
+**Required contexts:** None
+
+**Vocabulary:** None
+
+### Change ID
+
+**Applicable record types:** *
+
+**Authority:** repository_change
+
+**Definition:** Canonical governed repository change ID once one exists.
+
+**Direction:** evidence
+
+**Id:** change_id
+
+**Managed:** Yes
+
+**Population:** Projected from authoritative local change scope.
+
+**Provider type:** text
+
+**Required contexts:** governed_change
+
+**Vocabulary:** None
+
+### Origin
+
+**Applicable record types:** *
+
+**Authority:** work_management
+
+**Definition:** Context that originated the record.
+
+**Direction:** command
+
+**Id:** origin
+
+**Managed:** Yes
+
+**Population:** Set when the Work record is created or classified.
+
+**Provider type:** single_select
+
+**Required contexts:** None
+
+**Vocabulary:** origin
+
+### Disposition
+
+**Applicable record types:** *
+
+**Authority:** work_management
+
+**Definition:** Explicit decision disposition for records that use disposition semantics.
+
+**Direction:** command
+
+**Id:** disposition
+
+**Managed:** Yes
+
+**Population:** Set by explicit Work decision/review operations.
+
+**Provider type:** single_select
+
+**Required contexts:** None
+
+**Vocabulary:** disposition
+
+### Verification
+
+**Applicable record types:** *
+
+**Authority:** actions
+
+**Definition:** Repository/source verification state; never live-runtime commissioning state.
+
+**Direction:** evidence
+
+**Id:** verification
+
+**Managed:** Yes
+
+**Population:** Projected from provider-native or governed verification evidence.
+
+**Provider type:** single_select
+
+**Required contexts:** None
+
+**Vocabulary:** verification
+
+### Severity
+
+**Applicable record types:** finding, security_finding, risk
+
+**Authority:** work_management
+
+**Definition:** Relative material impact for finding/risk records.
+
+**Direction:** command
+
+**Id:** severity
+
+**Managed:** Yes
+
+**Population:** Set when a finding or risk is classified.
+
+**Provider type:** single_select
+
+**Required contexts:** finding_or_risk
+
+**Vocabulary:** severity
+
+### Confidence
+
+**Applicable record types:** finding, security_finding, assumption
+
+**Authority:** work_management
+
+**Definition:** Evidence confidence for finding/assumption records.
+
+**Direction:** command
+
+**Id:** confidence
+
+**Managed:** Yes
+
+**Population:** Set from the evidence quality supporting the record.
+
+**Provider type:** single_select
+
+**Required contexts:** finding_or_assumption
+
+**Vocabulary:** confidence
+
+### Review Trigger
+
+**Applicable record types:** *
+
+**Authority:** work_management
+
+**Definition:** Condition or date/event trigger for reconsidering paused work.
+
+**Direction:** command
+
+**Id:** review_trigger
+
+**Managed:** Yes
+
+**Population:** Required when work enters On Hold or Deferred.
+
+**Provider type:** text
+
+**Required contexts:** hold_or_defer
+
+**Vocabulary:** None
+
+### Target Date
+
+**Applicable record types:** *
+
+**Authority:** work_management
+
+**Definition:** Optional target date for planned work or reconsideration.
+
+**Direction:** command
+
+**Id:** target_date
+
+**Managed:** Yes
+
+**Population:** Set explicitly by Work Management.
+
+**Provider type:** date
+
+**Required contexts:** None
+
+**Vocabulary:** None
+
+### Iteration
+
+**Applicable record types:** *
+
+**Authority:** work_management
+
+**Definition:** Optional provider iteration assignment.
+
+**Direction:** command
+
+**Id:** iteration
+
+**Managed:** Yes
+
+**Population:** Set explicitly by Work Management.
+
+**Provider type:** iteration
+
+**Required contexts:** None
+
+**Vocabulary:** None
+
+### Source Review
+
+**Applicable record types:** *
+
+**Authority:** work_management
+
+**Definition:** Reference to the review source that produced or governs the record.
+
+**Direction:** command
+
+**Id:** source_review
+
+**Managed:** Yes
+
+**Population:** Set when review-derived records are captured.
+
+**Provider type:** text
+
+**Required contexts:** None
+
+**Vocabulary:** None
+
+### Authority Revision
+
+**Applicable record types:** *
+
+**Authority:** git
+
+**Definition:** Revision identity of the authority evidence used for the Work record.
+
+**Direction:** evidence
+
+**Id:** authority_revision
+
+**Managed:** Yes
+
+**Population:** Projected from Git/provider revision evidence.
+
+**Provider type:** text
+
+**Required contexts:** None
+
+**Vocabulary:** None
+
+### External Link
+
+**Applicable record types:** *
+
+**Authority:** work_management
+
+**Definition:** Optional bounded external reference associated with the work.
+
+**Direction:** command
+
+**Id:** external_link
+
+**Managed:** Yes
+
+**Population:** Set explicitly by Work Management.
+
+**Provider type:** text
+
+**Required contexts:** None
+
+**Vocabulary:** None
+
+### Created
+
+**Applicable record types:** *
+
+**Authority:** github
+
+**Definition:** Provider-native creation timestamp used as deterministic age evidence.
+
+**Direction:** evidence
+
+**Id:** created
+
+**Managed:** No
+
+**Population:** Read from GitHub native item metadata.
+
+**Provider type:** native_datetime
+
+**Required contexts:** None
+
+**Vocabulary:** None
+
+### Live Verification
+
+**Applicable record types:** *
+
+**Authority:** derived
+
+**Definition:** Post-merge live runtime verification state, distinct from source Verification.
+
+**Direction:** evidence
+
+**Id:** live_verification
+
+**Managed:** Yes
+
+**Population:** Projected by the deterministic commissioning lifecycle under #419.
+
+**Provider type:** single_select
+
+**Required contexts:** None
+
+**Vocabulary:** live_verification
+
+### Commissioning Key
+
+**Applicable record types:** *
+
+**Authority:** derived
+
+**Definition:** Deterministic commissioning identity: the exact obligation key for one required surface, or the deterministic set key for a source merge with multiple required surfaces.
+
+**Direction:** evidence
+
+**Id:** commissioning_key
+
+**Managed:** Yes
+
+**Population:** Derived by the commissioning classifier/runner under #419; source projection uses a set-<digest24> key when multiple obligations must be aggregated.
+
+**Provider type:** text
+
+**Required contexts:** None
+
+**Vocabulary:** None
+
+### Live Verification Evidence
+
+**Applicable record types:** *
+
+**Authority:** derived
+
+**Definition:** Compact reference to durable live-verification evidence or linked commissioning work; never free-form logs.
+
+**Direction:** evidence
+
+**Id:** live_verification_evidence
+
+**Managed:** Yes
+
+**Population:** Projected from commissioning evidence under #419.
+
+**Provider type:** text
+
+**Required contexts:** None
+
+**Vocabulary:** None
+
+## Rules
+
+Every managed field has one authority and one direction., Project-native evidence is observed, not redefined by generated documentation.
+
+## Vocabularies
+
+### status
+
+**Definition:** Operational Work lifecycle status projected to GitHub Project Status.
+
+**Id:** status
+
+#### Values
+
+##### Inbox
+
+**Definition:** Captured work not yet triaged.
+
+**Token:** inbox
+
+##### Triage
+
+**Definition:** Work being classified and prepared for a disposition.
+
+**Token:** triage
+
+##### Proposed
+
+**Definition:** Work proposed for acceptance but not yet approved.
+
+**Token:** proposed
+
+##### Approved
+
+**Definition:** Accepted work that is not yet admitted to the executable queue.
+
+**Token:** approved
+
+##### Ready
+
+**Definition:** Work admitted for deterministic next-work eligibility subject to readiness, claim, and dependency guards.
+
+**Token:** ready
+
+##### Active
+
+**Definition:** Work currently claimed for execution.
+
+**Token:** active
+
+##### Blocked
+
+**Definition:** Work that cannot proceed because a blocking condition is present.
+
+**Token:** blocked
+
+##### On Hold
+
+**Definition:** Work intentionally paused pending a declared review trigger.
+
+**Token:** on_hold
+
+##### Deferred
+
+**Definition:** Work postponed for later reconsideration with a declared review trigger.
+
+**Token:** deferred
+
+##### Rejected
+
+**Definition:** Work explicitly not accepted for execution in its current form.
+
+**Token:** rejected
+
+##### Superseded
+
+**Definition:** Work replaced by a newer authoritative record or outcome.
+
+**Token:** superseded
+
+##### Done
+
+**Definition:** Work whose required completion and closeout gates are satisfied.
+
+**Token:** done
+
+### record type
+
+**Definition:** Classification of the purpose of a Work record.
+
+**Id:** record_type
+
+#### Values
+
+##### Idea
+
+**Definition:** Uncommitted candidate work requiring triage before it becomes actionable.
+
+**Token:** idea
+
+##### Task
+
+**Definition:** A bounded actionable unit of work.
+
+**Token:** task
+
+##### Specification Slice
+
+**Definition:** A bounded specification or delivery slice tracked as work.
+
+**Token:** specification_slice
+
+##### Review Run
+
+**Definition:** A record representing one review execution and its evidence.
+
+**Token:** review_run
+
+##### Finding
+
+**Definition:** An actionable observation produced by review, verification, audit, or commissioning.
+
+**Token:** finding
+
+##### Decision
+
+**Definition:** A record of an explicit authoritative choice.
+
+**Token:** decision
+
+##### Assumption
+
+**Definition:** A proposition tracked because later evidence may validate or invalidate it.
+
+**Token:** assumption
+
+##### Risk
+
+**Definition:** A potential adverse condition tracked for mitigation or disposition.
+
+**Token:** risk
+
+##### Approval
+
+**Definition:** A record of an explicit approval decision.
+
+**Token:** approval
+
+##### Hold
+
+**Definition:** A record whose purpose is to track a pause or hold condition.
+
+**Token:** hold
+
+##### Research
+
+**Definition:** A bounded investigation intended to produce evidence or a decision.
+
+**Token:** research
+
+##### Defect
+
+**Definition:** A known incorrect or broken product or system behavior requiring correction.
+
+**Token:** defect
+
+##### Security Finding
+
+**Definition:** A finding whose material impact is security-related.
+
+**Token:** security_finding
+
+### priority
+
+**Definition:** Relative scheduling importance used by the current deterministic Work queue.
+
+**Id:** priority
+
+#### Values
+
+##### Critical
+
+**Definition:** Highest configured scheduling importance.
+
+**Token:** critical
+
+##### High
+
+**Definition:** High scheduling importance below Critical.
+
+**Token:** high
+
+##### Medium
+
+**Definition:** Normal scheduling importance below High.
+
+**Token:** medium
+
+##### Low
+
+**Definition:** Lowest configured scheduling importance.
+
+**Token:** low
+
+### effort
+
+**Definition:** Relative implementation or coordination size used by the current deterministic Work queue.
+
+**Id:** effort
+
+#### Values
+
+##### Tiny
+
+**Definition:** Smallest configured relative effort.
+
+**Token:** tiny
+
+##### Small
+
+**Definition:** Small relative effort.
+
+**Token:** small
+
+##### Medium
+
+**Definition:** Moderate relative effort.
+
+**Token:** medium
+
+##### Large
+
+**Definition:** Largest configured relative effort.
+
+**Token:** large
+
+### delivery stage
+
+**Definition:** Evidence-derived stage of governed repository delivery.
+
+**Id:** delivery_stage
+
+#### Values
+
+##### None
+
+**Definition:** No governed delivery stage has been established.
+
+**Token:** none
+
+##### Change Created
+
+**Definition:** A governed repository change has been created.
+
+**Token:** change_created
+
+##### Implementing
+
+**Definition:** Implementation is in progress.
+
+**Token:** implementing
+
+##### PR Open
+
+**Definition:** A pull request is open for the governed change.
+
+**Token:** pr_open
+
+##### Review
+
+**Definition:** The governed change is in review.
+
+**Token:** review
+
+##### CI Pending
+
+**Definition:** Provider-native verification is pending.
+
+**Token:** ci_pending
+
+##### CI Failed
+
+**Definition:** Provider-native verification failed.
+
+**Token:** ci_failed
+
+##### CI Passed
+
+**Definition:** Provider-native verification passed for the applicable head.
+
+**Token:** ci_passed
+
+##### Merged
+
+**Definition:** The governed change has been observed merged.
+
+**Token:** merged
+
+##### Documentation
+
+**Definition:** Post-merge documentation reconciliation is due or in progress.
+
+**Token:** documentation
+
+##### Commissioning
+
+**Definition:** Live verification or commissioning is pending or in progress.
+
+**Token:** commissioning
+
+##### Complete
+
+**Definition:** Delivery and required closeout evidence are complete.
+
+**Token:** complete
+
+### documentation impact
+
+**Definition:** Repository documentation impact projected from Work to governed change and back as evidence.
+
+**Id:** documentation_impact
+
+#### Values
+
+##### Not Assessed
+
+**Definition:** Documentation impact has not yet been assessed.
+
+**Token:** not_assessed
+
+##### None
+
+**Definition:** No documentation change is required, with rationale recorded where required.
+
+**Token:** none
+
+##### Planned
+
+**Definition:** Documentation changes are planned.
+
+**Token:** planned
+
+##### In Progress
+
+**Definition:** Documentation changes are being implemented.
+
+**Token:** in_progress
+
+##### Pre-merge Complete
+
+**Definition:** Required pre-merge documentation work is complete.
+
+**Token:** pre_merge_complete
+
+##### Post-merge Complete
+
+**Definition:** Required post-merge documentation reconciliation is complete.
+
+**Token:** post_merge_complete
+
+### complexity
+
+**Definition:** Projection of repository change-governance complexity; detailed classification criteria remain owned by change-governance settings.
+
+**Id:** complexity
+
+#### Values
+
+##### Small
+
+**Definition:** Repository change-governance Small classification.
+
+**Token:** small
+
+##### Medium
+
+**Definition:** Repository change-governance Medium classification.
+
+**Token:** medium
+
+##### Large
+
+**Definition:** Repository change-governance Large classification.
+
+**Token:** large
+
+### origin
+
+**Definition:** Source context that caused a Work record to be created.
+
+**Id:** origin
+
+#### Values
+
+##### Operator
+
+**Definition:** Created directly from operator intent.
+
+**Token:** operator
+
+##### Review
+
+**Definition:** Created from review evidence.
+
+**Token:** review
+
+##### Verification
+
+**Definition:** Created from verification evidence.
+
+**Token:** verification
+
+##### Implementation
+
+**Definition:** Created from implementation activity or discovery.
+
+**Token:** implementation
+
+##### Research
+
+**Definition:** Created from research activity or evidence.
+
+**Token:** research
+
+### disposition
+
+**Definition:** Current decision disposition for records that require an explicit disposition.
+
+**Id:** disposition
+
+#### Values
+
+##### Open
+
+**Definition:** No terminal disposition has been selected.
+
+**Token:** open
+
+##### Accepted
+
+**Definition:** The record or proposition is accepted.
+
+**Token:** accepted
+
+##### Rejected
+
+**Definition:** The record or proposition is rejected.
+
+**Token:** rejected
+
+##### Superseded
+
+**Definition:** A newer authoritative record replaces this one.
+
+**Token:** superseded
+
+##### Mitigated
+
+**Definition:** The tracked risk or finding has been mitigated.
+
+**Token:** mitigated
+
+##### Deferred
+
+**Definition:** Disposition is intentionally postponed.
+
+**Token:** deferred
+
+### verification
+
+**Definition:** Repository/source verification state; it does not represent post-merge live runtime proof.
+
+**Id:** verification
+
+#### Values
+
+##### Not Run
+
+**Definition:** Repository/source verification has not run.
+
+**Token:** not_run
+
+##### Pending
+
+**Definition:** Repository/source verification is pending or running.
+
+**Token:** pending
+
+##### Passed
+
+**Definition:** Repository/source verification passed for the applicable evidence identity.
+
+**Token:** passed
+
+##### Failed
+
+**Definition:** Repository/source verification failed.
+
+**Token:** failed
+
+##### Blocked
+
+**Definition:** Repository/source verification cannot currently complete.
+
+**Token:** blocked
+
+### severity
+
+**Definition:** Relative material impact of a finding or risk.
+
+**Id:** severity
+
+#### Values
+
+##### Critical
+
+**Definition:** Highest material impact requiring urgent attention.
+
+**Token:** critical
+
+##### High
+
+**Definition:** High material impact.
+
+**Token:** high
+
+##### Medium
+
+**Definition:** Moderate material impact.
+
+**Token:** medium
+
+##### Low
+
+**Definition:** Limited material impact.
+
+**Token:** low
+
+### confidence
+
+**Definition:** Relative confidence classification for finding and assumption evidence; current Work authority does not define quantitative or qualitative thresholds.
+
+**Id:** confidence
+
+#### Values
+
+##### High
+
+**Definition:** Highest configured confidence label; no additional threshold is defined by current Work authority.
+
+**Token:** high
+
+##### Medium
+
+**Definition:** Middle configured confidence label; no additional threshold is defined by current Work authority.
+
+**Token:** medium
+
+##### Low
+
+**Definition:** Lowest configured confidence label; no additional threshold is defined by current Work authority.
+
+**Token:** low
+
+### live verification
+
+**Definition:** Post-merge live runtime verification state, distinct from repository/source Verification.
+
+**Id:** live_verification
+
+#### Values
+
+##### Not Assessed
+
+**Definition:** The need for live verification has not yet been classified.
+
+**Token:** not_assessed
+
+##### Not Required
+
+**Definition:** Deterministic classification found no live verification obligation.
+
+**Token:** not_required
+
+##### Pending
+
+**Definition:** Live verification is required and has not yet completed.
+
+**Token:** pending
+
+##### Passed
+
+**Definition:** Required live verification passed against the actual exposed capability or runtime path.
+
+**Token:** passed
+
+##### Failed
+
+**Definition:** Required live verification ran and failed its expected invariant.
+
+**Token:** failed
+
+##### Blocked
+
+**Definition:** Required live verification cannot currently complete.
+
+**Token:** blocked
+
+## Source and authority
+
+This page projects `KIS-WORK-SEM-REG-001` version `1.0.0`. The MRD is authoritative; this generated page has no write-back authority.

--- a/generated/work-management-spec/003-work-lifecycle.md
+++ b/generated/work-management-spec/003-work-lifecycle.md
@@ -1,0 +1,326 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Work lifecycle
+
+<div id="enable-section-numbers" />
+
+[Specification](001-specification.md) | [Documentation index](000-index.md)
+
+Define Work states, transitions, readiness, claims, delivery stages, completion gates, and guards.
+
+## Claim
+
+**Auto expiry:** No
+
+**Execution owner field:** Execution Owner
+
+## Completion
+
+**Require no active claim after close:** No
+
+**Terminal state:** done
+
+## Delivery
+
+**Change created stage:** change_created
+
+**Change id field:** Change ID
+
+**Complete stage:** complete
+
+**Complexity field:** Complexity
+
+**Risk triggers field:** Risk Triggers
+
+**Stage field:** Delivery Stage
+
+**Stages:** none, change_created, implementing, pr_open, review, ci_pending, ci_failed, ci_passed, merged, documentation, commissioning, complete
+
+## Guards
+
+### approval-before-active
+
+**Condition:** approval_required_and_incomplete
+
+**Definition:** Reject activation when the record requires approval and approval is incomplete.
+
+**Disposition:** reject
+
+**Id:** approval-before-active
+
+**Reason code:** approval_incomplete
+
+**Target:** active
+
+### completion-no-active-claim
+
+**Condition:** completion_requires_no_active_claim_and_claim_present
+
+**Definition:** When configured, reject completion while an execution claim remains.
+
+**Disposition:** reject
+
+**Id:** completion-no-active-claim
+
+**Reason code:** active_claim_present
+
+**Target:** done
+
+### completion-documentation-due
+
+**Condition:** required_documentation_reconciliation_due
+
+**Definition:** Required post-merge documentation reconciliation must be completed before Done.
+
+**Disposition:** reject
+
+**Id:** completion-documentation-due
+
+**Reason code:** documentation_reconciliation_due
+
+**Target:** done
+
+### completion-documentation-due-advisory
+
+**Condition:** advisory_documentation_reconciliation_due
+
+**Definition:** Advisory post-merge documentation reconciliation may complete with an explicit advisory reason.
+
+**Disposition:** allow_with_reason
+
+**Id:** completion-documentation-due-advisory
+
+**Reason code:** documentation_reconciliation_advisory_due
+
+**Target:** done
+
+### completion-documentation-unrecorded
+
+**Condition:** required_documentation_reconciliation_unrecorded
+
+**Definition:** Required post-merge documentation milestone must be recorded before Done.
+
+**Disposition:** reject
+
+**Id:** completion-documentation-unrecorded
+
+**Reason code:** documentation_reconciliation_unrecorded
+
+**Target:** done
+
+### completion-documentation-unrecorded-advisory
+
+**Condition:** advisory_documentation_reconciliation_unrecorded
+
+**Definition:** Advisory documentation reconciliation may complete without a recorded post-merge milestone, with an explicit advisory reason.
+
+**Disposition:** allow_with_reason
+
+**Id:** completion-documentation-unrecorded-advisory
+
+**Reason code:** documentation_reconciliation_advisory_incomplete
+
+**Target:** done
+
+### completion-documentation-incomplete
+
+**Condition:** required_documentation_incomplete
+
+**Definition:** Required documentation impact must be complete before Done.
+
+**Disposition:** reject
+
+**Id:** completion-documentation-incomplete
+
+**Reason code:** documentation_incomplete
+
+**Target:** done
+
+### completion-documentation-incomplete-advisory
+
+**Condition:** advisory_documentation_incomplete
+
+**Definition:** Advisory documentation may complete while incomplete, with an explicit advisory reason.
+
+**Disposition:** allow_with_reason
+
+**Id:** completion-documentation-incomplete-advisory
+
+**Reason code:** documentation_advisory_incomplete
+
+**Target:** done
+
+## Intake aliases
+
+**Todo:** inbox
+
+## Readiness
+
+**Required issue sections:** Outcome, Acceptance criteria
+
+**Required project fields:** Record Type, Priority, Effort, Documentation Impact
+
+**Requires dependencies understood:** Yes
+
+## States
+
+### Inbox
+
+**Definition:** Captured work not yet triaged.
+
+**Project status:** Yes
+
+**Token:** inbox
+
+### Triage
+
+**Definition:** Work being classified.
+
+**Project status:** Yes
+
+**Token:** triage
+
+### Proposed
+
+**Definition:** Work proposed for approval.
+
+**Project status:** Yes
+
+**Token:** proposed
+
+### Approved
+
+**Definition:** Accepted work not yet admitted to Ready.
+
+**Project status:** Yes
+
+**Token:** approved
+
+### Ready
+
+**Definition:** Executable queue state subject to readiness guards.
+
+**Project status:** Yes
+
+**Token:** ready
+
+### Active
+
+**Definition:** Claimed execution state.
+
+**Project status:** Yes
+
+**Token:** active
+
+### Review
+
+**Definition:** Internal delivery state for review activity.
+
+**Project status:** No
+
+**Token:** review
+
+### Verification
+
+**Definition:** Internal delivery state for verification activity.
+
+**Project status:** No
+
+**Token:** verification
+
+### Documentation
+
+**Definition:** Internal delivery state for documentation reconciliation.
+
+**Project status:** No
+
+**Token:** documentation
+
+### Blocked
+
+**Definition:** Execution cannot proceed because a blocker is present.
+
+**Project status:** Yes
+
+**Token:** blocked
+
+### On Hold
+
+**Definition:** Intentionally paused pending a review trigger.
+
+**Project status:** Yes
+
+**Token:** on_hold
+
+### Deferred
+
+**Definition:** Postponed for later reconsideration.
+
+**Project status:** Yes
+
+**Token:** deferred
+
+### Rejected
+
+**Definition:** Not accepted for execution in current form.
+
+**Project status:** Yes
+
+**Token:** rejected
+
+### Superseded
+
+**Definition:** Replaced by newer authoritative work.
+
+**Project status:** Yes
+
+**Token:** superseded
+
+### Done
+
+**Definition:** Required completion gates are satisfied.
+
+**Project status:** Yes
+
+**Token:** done
+
+## Transition requirements
+
+**Deferred:** Review Trigger
+
+**On hold:** Review Trigger
+
+## Transitions
+
+**Active:** ready, review, blocked, on_hold, deferred, done, superseded
+
+**Approved:** ready, active, on_hold, deferred, superseded
+
+**Blocked:** ready, active, on_hold, deferred, superseded
+
+**Deferred:** triage, proposed, approved, rejected, superseded
+
+**Documentation:** done, active, blocked, superseded
+
+**Done:** None
+
+**Inbox:** triage, deferred, rejected, superseded
+
+**On hold:** ready, active, deferred, rejected, superseded
+
+**Proposed:** approved, deferred, rejected, superseded
+
+**Ready:** active, on_hold, deferred, superseded
+
+**Rejected:** triage, superseded
+
+**Review:** active, verification, blocked, on_hold, superseded
+
+**Superseded:** None
+
+**Triage:** proposed, approved, deferred, rejected, superseded
+
+**Verification:** active, documentation, blocked, superseded
+
+## Source and authority
+
+This page projects `KIS-WORK-WRK-STM-001` version `1.0.0`. The MRD is authoritative; this generated page has no write-back authority.

--- a/generated/work-management-spec/004-work-operations.md
+++ b/generated/work-management-spec/004-work-operations.md
@@ -1,0 +1,174 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Work operations
+
+<div id="enable-section-numbers" />
+
+[Specification](001-specification.md) | [Documentation index](000-index.md)
+
+Define the bounded Work Management operations and their implementation surfaces.
+
+## Mutation rule
+
+External Project mutations require apply=true and an explicit idempotency key.
+
+## Operations
+
+### capture work
+
+**Definition:** Capture one bounded source record into Work without duplicating source identity.
+
+**Effect:** external_or_local_change
+
+**Id:** capture_work
+
+**Implementation surface:** project_management_reconcile
+
+### create work
+
+**Definition:** Create or reconcile one new Work record through the configured provider boundary.
+
+**Effect:** external_or_local_change
+
+**Id:** create_work
+
+**Implementation surface:** project_management_reconcile
+
+### take next work
+
+**Definition:** Select the next eligible Ready item and establish its execution claim.
+
+**Effect:** external_or_local_change
+
+**Id:** take_next_work
+
+**Implementation surface:** project_management_take_next_work
+
+### claim work
+
+**Definition:** Establish one execution owner after revision and state guards pass.
+
+**Effect:** external_or_local_change
+
+**Id:** claim_work
+
+**Implementation surface:** project_management_claim_work
+
+### release work
+
+**Definition:** Clear an execution claim through the bounded command plane.
+
+**Effect:** external_or_local_change
+
+**Id:** release_work
+
+**Implementation surface:** project_management_release_work
+
+### hold work
+
+**Definition:** Move work to On Hold only with the required review trigger.
+
+**Effect:** external_or_local_change
+
+**Id:** hold_work
+
+**Implementation surface:** project_management_hold_work
+
+### defer work
+
+**Definition:** Move work to Deferred only with the required review trigger.
+
+**Effect:** external_or_local_change
+
+**Id:** defer_work
+
+**Implementation surface:** project_management_defer_work
+
+### complete work
+
+**Definition:** Complete work only after configured completion and evidence guards pass.
+
+**Effect:** external_or_local_change
+
+**Id:** complete_work
+
+**Implementation surface:** project_management_complete_work
+
+### readiness
+
+**Definition:** Evaluate deterministic queue eligibility and readiness evidence.
+
+**Effect:** read_only
+
+**Id:** readiness
+
+**Implementation surface:** project_management_next_work
+
+### assignment packet
+
+**Definition:** Bind execution to a generation-specific work packet and reservation fence.
+
+**Effect:** local_change
+
+**Id:** assignment_packet
+
+**Implementation surface:** coordinator_work_packet
+
+### verification
+
+**Definition:** Evaluate repository/source verification evidence for the exact delivery identity.
+
+**Effect:** read_only_or_external_evidence
+
+**Id:** verification
+
+**Implementation surface:** project_management_merge_readiness
+
+### commissioning
+
+**Definition:** Track post-merge live verification separately from source verification.
+
+**Effect:** external_or_local_change
+
+**Id:** commissioning
+
+**Implementation surface:** issue_419_commissioning
+
+### authority revision
+
+**Definition:** Retain provider/Git revision evidence used for optimistic concurrency and traceability.
+
+**Effect:** read_only
+
+**Id:** authority_revision
+
+**Implementation surface:** project_management_inventory
+
+## Result envelope
+
+observed_at, resolved_target, provenance, result, next_actions
+
+## Typed errors
+
+provider_unavailable, project_not_commissioned, inventory_incomplete, conflict, invalid_transition, not_found, invalid_request, internal
+
+## Verification domains
+
+### source verification
+
+**Definition:** Repository/source verification evidence tied to the delivery identity.
+
+**Field:** Verification
+
+**Id:** source_verification
+
+### live verification
+
+**Definition:** Post-merge runtime proof tied to the actual exposed capability or runtime path.
+
+**Field:** Live Verification
+
+**Id:** live_verification
+
+## Source and authority
+
+This page projects `KIS-WORK-WRK-WFL-001` version `1.0.0`. The MRD is authoritative; this generated page has no write-back authority.

--- a/generated/work-management-spec/005-next-work-selection.md
+++ b/generated/work-management-spec/005-next-work-selection.md
@@ -1,0 +1,190 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Next-work selection
+
+<div id="enable-section-numbers" />
+
+[Specification](001-specification.md) | [Documentation index](000-index.md)
+
+Define deterministic eligibility and ranking for selecting executable work.
+
+## Dependency evidence
+
+unavailable, partial, observed
+
+## Effort order
+
+tiny, small, medium, large
+
+## Eligible states
+
+ready
+
+## Fields
+
+**Blocked by:** Blocked By
+
+**Created:** Created
+
+**Effort:** Effort
+
+**Execution owner:** Execution Owner
+
+**Priority:** Priority
+
+**State:** Status
+
+## Priority order
+
+critical, high, medium, low
+
+## Profiles
+
+### Normalized domain
+
+#### Reason overrides
+
+**Dependencies clear:** dependency_incomplete:{dependency_id}
+
+**Eligible state:** state_not_executable
+
+**Rules:** project_match, eligible_state, unclaimed, approval_complete, dependencies_clear
+
+### Provider project
+
+#### Reason overrides
+
+**Dependencies clear:** native_dependency_blocking
+
+**Eligible state:** state_not_ready
+
+**Rules:** source_issue, source_open, eligible_state, valid_priority, valid_effort, required_fields, unclaimed, dependency_evidence, dependencies_clear
+
+## Ranking
+
+priority, effort, created_order, record_id
+
+## Rules
+
+### SEL-001
+
+**Definition:** Only issue records are eligible in the provider-backed next-work queue.
+
+**Id:** SEL-001
+
+**Kind:** source_issue
+
+**Reason code:** not_issue
+
+### SEL-002
+
+**Definition:** Provider-backed source issues must remain open.
+
+**Id:** SEL-002
+
+**Kind:** source_open
+
+**Reason code:** source_not_open
+
+### SEL-003
+
+**Definition:** Normalized-domain selection respects an explicit project scope.
+
+**Id:** SEL-003
+
+**Kind:** project_match
+
+**Reason code:** project_mismatch
+
+### SEL-004
+
+**Definition:** Candidate state must be one of the configured eligible states; domain adapters may preserve their existing equivalent reason code.
+
+**Id:** SEL-004
+
+**Kind:** eligible_state
+
+**Reason code:** state_not_ready
+
+### SEL-005
+
+**Definition:** Priority must be present in the canonical priority order.
+
+**Id:** SEL-005
+
+**Kind:** valid_priority
+
+**Reason code:** missing_or_invalid:{field}
+
+### SEL-006
+
+**Definition:** Effort must be present in the canonical effort order.
+
+**Id:** SEL-006
+
+**Kind:** valid_effort
+
+**Reason code:** missing_or_invalid:{field}
+
+### SEL-007
+
+**Definition:** Configured readiness fields must be present before provider-backed selection.
+
+**Id:** SEL-007
+
+**Kind:** required_fields
+
+**Reason code:** missing_required:{field}
+
+### SEL-008
+
+**Definition:** Already claimed work is excluded from next-work selection.
+
+**Id:** SEL-008
+
+**Kind:** unclaimed
+
+**Reason code:** already_claimed:{owner}
+
+### SEL-009
+
+**Definition:** Normalized-domain records that require approval must have completed approval.
+
+**Id:** SEL-009
+
+**Kind:** approval_complete
+
+**Reason code:** approval_incomplete
+
+### SEL-010
+
+**Definition:** Required provider dependency evidence must be observable.
+
+**Id:** SEL-010
+
+**Kind:** dependency_evidence
+
+**Reason code:** dependency_evidence_unavailable
+
+### SEL-011
+
+**Definition:** Provider-native blocker evidence must be empty; normalized-domain adapters preserve dependency-specific reason codes.
+
+**Id:** SEL-011
+
+**Kind:** dependencies_clear
+
+**Reason code:** native_dependency_blocking
+
+### SEL-012
+
+**Definition:** Eligible candidates rank by Priority, Effort, creation order, then stable record identity.
+
+**Id:** SEL-012
+
+**Kind:** ranking
+
+**Reason code:** None
+
+## Source and authority
+
+This page projects `KIS-WORK-DEC-SCR-001` version `1.0.0`. The MRD is authoritative; this generated page has no write-back authority.

--- a/generated/work-management-spec/006-authority-and-reconciliation-policy.md
+++ b/generated/work-management-spec/006-authority-and-reconciliation-policy.md
@@ -1,0 +1,622 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Authority and reconciliation policy
+
+<div id="enable-section-numbers" />
+
+[Specification](001-specification.md) | [Documentation index](000-index.md)
+
+Define authority ownership, repository handoff, Project reconciliation, and no-drift rules.
+
+## Change governance
+
+### Complexities
+
+#### Large
+
+**Artifacts:** scope.json, spec.md, plan.md, tasks.md, closeout.md
+
+**Base reviews:** code-quality
+
+**Description:** Work spanning components or system boundaries, independently reviewable subwork, substantial state or architecture change, a new integration, or significant release or commissioning coordination.
+
+**Max verifications:** 20
+
+#### Medium
+
+**Artifacts:** scope.json, spec.md, plan.md, tasks.md, closeout.md
+
+**Base reviews:** code-quality
+
+**Description:** Several dependent steps or bounded design/shared-interface work in one contained area.
+
+**Max verifications:** 20
+
+#### Small
+
+**Artifacts:** scope.json, change.md
+
+**Base reviews:** None
+
+**Description:** One bounded straightforward outcome with no material design or interface redesign.
+
+**Max verifications:** 6
+
+**Review types:** code-quality, safety-security, architecture, performance, test-quality, documentation, api-contracts
+
+### Risk triggers
+
+#### Architecture boundary
+
+**Description:** A module, provider, subsystem, ownership, dependency-direction, or system-boundary contract changes.
+
+**Reviews:** architecture
+
+#### Deployment
+
+**Description:** Deployment, release, environment promotion, or commissioning behavior changes.
+
+**Reviews:** None
+
+#### Destructive
+
+**Description:** The change can remove, replace, invalidate, or irreversibly transform durable resources or state.
+
+**Reviews:** None
+
+#### External action
+
+**Description:** The change can cause externally observable actions through an approved provider or integration.
+
+**Reviews:** None
+
+#### Migration
+
+**Description:** Existing state, schema, configuration, or users require migration or compatibility handling.
+
+**Reviews:** None
+
+#### Money
+
+**Description:** Payments, balances, billing, settlement, or other monetary-value behavior changes.
+
+**Reviews:** None
+
+#### Persistent state
+
+**Description:** Durable state, stored records, or persistence semantics change.
+
+**Reviews:** None
+
+#### Public contract
+
+**Description:** A public or externally consumed interface, schema, command, tool, API, or contract changes.
+
+**Reviews:** api-contracts
+
+#### Secrets
+
+**Description:** Secret material, credentials, key handling, or secret-storage behavior changes.
+
+**Reviews:** safety-security
+
+#### Security
+
+**Description:** Authentication, authorization, trust-boundary, or security-control behavior changes.
+
+**Reviews:** safety-security
+
+#### Sensitive data
+
+**Description:** Personal, regulated, confidential, or otherwise sensitive data handling changes.
+
+**Reviews:** safety-security
+
+**Schema version:** 1
+
+## Github project schema
+
+### Fields
+
+#### Status
+
+**Options:** Inbox, Triage, Proposed, Approved, Ready, Active, Blocked, On Hold, Deferred, Rejected, Superseded, Done
+
+**Type:** single_select
+
+#### Record Type
+
+**Options:** Idea, Task, Specification Slice, Review Run, Finding, Decision, Assumption, Risk, Approval, Hold, Research, Defect, Security Finding
+
+**Type:** single_select
+
+#### Priority
+
+**Options:** Critical, High, Medium, Low
+
+**Type:** single_select
+
+#### Effort
+
+**Options:** Tiny, Small, Medium, Large
+
+**Type:** single_select
+
+#### Delivery Stage
+
+**Options:** None, Change Created, Implementing, PR Open, Review, CI Pending, CI Failed, CI Passed, Merged, Documentation, Commissioning, Complete
+
+**Type:** single_select
+
+#### Execution Owner
+
+**Options:** None
+
+**Type:** text
+
+#### Blocked By
+
+**Options:** None
+
+**Type:** text
+
+#### Documentation Impact
+
+**Options:** Not Assessed, None, Planned, In Progress, Pre-merge Complete, Post-merge Complete
+
+**Type:** single_select
+
+#### Complexity
+
+**Options:** Small, Medium, Large
+
+**Type:** single_select
+
+#### Risk Triggers
+
+**Options:** None
+
+**Type:** text
+
+#### Project ID
+
+**Options:** None
+
+**Type:** text
+
+#### Repository
+
+**Options:** None
+
+**Type:** repository
+
+#### Module
+
+**Options:** None
+
+**Type:** text
+
+#### Change ID
+
+**Options:** None
+
+**Type:** text
+
+#### Origin
+
+**Options:** Operator, Review, Verification, Implementation, Research
+
+**Type:** single_select
+
+#### Disposition
+
+**Options:** Open, Accepted, Rejected, Superseded, Mitigated, Deferred
+
+**Type:** single_select
+
+#### Verification
+
+**Options:** Not Run, Pending, Passed, Failed, Blocked
+
+**Type:** single_select
+
+#### Severity
+
+**Options:** Critical, High, Medium, Low
+
+**Type:** single_select
+
+#### Confidence
+
+**Options:** High, Medium, Low
+
+**Type:** single_select
+
+#### Review Trigger
+
+**Options:** None
+
+**Type:** text
+
+#### Target Date
+
+**Options:** None
+
+**Type:** date
+
+#### Iteration
+
+**Options:** None
+
+**Type:** iteration
+
+#### Source Review
+
+**Options:** None
+
+**Type:** text
+
+#### Authority Revision
+
+**Options:** None
+
+**Type:** text
+
+#### External Link
+
+**Options:** None
+
+**Type:** text
+
+#### Live Verification
+
+**Options:** Not Assessed, Not Required, Pending, Passed, Failed, Blocked
+
+**Type:** single_select
+
+#### Commissioning Key
+
+**Options:** None
+
+**Type:** text
+
+#### Live Verification Evidence
+
+**Options:** None
+
+**Type:** text
+
+**Portfolio id:** default
+
+**Schema version:** 1
+
+### Views
+
+#### 01 Inbox
+
+**Filter:** status:Inbox
+
+**Group by:** None
+
+**Layout:** table
+
+**Purpose:** Untriaged ideas and tasks
+
+**Sort by:** None
+
+**Vertical group by:** None
+
+**Visible fields:** Title, Status, Record Type, Priority, Effort, Repository
+
+#### 02 Programme Table
+
+**Filter:** status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred
+
+**Group by:** None
+
+**Layout:** table
+
+**Purpose:** All active records and key fields
+
+**Sort by:** None
+
+**Vertical group by:** None
+
+**Visible fields:** Title, Status, Record Type, Priority, Effort, Execution Owner, Repository, Change ID, Delivery Stage
+
+#### 03 Delivery Board
+
+**Filter:** status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred
+
+**Group by:** None
+
+**Layout:** board
+
+**Purpose:** Delivery flow grouped by lifecycle status
+
+**Sort by:** None
+
+**Vertical group by:** Status
+
+**Visible fields:** Title, Priority, Effort, Execution Owner, Repository, Delivery Stage
+
+#### 04 Roadmap
+
+**Filter:** record-type:"Specification Slice",Task status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done
+
+**Group by:** None
+
+**Layout:** roadmap
+
+**Purpose:** Dated or iterated specification and implementation slices
+
+**Sort by:** None
+
+**Vertical group by:** None
+
+**Visible fields:** None
+
+#### 05 Specification Slices
+
+**Filter:** record-type:"Specification Slice" status:Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done
+
+**Group by:** None
+
+**Layout:** table
+
+**Purpose:** Proposed through completed specification records
+
+**Sort by:** None
+
+**Vertical group by:** None
+
+**Visible fields:** Title, Status, Priority, Change ID, Delivery Stage, Repository
+
+#### 06 Decisions
+
+**Filter:** record-type:Decision status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done
+
+**Group by:** None
+
+**Layout:** table
+
+**Purpose:** Proposed, accepted, rejected, and superseded decisions
+
+**Sort by:** None
+
+**Vertical group by:** None
+
+**Visible fields:** Title, Status, Disposition, Review Trigger, Authority Revision, Repository
+
+#### 07 Assumptions and Risks
+
+**Filter:** record-type:Assumption,Risk status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred
+
+**Group by:** None
+
+**Layout:** table
+
+**Purpose:** Open validation and mitigation work
+
+**Sort by:** None
+
+**Vertical group by:** None
+
+**Visible fields:** Title, Status, Severity, Confidence, Review Trigger, Disposition, Repository
+
+#### 08 Holds and Deferred
+
+**Filter:** status:"On Hold",Deferred
+
+**Group by:** None
+
+**Layout:** table
+
+**Purpose:** Paused items with review triggers
+
+**Sort by:** None
+
+**Vertical group by:** None
+
+**Visible fields:** Title, Status, Review Trigger, Execution Owner, Blocked By, Target Date, Repository
+
+#### 09 Reviews and Findings
+
+**Filter:** record-type:"Review Run",Finding,"Security Finding" status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done
+
+**Group by:** None
+
+**Layout:** table
+
+**Purpose:** Review runs and extracted records
+
+**Sort by:** None
+
+**Vertical group by:** None
+
+**Visible fields:** Title, Status, Severity, Confidence, Source Review, Verification, Disposition, Repository
+
+#### 10 Verification
+
+**Filter:** verification:Pending,Failed,Blocked status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done
+
+**Group by:** None
+
+**Layout:** table
+
+**Purpose:** Work awaiting or failing verification
+
+**Sort by:** None
+
+**Vertical group by:** None
+
+**Visible fields:** Title, Status, Verification, Change ID, Delivery Stage, Repository
+
+#### 11 Documentation and Closeout
+
+**Filter:** delivery-stage:Documentation,Commissioning status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done
+
+**Group by:** None
+
+**Layout:** table
+
+**Purpose:** Records awaiting documentation reconciliation or final closeout
+
+**Sort by:** None
+
+**Vertical group by:** None
+
+**Visible fields:** Title, Status, Documentation Impact, Change ID, Delivery Stage, Repository
+
+#### 12 Completed
+
+**Filter:** status:Done
+
+**Group by:** None
+
+**Layout:** table
+
+**Purpose:** Closed records retained for history
+
+**Sort by:** None
+
+**Vertical group by:** None
+
+**Visible fields:** Title, Record Type, Repository, Change ID, Delivery Stage, Verification, Authority Revision
+
+## Principles
+
+Work Management owns command fields., Repository change governance owns Change ID, Complexity, and Risk Triggers after a governed change exists., GitHub owns provider-native source identity and observed dependency evidence., Actions and governed verification evidence own source Verification., Generated specifications are downstream review projections with no write-back authority., Conflicts and unavailable evidence fail closed or remain explicitly unknown.
+
+## Project bindings
+
+### Backend bindings
+
+#### Item 1
+
+**Binding id:** github-default
+
+**Owner:** NielPieterse0
+
+**Owner type:** user
+
+**Project number:** 1
+
+**Provider:** github-mcp
+
+**Enabled:** Yes
+
+### Evidence
+
+**Max file bytes:** 1048576
+
+**Max total bytes:** 4194304
+
+### Features
+
+**Intake:** read_only
+
+**Programme status:** enabled
+
+**Reconciliation:** enabled
+
+**Review import:** read_only
+
+### Gates
+
+**Change traceability:** required
+
+**Decision authority:** advisory
+
+**Hold integrity:** advisory
+
+**Programme drift:** advisory
+
+**Project schema drift:** advisory
+
+**Project settings:** required
+
+**Review disposition:** advisory
+
+**Verification evidence:** required
+
+### Managed projects
+
+#### Item 1
+
+**Backend binding:** github-default
+
+**Display name:** ChatGPT-skill
+
+**Local root:** C:\Projects\ChatGPT-skill
+
+**Project id:** chatgpt-skill
+
+**Repository:** NielPieterse0/chatgpt-skill
+
+#### Item 2
+
+**Backend binding:** github-default
+
+**Display name:** college
+
+**Local root:** C:\Projects\college
+
+**Project id:** college
+
+**Repository:** NielPieterse0/college
+
+#### Item 3
+
+**Backend binding:** github-default
+
+**Display name:** commodity
+
+**Local root:** C:\Projects\commodity
+
+**Project id:** commodity
+
+**Repository:** NielPieterse0/commodity
+
+#### Item 4
+
+**Backend binding:** github-default
+
+**Display name:** import-isolate
+
+**Local root:** C:\Projects\import-isolate
+
+**Project id:** import-isolate
+
+**Repository:** NielPieterse0/import-isolate
+
+#### Item 5
+
+**Backend binding:** github-default
+
+**Display name:** kis-mcp
+
+**Local root:** C:\Projects\kis-mcp
+
+**Project id:** kis-mcp
+
+**Repository:** NielPieterse0/kis-mcp
+
+#### Item 6
+
+**Backend binding:** github-default
+
+**Display name:** kis-mcp-doc
+
+**Local root:** C:\Projects\kis-mcp-doc
+
+**Project id:** kis-mcp-doc
+
+**Repository:** NielPieterse0/kis-mcp-doc
+
+**Portfolio id:** default
+
+**Schema version:** 1
+
+## Source and authority
+
+This page projects `KIS-WORK-CON-POL-001` version `1.0.0`. The MRD is authoritative; this generated page has no write-back authority.

--- a/generated/work-management-spec/007-provider-and-command-plane-boundary.md
+++ b/generated/work-management-spec/007-provider-and-command-plane-boundary.md
@@ -1,0 +1,302 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Provider and command-plane boundary
+
+<div id="enable-section-numbers" />
+
+[Specification](001-specification.md) | [Documentation index](000-index.md)
+
+Define the configured command plane and GitHub Project provider boundary.
+
+## Command plane
+
+### Claim
+
+**Auto expiry:** No
+
+**Execution owner field:** Execution Owner
+
+### Completion
+
+**Require no active claim after close:** No
+
+**Terminal state:** done
+
+### Delivery
+
+**Change created stage:** change_created
+
+**Change id field:** Change ID
+
+**Complete stage:** complete
+
+**Complexity field:** Complexity
+
+**Risk triggers field:** Risk Triggers
+
+**Stage field:** Delivery Stage
+
+**Delivery stages:** none, change_created, implementing, pr_open, review, ci_pending, ci_failed, ci_passed, merged, documentation, commissioning, complete
+
+### Field authority
+
+#### Authority revision
+
+**Authority:** git
+
+**Direction:** evidence
+
+#### Blocked by
+
+**Authority:** github
+
+**Direction:** evidence
+
+#### Change id
+
+**Authority:** repository_change
+
+**Direction:** evidence
+
+#### Commissioning key
+
+**Authority:** derived
+
+**Direction:** evidence
+
+#### Complexity
+
+**Authority:** repository_change
+
+**Direction:** evidence
+
+#### Confidence
+
+**Authority:** work_management
+
+**Direction:** command
+
+#### Created
+
+**Authority:** github
+
+**Direction:** evidence
+
+#### Delivery stage
+
+**Authority:** derived
+
+**Direction:** evidence
+
+#### Disposition
+
+**Authority:** work_management
+
+**Direction:** command
+
+#### Documentation impact
+
+**Authority:** work_management_then_repository_change
+
+**Direction:** handoff
+
+#### Effort
+
+**Authority:** work_management
+
+**Direction:** command
+
+#### Execution owner
+
+**Authority:** work_management
+
+**Direction:** command
+
+#### External link
+
+**Authority:** work_management
+
+**Direction:** command
+
+#### Iteration
+
+**Authority:** work_management
+
+**Direction:** command
+
+#### Live verification
+
+**Authority:** derived
+
+**Direction:** evidence
+
+#### Live verification evidence
+
+**Authority:** derived
+
+**Direction:** evidence
+
+#### Module
+
+**Authority:** work_management_then_repository_change
+
+**Direction:** handoff
+
+#### Origin
+
+**Authority:** work_management
+
+**Direction:** command
+
+#### Priority
+
+**Authority:** work_management
+
+**Direction:** command
+
+#### Project id
+
+**Authority:** derived
+
+**Direction:** evidence
+
+#### Record type
+
+**Authority:** work_management
+
+**Direction:** command
+
+#### Repository
+
+**Authority:** github
+
+**Direction:** evidence
+
+#### Review trigger
+
+**Authority:** work_management
+
+**Direction:** command
+
+#### Risk triggers
+
+**Authority:** repository_change
+
+**Direction:** evidence
+
+#### Severity
+
+**Authority:** work_management
+
+**Direction:** command
+
+#### Source review
+
+**Authority:** work_management
+
+**Direction:** command
+
+#### Status
+
+**Authority:** work_management
+
+**Direction:** command
+
+#### Target date
+
+**Authority:** work_management
+
+**Direction:** command
+
+#### Verification
+
+**Authority:** actions
+
+**Direction:** evidence
+
+### Intake aliases
+
+**Todo:** inbox
+
+### Queue
+
+**Blocked by field:** Blocked By
+
+**Created field:** Created
+
+**Effort field:** Effort
+
+**Effort order:** tiny, small, medium, large
+
+**Eligible states:** ready
+
+**Priority field:** Priority
+
+**Priority order:** critical, high, medium, low
+
+**Ranking:** priority, effort, created_order, record_id
+
+**State field:** Status
+
+### Readiness
+
+**Required issue sections:** Outcome, Acceptance criteria
+
+**Required project fields:** Record Type, Priority, Effort, Documentation Impact
+
+**Requires dependencies understood:** Yes
+
+**Schema version:** 1
+
+### Transition requirements
+
+**Deferred:** Review Trigger
+
+**On hold:** Review Trigger
+
+### Transitions
+
+**Active:** ready, review, blocked, on_hold, deferred, done, superseded
+
+**Approved:** ready, active, on_hold, deferred, superseded
+
+**Blocked:** ready, active, on_hold, deferred, superseded
+
+**Deferred:** triage, proposed, approved, rejected, superseded
+
+**Documentation:** done, active, blocked, superseded
+
+**Done:** None
+
+**Inbox:** triage, deferred, rejected, superseded
+
+**On hold:** ready, active, deferred, rejected, superseded
+
+**Proposed:** approved, deferred, rejected, superseded
+
+**Ready:** active, on_hold, deferred, superseded
+
+**Rejected:** triage, superseded
+
+**Review:** active, verification, blocked, on_hold, superseded
+
+**Superseded:** None
+
+**Triage:** proposed, approved, deferred, rejected, superseded
+
+**Verification:** active, documentation, blocked, superseded
+
+**Work states:** inbox, triage, proposed, approved, ready, active, blocked, on_hold, deferred, rejected, superseded, done
+
+## Provider contract
+
+**Live observation:** not captured in this revision because provider inventory response was invalid
+
+**Project:** NielPieterse0/1
+
+**Read model:** bounded inventory and schema observation
+
+**Write model:** preview or idempotent mutation
+
+## Source and authority
+
+This page projects `KIS-WORK-CTR-SVC-001` version `1.0.0`. The MRD is authoritative; this generated page has no write-back authority.

--- a/generated/work-management-spec/008-work-management-conformance.md
+++ b/generated/work-management-spec/008-work-management-conformance.md
@@ -1,0 +1,16 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Work Management conformance
+
+<div id="enable-section-numbers" />
+
+[Specification](001-specification.md) | [Documentation index](000-index.md)
+
+Define conformance requirements for the Work Management specification.
+
+## Checks
+
+MRD envelopes validate against the KIS MRD core schema., All MRD dependencies resolve and preserve one-owner authority., Harvested source hashes match the pinned canonical snapshot., Generated specification is byte deterministic., Generated output is stale/tamper detectable., Lifecycle transitions and selection rules are reproduced exactly from canonical contracts., Unavailable live Project evidence remains explicit and does not become inferred authority.
+
+## Source and authority
+
+This page projects `KIS-WORK-EVL-TST-001` version `1.0.0`. The MRD is authoritative; this generated page has no write-back authority.

--- a/generated/work-management-spec/manifest.json
+++ b/generated/work-management-spec/manifest.json
@@ -1,0 +1,116 @@
+{
+  "bundle_sha256": "a74e185bacc5372a7ffefebd819ead38090469695c049c79cc9c048e253b621c",
+  "contract": {
+    "name": "kis-work-management-spec-build",
+    "version": 1
+  },
+  "files": [
+    {
+      "bytes": 780,
+      "path": "000-index.md",
+      "sha256": "7bdd16776e4db148096d96eca8094777ba751554d68beec389aeb2f232c6c2a7"
+    },
+    {
+      "bytes": 1516,
+      "path": "001-specification.md",
+      "sha256": "4b90e222164801bbb7e7370c1c41d1af6c709fe2ffef87351dfdc144a219f810"
+    },
+    {
+      "bytes": 23896,
+      "path": "002-work-management-domain-model.md",
+      "sha256": "25b14dafd0a6ebfeeb079ea310a2e30fb34a66d5f21274488ca57154ca1d0dbf"
+    },
+    {
+      "bytes": 6917,
+      "path": "003-work-lifecycle.md",
+      "sha256": "f8dea98c659bdab5efb9fa74792c64ced2f8e183ddc26fb8072059d4fb0810d5"
+    },
+    {
+      "bytes": 4213,
+      "path": "004-work-operations.md",
+      "sha256": "310f64aa32606427bde125ba32156a9cf8efec7a45ccbf46f99fee6f60ce779b"
+    },
+    {
+      "bytes": 3785,
+      "path": "005-next-work-selection.md",
+      "sha256": "243f2fcf4faae34e39b2bb043b22baa480a56a3f0c444fcacc8ff8ee614beb0e"
+    },
+    {
+      "bytes": 12945,
+      "path": "006-authority-and-reconciliation-policy.md",
+      "sha256": "e16ede2f461b86a40459b2954a3780df4c1e5b6436d28790f1d83dcdd318080f"
+    },
+    {
+      "bytes": 5322,
+      "path": "007-provider-and-command-plane-boundary.md",
+      "sha256": "533211f83b23ea5f19915521ebf151aebbfeff8a1cd6f228fdf8dbe94189799b"
+    },
+    {
+      "bytes": 899,
+      "path": "008-work-management-conformance.md",
+      "sha256": "5dc644e111b06f20df0436804b7053314e507262a355b78ac133b3fd4bd40287"
+    },
+    {
+      "bytes": 1516,
+      "path": "specification.md",
+      "sha256": "4b90e222164801bbb7e7370c1c41d1af6c709fe2ffef87351dfdc144a219f810"
+    }
+  ],
+  "inputs": {
+    "mrds": [
+      {
+        "id": "KIS-WORK-SEM-REG-001",
+        "path": "mrd/work-management/01-reg.mrd.json",
+        "sha256": "54f93adedfa74ccd8411a4c38bde91851ba1eddb1869ecf9301263f935336603",
+        "version": "1.0.0"
+      },
+      {
+        "id": "KIS-WORK-WRK-STM-001",
+        "path": "mrd/work-management/02-stm.mrd.json",
+        "sha256": "60b2622666654ea2b0332c4720fe0bc70a902cab7ded3ba955737727f8b8d9a1",
+        "version": "1.0.0"
+      },
+      {
+        "id": "KIS-WORK-WRK-WFL-001",
+        "path": "mrd/work-management/03-wfl.mrd.json",
+        "sha256": "ad5cbeb8e675aa1edbcd670db83ebe4b59f3d6e09407a5ec62b81285156c9367",
+        "version": "1.0.0"
+      },
+      {
+        "id": "KIS-WORK-DEC-SCR-001",
+        "path": "mrd/work-management/04-scr.mrd.json",
+        "sha256": "934dc44aa1c173b09cb0e9185678a53703b4740dc7d6a5163b2853caf83b6b4e",
+        "version": "1.0.0"
+      },
+      {
+        "id": "KIS-WORK-CON-POL-001",
+        "path": "mrd/work-management/05-pol.mrd.json",
+        "sha256": "d83e7341af76952a3ca66c75bca0ec5407156d24237601677d8e71346b98d85f",
+        "version": "1.0.0"
+      },
+      {
+        "id": "KIS-WORK-CTR-SVC-001",
+        "path": "mrd/work-management/06-svc.mrd.json",
+        "sha256": "efda40ea7a1918ed077bc3c6782089046daf4e7d0f0587d031d375476851e7e9",
+        "version": "1.0.0"
+      },
+      {
+        "id": "KIS-WORK-EVL-TST-001",
+        "path": "mrd/work-management/07-tst.mrd.json",
+        "sha256": "db8f93cd8aa889d29ed95a97375e78aa38a4a277ae3cd8e3f1bb1feb7302d894",
+        "version": "1.0.0"
+      }
+    ],
+    "source_set_sha256": "8b0bfecf145821e6481e388e57a0f5673d39b181b6f022a46a1d69b91cefd182"
+  },
+  "specification": {
+    "layout_profile": "mcp-spec",
+    "status": "draft",
+    "title": "KIS Work Management Specification",
+    "version": "1.0.0"
+  },
+  "validation": {
+    "diagnostics": [],
+    "status": "valid"
+  }
+}

--- a/generated/work-management-spec/specification.md
+++ b/generated/work-management-spec/specification.md
@@ -1,0 +1,28 @@
+<!-- GENERATED — DO NOT EDIT -->
+# KIS Work Management Specification
+
+<div id="enable-section-numbers" />
+
+Governed operating specification for work intake, state, selection, delivery, reconciliation, and GitHub Project integration.
+
+The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", and "OPTIONAL" are normative when they appear in all capitals.
+
+## Overview
+
+Work Management separates command authority from evidence. It governs work-item semantics, lifecycle state, deterministic selection, provider reconciliation, delivery evidence, and closeout while keeping repository change governance authoritative for governed change facts.
+
+The specification is generated from seven prescriptive MRDs harvested from the pinned `kis-mcp` implementation contracts. Live GitHub Project evidence that could not be observed remains explicitly unavailable rather than inferred.
+
+## Detailed specification
+
+- [Work Management domain model](002-work-management-domain-model.md)
+- [Work lifecycle](003-work-lifecycle.md)
+- [Work operations](004-work-operations.md)
+- [Next-work selection](005-next-work-selection.md)
+- [Authority and reconciliation policy](006-authority-and-reconciliation-policy.md)
+- [Provider and command-plane boundary](007-provider-and-command-plane-boundary.md)
+- [Work Management conformance](008-work-management-conformance.md)
+
+## Traceability
+
+See the [documentation index](000-index.md) and [build manifest](manifest.json) for source identities and hashes.

--- a/mrd/work-management/01-reg.mrd.json
+++ b/mrd/work-management/01-reg.mrd.json
@@ -1,0 +1,997 @@
+{
+  "_mrd": {
+    "class": "SEM",
+    "dependencies": [
+      {
+        "relationship": "evidenced_by",
+        "source": "repo:evidence/work-management/canonical-snapshot.json"
+      }
+    ],
+    "id": "KIS-WORK-SEM-REG-001",
+    "layer": "L1",
+    "module": "work-management",
+    "provenance": {
+      "fact_quality": "direct",
+      "source_fingerprint": "sha256:3a6da5488cfc8c782fb3ee38617de7ac28d0ba28d877c352033528bfca8797fa",
+      "sources": [
+        {
+          "kind": "repo_path",
+          "locator": "repo:evidence/work-management/canonical-snapshot.json",
+          "revision": "b1c7f00a90c063c6cae287669035e358a04295e0",
+          "role": "implementation_evidence",
+          "sha256": "343154fdc443d75d03b14feb9471331fe5c25c9f9bdfe7d38c8b179a1731d79d",
+          "source_id": "KIS-MCP-WORK-MANAGEMENT-SNAPSHOT"
+        }
+      ]
+    },
+    "record_mode": "prescriptive",
+    "schema_version": 1,
+    "status": "active",
+    "superseded_by": null,
+    "supersedes": [],
+    "title": "Work Management domain model",
+    "type": "REG",
+    "version": "1.0.0"
+  },
+  "content": {
+    "fields": [
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "work_management",
+        "definition": "Operational Work lifecycle status.",
+        "direction": "command",
+        "id": "status",
+        "managed": true,
+        "name": "Status",
+        "population": "Set by explicit Work lifecycle operations.",
+        "provider_type": "single_select",
+        "required_contexts": [],
+        "vocabulary": "status"
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "work_management",
+        "definition": "Purpose classification of the Work record.",
+        "direction": "command",
+        "id": "record_type",
+        "managed": true,
+        "name": "Record Type",
+        "population": "Set during intake/triage and changed only by explicit Work authority.",
+        "provider_type": "single_select",
+        "required_contexts": [
+          "ready_metadata"
+        ],
+        "vocabulary": "record_type"
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "work_management",
+        "definition": "Relative scheduling importance.",
+        "direction": "command",
+        "id": "priority",
+        "managed": true,
+        "name": "Priority",
+        "population": "Set by Work Management and consumed by selection ranking.",
+        "provider_type": "single_select",
+        "required_contexts": [
+          "ready_metadata"
+        ],
+        "vocabulary": "priority"
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "work_management",
+        "definition": "Relative implementation or coordination effort.",
+        "direction": "command",
+        "id": "effort",
+        "managed": true,
+        "name": "Effort",
+        "population": "Set by Work Management and consumed by selection ranking.",
+        "provider_type": "single_select",
+        "required_contexts": [
+          "ready_metadata"
+        ],
+        "vocabulary": "effort"
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "derived",
+        "definition": "Evidence-derived governed delivery stage.",
+        "direction": "evidence",
+        "id": "delivery_stage",
+        "managed": true,
+        "name": "Delivery Stage",
+        "population": "Projected from repository/GitHub delivery evidence.",
+        "provider_type": "single_select",
+        "required_contexts": [],
+        "vocabulary": "delivery_stage"
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "work_management",
+        "definition": "Stable identity of the current execution claimant.",
+        "direction": "command",
+        "id": "execution_owner",
+        "managed": true,
+        "name": "Execution Owner",
+        "population": "Set and cleared only by claim/release lifecycle operations.",
+        "provider_type": "text",
+        "required_contexts": [
+          "active_claim"
+        ],
+        "vocabulary": null
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "github",
+        "definition": "Provider-observed dependency or blocker reference; explicit empty differs from unavailable evidence.",
+        "direction": "evidence",
+        "id": "blocked_by",
+        "managed": true,
+        "name": "Blocked By",
+        "population": "Read from GitHub Project dependency evidence.",
+        "provider_type": "text",
+        "required_contexts": [],
+        "vocabulary": null
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "work_management_then_repository_change",
+        "definition": "Expected or completed documentation impact for the work/change.",
+        "direction": "handoff",
+        "id": "documentation_impact",
+        "managed": true,
+        "name": "Documentation Impact",
+        "population": "Starts as Work command data and becomes governed change evidence.",
+        "provider_type": "single_select",
+        "required_contexts": [
+          "ready_metadata"
+        ],
+        "vocabulary": "documentation_impact"
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "repository_change",
+        "definition": "Repository change-governance complexity projected into Work.",
+        "direction": "evidence",
+        "id": "complexity",
+        "managed": true,
+        "name": "Complexity",
+        "population": "Projected from authoritative schema-v4 governed change scope.",
+        "provider_type": "single_select",
+        "required_contexts": [],
+        "vocabulary": "complexity"
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "repository_change",
+        "definition": "Comma-separated repository change-governance risk-trigger tokens.",
+        "direction": "evidence",
+        "id": "risk_triggers",
+        "managed": true,
+        "name": "Risk Triggers",
+        "population": "Projected from authoritative governed change scope.",
+        "provider_type": "text",
+        "required_contexts": [],
+        "vocabulary": null
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "derived",
+        "definition": "Stable KIS project registry identity for the work item.",
+        "direction": "evidence",
+        "id": "project_id",
+        "managed": true,
+        "name": "Project ID",
+        "population": "Derived from the registered repository-to-project mapping.",
+        "provider_type": "text",
+        "required_contexts": [],
+        "vocabulary": null
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "github",
+        "definition": "GitHub repository identity of the source item.",
+        "direction": "evidence",
+        "id": "repository",
+        "managed": true,
+        "name": "Repository",
+        "population": "Read from the GitHub source item/provider binding.",
+        "provider_type": "repository",
+        "required_contexts": [],
+        "vocabulary": null
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "work_management_then_repository_change",
+        "definition": "Optional bounded module or subsystem context for the work.",
+        "direction": "handoff",
+        "id": "module",
+        "managed": true,
+        "name": "Module",
+        "population": "Set by Work and handed to governed change planning when applicable.",
+        "provider_type": "text",
+        "required_contexts": [],
+        "vocabulary": null
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "repository_change",
+        "definition": "Canonical governed repository change ID once one exists.",
+        "direction": "evidence",
+        "id": "change_id",
+        "managed": true,
+        "name": "Change ID",
+        "population": "Projected from authoritative local change scope.",
+        "provider_type": "text",
+        "required_contexts": [
+          "governed_change"
+        ],
+        "vocabulary": null
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "work_management",
+        "definition": "Context that originated the record.",
+        "direction": "command",
+        "id": "origin",
+        "managed": true,
+        "name": "Origin",
+        "population": "Set when the Work record is created or classified.",
+        "provider_type": "single_select",
+        "required_contexts": [],
+        "vocabulary": "origin"
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "work_management",
+        "definition": "Explicit decision disposition for records that use disposition semantics.",
+        "direction": "command",
+        "id": "disposition",
+        "managed": true,
+        "name": "Disposition",
+        "population": "Set by explicit Work decision/review operations.",
+        "provider_type": "single_select",
+        "required_contexts": [],
+        "vocabulary": "disposition"
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "actions",
+        "definition": "Repository/source verification state; never live-runtime commissioning state.",
+        "direction": "evidence",
+        "id": "verification",
+        "managed": true,
+        "name": "Verification",
+        "population": "Projected from provider-native or governed verification evidence.",
+        "provider_type": "single_select",
+        "required_contexts": [],
+        "vocabulary": "verification"
+      },
+      {
+        "applicable_record_types": [
+          "finding",
+          "security_finding",
+          "risk"
+        ],
+        "authority": "work_management",
+        "definition": "Relative material impact for finding/risk records.",
+        "direction": "command",
+        "id": "severity",
+        "managed": true,
+        "name": "Severity",
+        "population": "Set when a finding or risk is classified.",
+        "provider_type": "single_select",
+        "required_contexts": [
+          "finding_or_risk"
+        ],
+        "vocabulary": "severity"
+      },
+      {
+        "applicable_record_types": [
+          "finding",
+          "security_finding",
+          "assumption"
+        ],
+        "authority": "work_management",
+        "definition": "Evidence confidence for finding/assumption records.",
+        "direction": "command",
+        "id": "confidence",
+        "managed": true,
+        "name": "Confidence",
+        "population": "Set from the evidence quality supporting the record.",
+        "provider_type": "single_select",
+        "required_contexts": [
+          "finding_or_assumption"
+        ],
+        "vocabulary": "confidence"
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "work_management",
+        "definition": "Condition or date/event trigger for reconsidering paused work.",
+        "direction": "command",
+        "id": "review_trigger",
+        "managed": true,
+        "name": "Review Trigger",
+        "population": "Required when work enters On Hold or Deferred.",
+        "provider_type": "text",
+        "required_contexts": [
+          "hold_or_defer"
+        ],
+        "vocabulary": null
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "work_management",
+        "definition": "Optional target date for planned work or reconsideration.",
+        "direction": "command",
+        "id": "target_date",
+        "managed": true,
+        "name": "Target Date",
+        "population": "Set explicitly by Work Management.",
+        "provider_type": "date",
+        "required_contexts": [],
+        "vocabulary": null
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "work_management",
+        "definition": "Optional provider iteration assignment.",
+        "direction": "command",
+        "id": "iteration",
+        "managed": true,
+        "name": "Iteration",
+        "population": "Set explicitly by Work Management.",
+        "provider_type": "iteration",
+        "required_contexts": [],
+        "vocabulary": null
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "work_management",
+        "definition": "Reference to the review source that produced or governs the record.",
+        "direction": "command",
+        "id": "source_review",
+        "managed": true,
+        "name": "Source Review",
+        "population": "Set when review-derived records are captured.",
+        "provider_type": "text",
+        "required_contexts": [],
+        "vocabulary": null
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "git",
+        "definition": "Revision identity of the authority evidence used for the Work record.",
+        "direction": "evidence",
+        "id": "authority_revision",
+        "managed": true,
+        "name": "Authority Revision",
+        "population": "Projected from Git/provider revision evidence.",
+        "provider_type": "text",
+        "required_contexts": [],
+        "vocabulary": null
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "work_management",
+        "definition": "Optional bounded external reference associated with the work.",
+        "direction": "command",
+        "id": "external_link",
+        "managed": true,
+        "name": "External Link",
+        "population": "Set explicitly by Work Management.",
+        "provider_type": "text",
+        "required_contexts": [],
+        "vocabulary": null
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "github",
+        "definition": "Provider-native creation timestamp used as deterministic age evidence.",
+        "direction": "evidence",
+        "id": "created",
+        "managed": false,
+        "name": "Created",
+        "population": "Read from GitHub native item metadata.",
+        "provider_type": "native_datetime",
+        "required_contexts": [],
+        "vocabulary": null
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "derived",
+        "definition": "Post-merge live runtime verification state, distinct from source Verification.",
+        "direction": "evidence",
+        "id": "live_verification",
+        "managed": true,
+        "name": "Live Verification",
+        "population": "Projected by the deterministic commissioning lifecycle under #419.",
+        "provider_type": "single_select",
+        "required_contexts": [],
+        "vocabulary": "live_verification"
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "derived",
+        "definition": "Deterministic commissioning identity: the exact obligation key for one required surface, or the deterministic set key for a source merge with multiple required surfaces.",
+        "direction": "evidence",
+        "id": "commissioning_key",
+        "managed": true,
+        "name": "Commissioning Key",
+        "population": "Derived by the commissioning classifier/runner under #419; source projection uses a set-<digest24> key when multiple obligations must be aggregated.",
+        "provider_type": "text",
+        "required_contexts": [],
+        "vocabulary": null
+      },
+      {
+        "applicable_record_types": [
+          "*"
+        ],
+        "authority": "derived",
+        "definition": "Compact reference to durable live-verification evidence or linked commissioning work; never free-form logs.",
+        "direction": "evidence",
+        "id": "live_verification_evidence",
+        "managed": true,
+        "name": "Live Verification Evidence",
+        "population": "Projected from commissioning evidence under #419.",
+        "provider_type": "text",
+        "required_contexts": [],
+        "vocabulary": null
+      }
+    ],
+    "purpose": "Define canonical Work Management entities, fields, vocabularies, and authority directions.",
+    "rules": [
+      "Every managed field has one authority and one direction.",
+      "Project-native evidence is observed, not redefined by generated documentation."
+    ],
+    "vocabularies": [
+      {
+        "definition": "Operational Work lifecycle status projected to GitHub Project Status.",
+        "id": "status",
+        "values": [
+          {
+            "definition": "Captured work not yet triaged.",
+            "label": "Inbox",
+            "token": "inbox"
+          },
+          {
+            "definition": "Work being classified and prepared for a disposition.",
+            "label": "Triage",
+            "token": "triage"
+          },
+          {
+            "definition": "Work proposed for acceptance but not yet approved.",
+            "label": "Proposed",
+            "token": "proposed"
+          },
+          {
+            "definition": "Accepted work that is not yet admitted to the executable queue.",
+            "label": "Approved",
+            "token": "approved"
+          },
+          {
+            "definition": "Work admitted for deterministic next-work eligibility subject to readiness, claim, and dependency guards.",
+            "label": "Ready",
+            "token": "ready"
+          },
+          {
+            "definition": "Work currently claimed for execution.",
+            "label": "Active",
+            "token": "active"
+          },
+          {
+            "definition": "Work that cannot proceed because a blocking condition is present.",
+            "label": "Blocked",
+            "token": "blocked"
+          },
+          {
+            "definition": "Work intentionally paused pending a declared review trigger.",
+            "label": "On Hold",
+            "token": "on_hold"
+          },
+          {
+            "definition": "Work postponed for later reconsideration with a declared review trigger.",
+            "label": "Deferred",
+            "token": "deferred"
+          },
+          {
+            "definition": "Work explicitly not accepted for execution in its current form.",
+            "label": "Rejected",
+            "token": "rejected"
+          },
+          {
+            "definition": "Work replaced by a newer authoritative record or outcome.",
+            "label": "Superseded",
+            "token": "superseded"
+          },
+          {
+            "definition": "Work whose required completion and closeout gates are satisfied.",
+            "label": "Done",
+            "token": "done"
+          }
+        ]
+      },
+      {
+        "definition": "Classification of the purpose of a Work record.",
+        "id": "record_type",
+        "values": [
+          {
+            "definition": "Uncommitted candidate work requiring triage before it becomes actionable.",
+            "label": "Idea",
+            "token": "idea"
+          },
+          {
+            "definition": "A bounded actionable unit of work.",
+            "label": "Task",
+            "token": "task"
+          },
+          {
+            "definition": "A bounded specification or delivery slice tracked as work.",
+            "label": "Specification Slice",
+            "token": "specification_slice"
+          },
+          {
+            "definition": "A record representing one review execution and its evidence.",
+            "label": "Review Run",
+            "token": "review_run"
+          },
+          {
+            "definition": "An actionable observation produced by review, verification, audit, or commissioning.",
+            "label": "Finding",
+            "token": "finding"
+          },
+          {
+            "definition": "A record of an explicit authoritative choice.",
+            "label": "Decision",
+            "token": "decision"
+          },
+          {
+            "definition": "A proposition tracked because later evidence may validate or invalidate it.",
+            "label": "Assumption",
+            "token": "assumption"
+          },
+          {
+            "definition": "A potential adverse condition tracked for mitigation or disposition.",
+            "label": "Risk",
+            "token": "risk"
+          },
+          {
+            "definition": "A record of an explicit approval decision.",
+            "label": "Approval",
+            "token": "approval"
+          },
+          {
+            "definition": "A record whose purpose is to track a pause or hold condition.",
+            "label": "Hold",
+            "token": "hold"
+          },
+          {
+            "definition": "A bounded investigation intended to produce evidence or a decision.",
+            "label": "Research",
+            "token": "research"
+          },
+          {
+            "definition": "A known incorrect or broken product or system behavior requiring correction.",
+            "label": "Defect",
+            "token": "defect"
+          },
+          {
+            "definition": "A finding whose material impact is security-related.",
+            "label": "Security Finding",
+            "token": "security_finding"
+          }
+        ]
+      },
+      {
+        "definition": "Relative scheduling importance used by the current deterministic Work queue.",
+        "id": "priority",
+        "values": [
+          {
+            "definition": "Highest configured scheduling importance.",
+            "label": "Critical",
+            "token": "critical"
+          },
+          {
+            "definition": "High scheduling importance below Critical.",
+            "label": "High",
+            "token": "high"
+          },
+          {
+            "definition": "Normal scheduling importance below High.",
+            "label": "Medium",
+            "token": "medium"
+          },
+          {
+            "definition": "Lowest configured scheduling importance.",
+            "label": "Low",
+            "token": "low"
+          }
+        ]
+      },
+      {
+        "definition": "Relative implementation or coordination size used by the current deterministic Work queue.",
+        "id": "effort",
+        "values": [
+          {
+            "definition": "Smallest configured relative effort.",
+            "label": "Tiny",
+            "token": "tiny"
+          },
+          {
+            "definition": "Small relative effort.",
+            "label": "Small",
+            "token": "small"
+          },
+          {
+            "definition": "Moderate relative effort.",
+            "label": "Medium",
+            "token": "medium"
+          },
+          {
+            "definition": "Largest configured relative effort.",
+            "label": "Large",
+            "token": "large"
+          }
+        ]
+      },
+      {
+        "definition": "Evidence-derived stage of governed repository delivery.",
+        "id": "delivery_stage",
+        "values": [
+          {
+            "definition": "No governed delivery stage has been established.",
+            "label": "None",
+            "token": "none"
+          },
+          {
+            "definition": "A governed repository change has been created.",
+            "label": "Change Created",
+            "token": "change_created"
+          },
+          {
+            "definition": "Implementation is in progress.",
+            "label": "Implementing",
+            "token": "implementing"
+          },
+          {
+            "definition": "A pull request is open for the governed change.",
+            "label": "PR Open",
+            "token": "pr_open"
+          },
+          {
+            "definition": "The governed change is in review.",
+            "label": "Review",
+            "token": "review"
+          },
+          {
+            "definition": "Provider-native verification is pending.",
+            "label": "CI Pending",
+            "token": "ci_pending"
+          },
+          {
+            "definition": "Provider-native verification failed.",
+            "label": "CI Failed",
+            "token": "ci_failed"
+          },
+          {
+            "definition": "Provider-native verification passed for the applicable head.",
+            "label": "CI Passed",
+            "token": "ci_passed"
+          },
+          {
+            "definition": "The governed change has been observed merged.",
+            "label": "Merged",
+            "token": "merged"
+          },
+          {
+            "definition": "Post-merge documentation reconciliation is due or in progress.",
+            "label": "Documentation",
+            "token": "documentation"
+          },
+          {
+            "definition": "Live verification or commissioning is pending or in progress.",
+            "label": "Commissioning",
+            "token": "commissioning"
+          },
+          {
+            "definition": "Delivery and required closeout evidence are complete.",
+            "label": "Complete",
+            "token": "complete"
+          }
+        ]
+      },
+      {
+        "definition": "Repository documentation impact projected from Work to governed change and back as evidence.",
+        "id": "documentation_impact",
+        "values": [
+          {
+            "definition": "Documentation impact has not yet been assessed.",
+            "label": "Not Assessed",
+            "token": "not_assessed"
+          },
+          {
+            "definition": "No documentation change is required, with rationale recorded where required.",
+            "label": "None",
+            "token": "none"
+          },
+          {
+            "definition": "Documentation changes are planned.",
+            "label": "Planned",
+            "token": "planned"
+          },
+          {
+            "definition": "Documentation changes are being implemented.",
+            "label": "In Progress",
+            "token": "in_progress"
+          },
+          {
+            "definition": "Required pre-merge documentation work is complete.",
+            "label": "Pre-merge Complete",
+            "token": "pre_merge_complete"
+          },
+          {
+            "definition": "Required post-merge documentation reconciliation is complete.",
+            "label": "Post-merge Complete",
+            "token": "post_merge_complete"
+          }
+        ]
+      },
+      {
+        "definition": "Projection of repository change-governance complexity; detailed classification criteria remain owned by change-governance settings.",
+        "id": "complexity",
+        "values": [
+          {
+            "definition": "Repository change-governance Small classification.",
+            "label": "Small",
+            "token": "small"
+          },
+          {
+            "definition": "Repository change-governance Medium classification.",
+            "label": "Medium",
+            "token": "medium"
+          },
+          {
+            "definition": "Repository change-governance Large classification.",
+            "label": "Large",
+            "token": "large"
+          }
+        ]
+      },
+      {
+        "definition": "Source context that caused a Work record to be created.",
+        "id": "origin",
+        "values": [
+          {
+            "definition": "Created directly from operator intent.",
+            "label": "Operator",
+            "token": "operator"
+          },
+          {
+            "definition": "Created from review evidence.",
+            "label": "Review",
+            "token": "review"
+          },
+          {
+            "definition": "Created from verification evidence.",
+            "label": "Verification",
+            "token": "verification"
+          },
+          {
+            "definition": "Created from implementation activity or discovery.",
+            "label": "Implementation",
+            "token": "implementation"
+          },
+          {
+            "definition": "Created from research activity or evidence.",
+            "label": "Research",
+            "token": "research"
+          }
+        ]
+      },
+      {
+        "definition": "Current decision disposition for records that require an explicit disposition.",
+        "id": "disposition",
+        "values": [
+          {
+            "definition": "No terminal disposition has been selected.",
+            "label": "Open",
+            "token": "open"
+          },
+          {
+            "definition": "The record or proposition is accepted.",
+            "label": "Accepted",
+            "token": "accepted"
+          },
+          {
+            "definition": "The record or proposition is rejected.",
+            "label": "Rejected",
+            "token": "rejected"
+          },
+          {
+            "definition": "A newer authoritative record replaces this one.",
+            "label": "Superseded",
+            "token": "superseded"
+          },
+          {
+            "definition": "The tracked risk or finding has been mitigated.",
+            "label": "Mitigated",
+            "token": "mitigated"
+          },
+          {
+            "definition": "Disposition is intentionally postponed.",
+            "label": "Deferred",
+            "token": "deferred"
+          }
+        ]
+      },
+      {
+        "definition": "Repository/source verification state; it does not represent post-merge live runtime proof.",
+        "id": "verification",
+        "values": [
+          {
+            "definition": "Repository/source verification has not run.",
+            "label": "Not Run",
+            "token": "not_run"
+          },
+          {
+            "definition": "Repository/source verification is pending or running.",
+            "label": "Pending",
+            "token": "pending"
+          },
+          {
+            "definition": "Repository/source verification passed for the applicable evidence identity.",
+            "label": "Passed",
+            "token": "passed"
+          },
+          {
+            "definition": "Repository/source verification failed.",
+            "label": "Failed",
+            "token": "failed"
+          },
+          {
+            "definition": "Repository/source verification cannot currently complete.",
+            "label": "Blocked",
+            "token": "blocked"
+          }
+        ]
+      },
+      {
+        "definition": "Relative material impact of a finding or risk.",
+        "id": "severity",
+        "values": [
+          {
+            "definition": "Highest material impact requiring urgent attention.",
+            "label": "Critical",
+            "token": "critical"
+          },
+          {
+            "definition": "High material impact.",
+            "label": "High",
+            "token": "high"
+          },
+          {
+            "definition": "Moderate material impact.",
+            "label": "Medium",
+            "token": "medium"
+          },
+          {
+            "definition": "Limited material impact.",
+            "label": "Low",
+            "token": "low"
+          }
+        ]
+      },
+      {
+        "definition": "Relative confidence classification for finding and assumption evidence; current Work authority does not define quantitative or qualitative thresholds.",
+        "id": "confidence",
+        "values": [
+          {
+            "definition": "Highest configured confidence label; no additional threshold is defined by current Work authority.",
+            "label": "High",
+            "token": "high"
+          },
+          {
+            "definition": "Middle configured confidence label; no additional threshold is defined by current Work authority.",
+            "label": "Medium",
+            "token": "medium"
+          },
+          {
+            "definition": "Lowest configured confidence label; no additional threshold is defined by current Work authority.",
+            "label": "Low",
+            "token": "low"
+          }
+        ]
+      },
+      {
+        "definition": "Post-merge live runtime verification state, distinct from repository/source Verification.",
+        "id": "live_verification",
+        "values": [
+          {
+            "definition": "The need for live verification has not yet been classified.",
+            "label": "Not Assessed",
+            "token": "not_assessed"
+          },
+          {
+            "definition": "Deterministic classification found no live verification obligation.",
+            "label": "Not Required",
+            "token": "not_required"
+          },
+          {
+            "definition": "Live verification is required and has not yet completed.",
+            "label": "Pending",
+            "token": "pending"
+          },
+          {
+            "definition": "Required live verification passed against the actual exposed capability or runtime path.",
+            "label": "Passed",
+            "token": "passed"
+          },
+          {
+            "definition": "Required live verification ran and failed its expected invariant.",
+            "label": "Failed",
+            "token": "failed"
+          },
+          {
+            "definition": "Required live verification cannot currently complete.",
+            "label": "Blocked",
+            "token": "blocked"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/mrd/work-management/02-stm.mrd.json
+++ b/mrd/work-management/02-stm.mrd.json
@@ -1,0 +1,344 @@
+{
+  "_mrd": {
+    "class": "WRK",
+    "dependencies": [
+      {
+        "mrd_id": "KIS-WORK-SEM-REG-001",
+        "relationship": "depends_on"
+      },
+      {
+        "relationship": "evidenced_by",
+        "source": "repo:evidence/work-management/canonical-snapshot.json"
+      }
+    ],
+    "id": "KIS-WORK-WRK-STM-001",
+    "layer": "L2",
+    "module": "work-management",
+    "provenance": {
+      "fact_quality": "direct",
+      "source_fingerprint": "sha256:3a6da5488cfc8c782fb3ee38617de7ac28d0ba28d877c352033528bfca8797fa",
+      "sources": [
+        {
+          "kind": "repo_path",
+          "locator": "repo:evidence/work-management/canonical-snapshot.json",
+          "revision": "b1c7f00a90c063c6cae287669035e358a04295e0",
+          "role": "implementation_evidence",
+          "sha256": "343154fdc443d75d03b14feb9471331fe5c25c9f9bdfe7d38c8b179a1731d79d",
+          "source_id": "KIS-MCP-WORK-MANAGEMENT-SNAPSHOT"
+        }
+      ]
+    },
+    "record_mode": "prescriptive",
+    "schema_version": 1,
+    "status": "active",
+    "superseded_by": null,
+    "supersedes": [],
+    "title": "Work lifecycle",
+    "type": "STM",
+    "version": "1.0.0"
+  },
+  "content": {
+    "claim": {
+      "auto_expiry": false,
+      "execution_owner_field": "Execution Owner"
+    },
+    "completion": {
+      "require_no_active_claim_after_close": false,
+      "terminal_state": "done"
+    },
+    "delivery": {
+      "change_created_stage": "change_created",
+      "change_id_field": "Change ID",
+      "complete_stage": "complete",
+      "complexity_field": "Complexity",
+      "risk_triggers_field": "Risk Triggers",
+      "stage_field": "Delivery Stage",
+      "stages": [
+        "none",
+        "change_created",
+        "implementing",
+        "pr_open",
+        "review",
+        "ci_pending",
+        "ci_failed",
+        "ci_passed",
+        "merged",
+        "documentation",
+        "commissioning",
+        "complete"
+      ]
+    },
+    "guards": [
+      {
+        "condition": "approval_required_and_incomplete",
+        "definition": "Reject activation when the record requires approval and approval is incomplete.",
+        "disposition": "reject",
+        "id": "approval-before-active",
+        "reason_code": "approval_incomplete",
+        "target": "active"
+      },
+      {
+        "condition": "completion_requires_no_active_claim_and_claim_present",
+        "definition": "When configured, reject completion while an execution claim remains.",
+        "disposition": "reject",
+        "id": "completion-no-active-claim",
+        "reason_code": "active_claim_present",
+        "target": "done"
+      },
+      {
+        "condition": "required_documentation_reconciliation_due",
+        "definition": "Required post-merge documentation reconciliation must be completed before Done.",
+        "disposition": "reject",
+        "id": "completion-documentation-due",
+        "reason_code": "documentation_reconciliation_due",
+        "target": "done"
+      },
+      {
+        "condition": "advisory_documentation_reconciliation_due",
+        "definition": "Advisory post-merge documentation reconciliation may complete with an explicit advisory reason.",
+        "disposition": "allow_with_reason",
+        "id": "completion-documentation-due-advisory",
+        "reason_code": "documentation_reconciliation_advisory_due",
+        "target": "done"
+      },
+      {
+        "condition": "required_documentation_reconciliation_unrecorded",
+        "definition": "Required post-merge documentation milestone must be recorded before Done.",
+        "disposition": "reject",
+        "id": "completion-documentation-unrecorded",
+        "reason_code": "documentation_reconciliation_unrecorded",
+        "target": "done"
+      },
+      {
+        "condition": "advisory_documentation_reconciliation_unrecorded",
+        "definition": "Advisory documentation reconciliation may complete without a recorded post-merge milestone, with an explicit advisory reason.",
+        "disposition": "allow_with_reason",
+        "id": "completion-documentation-unrecorded-advisory",
+        "reason_code": "documentation_reconciliation_advisory_incomplete",
+        "target": "done"
+      },
+      {
+        "condition": "required_documentation_incomplete",
+        "definition": "Required documentation impact must be complete before Done.",
+        "disposition": "reject",
+        "id": "completion-documentation-incomplete",
+        "reason_code": "documentation_incomplete",
+        "target": "done"
+      },
+      {
+        "condition": "advisory_documentation_incomplete",
+        "definition": "Advisory documentation may complete while incomplete, with an explicit advisory reason.",
+        "disposition": "allow_with_reason",
+        "id": "completion-documentation-incomplete-advisory",
+        "reason_code": "documentation_advisory_incomplete",
+        "target": "done"
+      }
+    ],
+    "intake_aliases": {
+      "todo": "inbox"
+    },
+    "purpose": "Define Work states, transitions, readiness, claims, delivery stages, completion gates, and guards.",
+    "readiness": {
+      "required_issue_sections": [
+        "Outcome",
+        "Acceptance criteria"
+      ],
+      "required_project_fields": [
+        "Record Type",
+        "Priority",
+        "Effort",
+        "Documentation Impact"
+      ],
+      "requires_dependencies_understood": true
+    },
+    "states": [
+      {
+        "definition": "Captured work not yet triaged.",
+        "label": "Inbox",
+        "project_status": true,
+        "token": "inbox"
+      },
+      {
+        "definition": "Work being classified.",
+        "label": "Triage",
+        "project_status": true,
+        "token": "triage"
+      },
+      {
+        "definition": "Work proposed for approval.",
+        "label": "Proposed",
+        "project_status": true,
+        "token": "proposed"
+      },
+      {
+        "definition": "Accepted work not yet admitted to Ready.",
+        "label": "Approved",
+        "project_status": true,
+        "token": "approved"
+      },
+      {
+        "definition": "Executable queue state subject to readiness guards.",
+        "label": "Ready",
+        "project_status": true,
+        "token": "ready"
+      },
+      {
+        "definition": "Claimed execution state.",
+        "label": "Active",
+        "project_status": true,
+        "token": "active"
+      },
+      {
+        "definition": "Internal delivery state for review activity.",
+        "label": "Review",
+        "project_status": false,
+        "token": "review"
+      },
+      {
+        "definition": "Internal delivery state for verification activity.",
+        "label": "Verification",
+        "project_status": false,
+        "token": "verification"
+      },
+      {
+        "definition": "Internal delivery state for documentation reconciliation.",
+        "label": "Documentation",
+        "project_status": false,
+        "token": "documentation"
+      },
+      {
+        "definition": "Execution cannot proceed because a blocker is present.",
+        "label": "Blocked",
+        "project_status": true,
+        "token": "blocked"
+      },
+      {
+        "definition": "Intentionally paused pending a review trigger.",
+        "label": "On Hold",
+        "project_status": true,
+        "token": "on_hold"
+      },
+      {
+        "definition": "Postponed for later reconsideration.",
+        "label": "Deferred",
+        "project_status": true,
+        "token": "deferred"
+      },
+      {
+        "definition": "Not accepted for execution in current form.",
+        "label": "Rejected",
+        "project_status": true,
+        "token": "rejected"
+      },
+      {
+        "definition": "Replaced by newer authoritative work.",
+        "label": "Superseded",
+        "project_status": true,
+        "token": "superseded"
+      },
+      {
+        "definition": "Required completion gates are satisfied.",
+        "label": "Done",
+        "project_status": true,
+        "token": "done"
+      }
+    ],
+    "transition_requirements": {
+      "deferred": [
+        "Review Trigger"
+      ],
+      "on_hold": [
+        "Review Trigger"
+      ]
+    },
+    "transitions": {
+      "active": [
+        "ready",
+        "review",
+        "blocked",
+        "on_hold",
+        "deferred",
+        "done",
+        "superseded"
+      ],
+      "approved": [
+        "ready",
+        "active",
+        "on_hold",
+        "deferred",
+        "superseded"
+      ],
+      "blocked": [
+        "ready",
+        "active",
+        "on_hold",
+        "deferred",
+        "superseded"
+      ],
+      "deferred": [
+        "triage",
+        "proposed",
+        "approved",
+        "rejected",
+        "superseded"
+      ],
+      "documentation": [
+        "done",
+        "active",
+        "blocked",
+        "superseded"
+      ],
+      "done": [],
+      "inbox": [
+        "triage",
+        "deferred",
+        "rejected",
+        "superseded"
+      ],
+      "on_hold": [
+        "ready",
+        "active",
+        "deferred",
+        "rejected",
+        "superseded"
+      ],
+      "proposed": [
+        "approved",
+        "deferred",
+        "rejected",
+        "superseded"
+      ],
+      "ready": [
+        "active",
+        "on_hold",
+        "deferred",
+        "superseded"
+      ],
+      "rejected": [
+        "triage",
+        "superseded"
+      ],
+      "review": [
+        "active",
+        "verification",
+        "blocked",
+        "on_hold",
+        "superseded"
+      ],
+      "superseded": [],
+      "triage": [
+        "proposed",
+        "approved",
+        "deferred",
+        "rejected",
+        "superseded"
+      ],
+      "verification": [
+        "active",
+        "documentation",
+        "blocked",
+        "superseded"
+      ]
+    }
+  }
+}

--- a/mrd/work-management/03-wfl.mrd.json
+++ b/mrd/work-management/03-wfl.mrd.json
@@ -1,0 +1,153 @@
+{
+  "_mrd": {
+    "class": "WRK",
+    "dependencies": [
+      {
+        "mrd_id": "KIS-WORK-WRK-STM-001",
+        "relationship": "depends_on"
+      },
+      {
+        "relationship": "evidenced_by",
+        "source": "repo:evidence/work-management/canonical-snapshot.json"
+      }
+    ],
+    "id": "KIS-WORK-WRK-WFL-001",
+    "layer": "L3",
+    "module": "work-management",
+    "provenance": {
+      "fact_quality": "direct",
+      "source_fingerprint": "sha256:3a6da5488cfc8c782fb3ee38617de7ac28d0ba28d877c352033528bfca8797fa",
+      "sources": [
+        {
+          "kind": "repo_path",
+          "locator": "repo:evidence/work-management/canonical-snapshot.json",
+          "revision": "b1c7f00a90c063c6cae287669035e358a04295e0",
+          "role": "implementation_evidence",
+          "sha256": "343154fdc443d75d03b14feb9471331fe5c25c9f9bdfe7d38c8b179a1731d79d",
+          "source_id": "KIS-MCP-WORK-MANAGEMENT-SNAPSHOT"
+        }
+      ]
+    },
+    "record_mode": "prescriptive",
+    "schema_version": 1,
+    "status": "active",
+    "superseded_by": null,
+    "supersedes": [],
+    "title": "Work operations",
+    "type": "WFL",
+    "version": "1.0.0"
+  },
+  "content": {
+    "mutation_rule": "External Project mutations require apply=true and an explicit idempotency key.",
+    "operations": [
+      {
+        "definition": "Capture one bounded source record into Work without duplicating source identity.",
+        "effect": "external_or_local_change",
+        "id": "capture_work",
+        "implementation_surface": "project_management_reconcile"
+      },
+      {
+        "definition": "Create or reconcile one new Work record through the configured provider boundary.",
+        "effect": "external_or_local_change",
+        "id": "create_work",
+        "implementation_surface": "project_management_reconcile"
+      },
+      {
+        "definition": "Select the next eligible Ready item and establish its execution claim.",
+        "effect": "external_or_local_change",
+        "id": "take_next_work",
+        "implementation_surface": "project_management_take_next_work"
+      },
+      {
+        "definition": "Establish one execution owner after revision and state guards pass.",
+        "effect": "external_or_local_change",
+        "id": "claim_work",
+        "implementation_surface": "project_management_claim_work"
+      },
+      {
+        "definition": "Clear an execution claim through the bounded command plane.",
+        "effect": "external_or_local_change",
+        "id": "release_work",
+        "implementation_surface": "project_management_release_work"
+      },
+      {
+        "definition": "Move work to On Hold only with the required review trigger.",
+        "effect": "external_or_local_change",
+        "id": "hold_work",
+        "implementation_surface": "project_management_hold_work"
+      },
+      {
+        "definition": "Move work to Deferred only with the required review trigger.",
+        "effect": "external_or_local_change",
+        "id": "defer_work",
+        "implementation_surface": "project_management_defer_work"
+      },
+      {
+        "definition": "Complete work only after configured completion and evidence guards pass.",
+        "effect": "external_or_local_change",
+        "id": "complete_work",
+        "implementation_surface": "project_management_complete_work"
+      },
+      {
+        "definition": "Evaluate deterministic queue eligibility and readiness evidence.",
+        "effect": "read_only",
+        "id": "readiness",
+        "implementation_surface": "project_management_next_work"
+      },
+      {
+        "definition": "Bind execution to a generation-specific work packet and reservation fence.",
+        "effect": "local_change",
+        "id": "assignment_packet",
+        "implementation_surface": "coordinator_work_packet"
+      },
+      {
+        "definition": "Evaluate repository/source verification evidence for the exact delivery identity.",
+        "effect": "read_only_or_external_evidence",
+        "id": "verification",
+        "implementation_surface": "project_management_merge_readiness"
+      },
+      {
+        "definition": "Track post-merge live verification separately from source verification.",
+        "effect": "external_or_local_change",
+        "id": "commissioning",
+        "implementation_surface": "issue_419_commissioning"
+      },
+      {
+        "definition": "Retain provider/Git revision evidence used for optimistic concurrency and traceability.",
+        "effect": "read_only",
+        "id": "authority_revision",
+        "implementation_surface": "project_management_inventory"
+      }
+    ],
+    "purpose": "Define the bounded Work Management operations and their implementation surfaces.",
+    "result_envelope": [
+      "observed_at",
+      "resolved_target",
+      "provenance",
+      "result",
+      "next_actions"
+    ],
+    "typed_errors": [
+      "provider_unavailable",
+      "project_not_commissioned",
+      "inventory_incomplete",
+      "conflict",
+      "invalid_transition",
+      "not_found",
+      "invalid_request",
+      "internal"
+    ],
+    "verification_domains": [
+      {
+        "definition": "Repository/source verification evidence tied to the delivery identity.",
+        "field": "Verification",
+        "id": "source_verification"
+      },
+      {
+        "definition": "Post-merge runtime proof tied to the actual exposed capability or runtime path.",
+        "field": "Live Verification",
+        "id": "live_verification"
+      }
+    ]
+  }
+}

--- a/mrd/work-management/04-scr.mrd.json
+++ b/mrd/work-management/04-scr.mrd.json
@@ -1,0 +1,183 @@
+{
+  "_mrd": {
+    "class": "DEC",
+    "dependencies": [
+      {
+        "mrd_id": "KIS-WORK-SEM-REG-001",
+        "relationship": "depends_on"
+      },
+      {
+        "relationship": "evidenced_by",
+        "source": "repo:evidence/work-management/canonical-snapshot.json"
+      }
+    ],
+    "id": "KIS-WORK-DEC-SCR-001",
+    "layer": "L2",
+    "module": "work-management",
+    "provenance": {
+      "fact_quality": "direct",
+      "source_fingerprint": "sha256:3a6da5488cfc8c782fb3ee38617de7ac28d0ba28d877c352033528bfca8797fa",
+      "sources": [
+        {
+          "kind": "repo_path",
+          "locator": "repo:evidence/work-management/canonical-snapshot.json",
+          "revision": "b1c7f00a90c063c6cae287669035e358a04295e0",
+          "role": "implementation_evidence",
+          "sha256": "343154fdc443d75d03b14feb9471331fe5c25c9f9bdfe7d38c8b179a1731d79d",
+          "source_id": "KIS-MCP-WORK-MANAGEMENT-SNAPSHOT"
+        }
+      ]
+    },
+    "record_mode": "prescriptive",
+    "schema_version": 1,
+    "status": "active",
+    "superseded_by": null,
+    "supersedes": [],
+    "title": "Next-work selection",
+    "type": "SCR",
+    "version": "1.0.0"
+  },
+  "content": {
+    "dependency_evidence": [
+      "unavailable",
+      "partial",
+      "observed"
+    ],
+    "effort_order": [
+      "tiny",
+      "small",
+      "medium",
+      "large"
+    ],
+    "eligible_states": [
+      "ready"
+    ],
+    "fields": {
+      "blocked_by": "Blocked By",
+      "created": "Created",
+      "effort": "Effort",
+      "execution_owner": "Execution Owner",
+      "priority": "Priority",
+      "state": "Status"
+    },
+    "priority_order": [
+      "critical",
+      "high",
+      "medium",
+      "low"
+    ],
+    "profiles": {
+      "normalized_domain": {
+        "reason_overrides": {
+          "dependencies_clear": "dependency_incomplete:{dependency_id}",
+          "eligible_state": "state_not_executable"
+        },
+        "rules": [
+          "project_match",
+          "eligible_state",
+          "unclaimed",
+          "approval_complete",
+          "dependencies_clear"
+        ]
+      },
+      "provider_project": {
+        "reason_overrides": {
+          "dependencies_clear": "native_dependency_blocking",
+          "eligible_state": "state_not_ready"
+        },
+        "rules": [
+          "source_issue",
+          "source_open",
+          "eligible_state",
+          "valid_priority",
+          "valid_effort",
+          "required_fields",
+          "unclaimed",
+          "dependency_evidence",
+          "dependencies_clear"
+        ]
+      }
+    },
+    "purpose": "Define deterministic eligibility and ranking for selecting executable work.",
+    "ranking": [
+      "priority",
+      "effort",
+      "created_order",
+      "record_id"
+    ],
+    "rules": [
+      {
+        "definition": "Only issue records are eligible in the provider-backed next-work queue.",
+        "id": "SEL-001",
+        "kind": "source_issue",
+        "reason_code": "not_issue"
+      },
+      {
+        "definition": "Provider-backed source issues must remain open.",
+        "id": "SEL-002",
+        "kind": "source_open",
+        "reason_code": "source_not_open"
+      },
+      {
+        "definition": "Normalized-domain selection respects an explicit project scope.",
+        "id": "SEL-003",
+        "kind": "project_match",
+        "reason_code": "project_mismatch"
+      },
+      {
+        "definition": "Candidate state must be one of the configured eligible states; domain adapters may preserve their existing equivalent reason code.",
+        "id": "SEL-004",
+        "kind": "eligible_state",
+        "reason_code": "state_not_ready"
+      },
+      {
+        "definition": "Priority must be present in the canonical priority order.",
+        "id": "SEL-005",
+        "kind": "valid_priority",
+        "reason_code": "missing_or_invalid:{field}"
+      },
+      {
+        "definition": "Effort must be present in the canonical effort order.",
+        "id": "SEL-006",
+        "kind": "valid_effort",
+        "reason_code": "missing_or_invalid:{field}"
+      },
+      {
+        "definition": "Configured readiness fields must be present before provider-backed selection.",
+        "id": "SEL-007",
+        "kind": "required_fields",
+        "reason_code": "missing_required:{field}"
+      },
+      {
+        "definition": "Already claimed work is excluded from next-work selection.",
+        "id": "SEL-008",
+        "kind": "unclaimed",
+        "reason_code": "already_claimed:{owner}"
+      },
+      {
+        "definition": "Normalized-domain records that require approval must have completed approval.",
+        "id": "SEL-009",
+        "kind": "approval_complete",
+        "reason_code": "approval_incomplete"
+      },
+      {
+        "definition": "Required provider dependency evidence must be observable.",
+        "id": "SEL-010",
+        "kind": "dependency_evidence",
+        "reason_code": "dependency_evidence_unavailable"
+      },
+      {
+        "definition": "Provider-native blocker evidence must be empty; normalized-domain adapters preserve dependency-specific reason codes.",
+        "id": "SEL-011",
+        "kind": "dependencies_clear",
+        "reason_code": "native_dependency_blocking"
+      },
+      {
+        "definition": "Eligible candidates rank by Priority, Effort, creation order, then stable record identity.",
+        "id": "SEL-012",
+        "kind": "ranking",
+        "reason_code": null
+      }
+    ]
+  }
+}

--- a/mrd/work-management/05-pol.mrd.json
+++ b/mrd/work-management/05-pol.mrd.json
@@ -1,0 +1,687 @@
+{
+  "_mrd": {
+    "class": "CON",
+    "dependencies": [
+      {
+        "mrd_id": "KIS-WORK-SEM-REG-001",
+        "relationship": "depends_on"
+      },
+      {
+        "relationship": "evidenced_by",
+        "source": "repo:evidence/work-management/canonical-snapshot.json"
+      }
+    ],
+    "id": "KIS-WORK-CON-POL-001",
+    "layer": "L1",
+    "module": "work-management",
+    "provenance": {
+      "fact_quality": "direct",
+      "source_fingerprint": "sha256:3a6da5488cfc8c782fb3ee38617de7ac28d0ba28d877c352033528bfca8797fa",
+      "sources": [
+        {
+          "kind": "repo_path",
+          "locator": "repo:evidence/work-management/canonical-snapshot.json",
+          "revision": "b1c7f00a90c063c6cae287669035e358a04295e0",
+          "role": "implementation_evidence",
+          "sha256": "343154fdc443d75d03b14feb9471331fe5c25c9f9bdfe7d38c8b179a1731d79d",
+          "source_id": "KIS-MCP-WORK-MANAGEMENT-SNAPSHOT"
+        }
+      ]
+    },
+    "record_mode": "prescriptive",
+    "schema_version": 1,
+    "status": "active",
+    "superseded_by": null,
+    "supersedes": [],
+    "title": "Authority and reconciliation policy",
+    "type": "POL",
+    "version": "1.0.0"
+  },
+  "content": {
+    "change_governance": {
+      "complexities": {
+        "large": {
+          "artifacts": [
+            "scope.json",
+            "spec.md",
+            "plan.md",
+            "tasks.md",
+            "closeout.md"
+          ],
+          "base_reviews": [
+            "code-quality"
+          ],
+          "description": "Work spanning components or system boundaries, independently reviewable subwork, substantial state or architecture change, a new integration, or significant release or commissioning coordination.",
+          "max_verifications": 20
+        },
+        "medium": {
+          "artifacts": [
+            "scope.json",
+            "spec.md",
+            "plan.md",
+            "tasks.md",
+            "closeout.md"
+          ],
+          "base_reviews": [
+            "code-quality"
+          ],
+          "description": "Several dependent steps or bounded design/shared-interface work in one contained area.",
+          "max_verifications": 20
+        },
+        "small": {
+          "artifacts": [
+            "scope.json",
+            "change.md"
+          ],
+          "base_reviews": [],
+          "description": "One bounded straightforward outcome with no material design or interface redesign.",
+          "max_verifications": 6
+        }
+      },
+      "review_types": [
+        "code-quality",
+        "safety-security",
+        "architecture",
+        "performance",
+        "test-quality",
+        "documentation",
+        "api-contracts"
+      ],
+      "risk_triggers": {
+        "architecture_boundary": {
+          "description": "A module, provider, subsystem, ownership, dependency-direction, or system-boundary contract changes.",
+          "reviews": [
+            "architecture"
+          ]
+        },
+        "deployment": {
+          "description": "Deployment, release, environment promotion, or commissioning behavior changes.",
+          "reviews": []
+        },
+        "destructive": {
+          "description": "The change can remove, replace, invalidate, or irreversibly transform durable resources or state.",
+          "reviews": []
+        },
+        "external_action": {
+          "description": "The change can cause externally observable actions through an approved provider or integration.",
+          "reviews": []
+        },
+        "migration": {
+          "description": "Existing state, schema, configuration, or users require migration or compatibility handling.",
+          "reviews": []
+        },
+        "money": {
+          "description": "Payments, balances, billing, settlement, or other monetary-value behavior changes.",
+          "reviews": []
+        },
+        "persistent_state": {
+          "description": "Durable state, stored records, or persistence semantics change.",
+          "reviews": []
+        },
+        "public_contract": {
+          "description": "A public or externally consumed interface, schema, command, tool, API, or contract changes.",
+          "reviews": [
+            "api-contracts"
+          ]
+        },
+        "secrets": {
+          "description": "Secret material, credentials, key handling, or secret-storage behavior changes.",
+          "reviews": [
+            "safety-security"
+          ]
+        },
+        "security": {
+          "description": "Authentication, authorization, trust-boundary, or security-control behavior changes.",
+          "reviews": [
+            "safety-security"
+          ]
+        },
+        "sensitive_data": {
+          "description": "Personal, regulated, confidential, or otherwise sensitive data handling changes.",
+          "reviews": [
+            "safety-security"
+          ]
+        }
+      },
+      "schema_version": 1
+    },
+    "github_project_schema": {
+      "fields": [
+        {
+          "name": "Status",
+          "options": [
+            "Inbox",
+            "Triage",
+            "Proposed",
+            "Approved",
+            "Ready",
+            "Active",
+            "Blocked",
+            "On Hold",
+            "Deferred",
+            "Rejected",
+            "Superseded",
+            "Done"
+          ],
+          "type": "single_select"
+        },
+        {
+          "name": "Record Type",
+          "options": [
+            "Idea",
+            "Task",
+            "Specification Slice",
+            "Review Run",
+            "Finding",
+            "Decision",
+            "Assumption",
+            "Risk",
+            "Approval",
+            "Hold",
+            "Research",
+            "Defect",
+            "Security Finding"
+          ],
+          "type": "single_select"
+        },
+        {
+          "name": "Priority",
+          "options": [
+            "Critical",
+            "High",
+            "Medium",
+            "Low"
+          ],
+          "type": "single_select"
+        },
+        {
+          "name": "Effort",
+          "options": [
+            "Tiny",
+            "Small",
+            "Medium",
+            "Large"
+          ],
+          "type": "single_select"
+        },
+        {
+          "name": "Delivery Stage",
+          "options": [
+            "None",
+            "Change Created",
+            "Implementing",
+            "PR Open",
+            "Review",
+            "CI Pending",
+            "CI Failed",
+            "CI Passed",
+            "Merged",
+            "Documentation",
+            "Commissioning",
+            "Complete"
+          ],
+          "type": "single_select"
+        },
+        {
+          "name": "Execution Owner",
+          "options": [],
+          "type": "text"
+        },
+        {
+          "name": "Blocked By",
+          "options": [],
+          "type": "text"
+        },
+        {
+          "name": "Documentation Impact",
+          "options": [
+            "Not Assessed",
+            "None",
+            "Planned",
+            "In Progress",
+            "Pre-merge Complete",
+            "Post-merge Complete"
+          ],
+          "type": "single_select"
+        },
+        {
+          "name": "Complexity",
+          "options": [
+            "Small",
+            "Medium",
+            "Large"
+          ],
+          "type": "single_select"
+        },
+        {
+          "name": "Risk Triggers",
+          "options": [],
+          "type": "text"
+        },
+        {
+          "name": "Project ID",
+          "options": [],
+          "type": "text"
+        },
+        {
+          "name": "Repository",
+          "options": [],
+          "type": "repository"
+        },
+        {
+          "name": "Module",
+          "options": [],
+          "type": "text"
+        },
+        {
+          "name": "Change ID",
+          "options": [],
+          "type": "text"
+        },
+        {
+          "name": "Origin",
+          "options": [
+            "Operator",
+            "Review",
+            "Verification",
+            "Implementation",
+            "Research"
+          ],
+          "type": "single_select"
+        },
+        {
+          "name": "Disposition",
+          "options": [
+            "Open",
+            "Accepted",
+            "Rejected",
+            "Superseded",
+            "Mitigated",
+            "Deferred"
+          ],
+          "type": "single_select"
+        },
+        {
+          "name": "Verification",
+          "options": [
+            "Not Run",
+            "Pending",
+            "Passed",
+            "Failed",
+            "Blocked"
+          ],
+          "type": "single_select"
+        },
+        {
+          "name": "Severity",
+          "options": [
+            "Critical",
+            "High",
+            "Medium",
+            "Low"
+          ],
+          "type": "single_select"
+        },
+        {
+          "name": "Confidence",
+          "options": [
+            "High",
+            "Medium",
+            "Low"
+          ],
+          "type": "single_select"
+        },
+        {
+          "name": "Review Trigger",
+          "options": [],
+          "type": "text"
+        },
+        {
+          "name": "Target Date",
+          "options": [],
+          "type": "date"
+        },
+        {
+          "name": "Iteration",
+          "options": [],
+          "type": "iteration"
+        },
+        {
+          "name": "Source Review",
+          "options": [],
+          "type": "text"
+        },
+        {
+          "name": "Authority Revision",
+          "options": [],
+          "type": "text"
+        },
+        {
+          "name": "External Link",
+          "options": [],
+          "type": "text"
+        },
+        {
+          "name": "Live Verification",
+          "options": [
+            "Not Assessed",
+            "Not Required",
+            "Pending",
+            "Passed",
+            "Failed",
+            "Blocked"
+          ],
+          "type": "single_select"
+        },
+        {
+          "name": "Commissioning Key",
+          "options": [],
+          "type": "text"
+        },
+        {
+          "name": "Live Verification Evidence",
+          "options": [],
+          "type": "text"
+        }
+      ],
+      "portfolio_id": "default",
+      "schema_version": 1,
+      "views": [
+        {
+          "filter": "status:Inbox",
+          "group_by": [],
+          "layout": "table",
+          "name": "01 Inbox",
+          "purpose": "Untriaged ideas and tasks",
+          "sort_by": [],
+          "vertical_group_by": [],
+          "visible_fields": [
+            "Title",
+            "Status",
+            "Record Type",
+            "Priority",
+            "Effort",
+            "Repository"
+          ]
+        },
+        {
+          "filter": "status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred",
+          "group_by": [],
+          "layout": "table",
+          "name": "02 Programme Table",
+          "purpose": "All active records and key fields",
+          "sort_by": [],
+          "vertical_group_by": [],
+          "visible_fields": [
+            "Title",
+            "Status",
+            "Record Type",
+            "Priority",
+            "Effort",
+            "Execution Owner",
+            "Repository",
+            "Change ID",
+            "Delivery Stage"
+          ]
+        },
+        {
+          "filter": "status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred",
+          "group_by": [],
+          "layout": "board",
+          "name": "03 Delivery Board",
+          "purpose": "Delivery flow grouped by lifecycle status",
+          "sort_by": [],
+          "vertical_group_by": [
+            "Status"
+          ],
+          "visible_fields": [
+            "Title",
+            "Priority",
+            "Effort",
+            "Execution Owner",
+            "Repository",
+            "Delivery Stage"
+          ]
+        },
+        {
+          "filter": "record-type:\"Specification Slice\",Task status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred,Rejected,Superseded,Done",
+          "group_by": [],
+          "layout": "roadmap",
+          "name": "04 Roadmap",
+          "purpose": "Dated or iterated specification and implementation slices",
+          "sort_by": [],
+          "vertical_group_by": [],
+          "visible_fields": []
+        },
+        {
+          "filter": "record-type:\"Specification Slice\" status:Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred,Rejected,Superseded,Done",
+          "group_by": [],
+          "layout": "table",
+          "name": "05 Specification Slices",
+          "purpose": "Proposed through completed specification records",
+          "sort_by": [],
+          "vertical_group_by": [],
+          "visible_fields": [
+            "Title",
+            "Status",
+            "Priority",
+            "Change ID",
+            "Delivery Stage",
+            "Repository"
+          ]
+        },
+        {
+          "filter": "record-type:Decision status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred,Rejected,Superseded,Done",
+          "group_by": [],
+          "layout": "table",
+          "name": "06 Decisions",
+          "purpose": "Proposed, accepted, rejected, and superseded decisions",
+          "sort_by": [],
+          "vertical_group_by": [],
+          "visible_fields": [
+            "Title",
+            "Status",
+            "Disposition",
+            "Review Trigger",
+            "Authority Revision",
+            "Repository"
+          ]
+        },
+        {
+          "filter": "record-type:Assumption,Risk status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred",
+          "group_by": [],
+          "layout": "table",
+          "name": "07 Assumptions and Risks",
+          "purpose": "Open validation and mitigation work",
+          "sort_by": [],
+          "vertical_group_by": [],
+          "visible_fields": [
+            "Title",
+            "Status",
+            "Severity",
+            "Confidence",
+            "Review Trigger",
+            "Disposition",
+            "Repository"
+          ]
+        },
+        {
+          "filter": "status:\"On Hold\",Deferred",
+          "group_by": [],
+          "layout": "table",
+          "name": "08 Holds and Deferred",
+          "purpose": "Paused items with review triggers",
+          "sort_by": [],
+          "vertical_group_by": [],
+          "visible_fields": [
+            "Title",
+            "Status",
+            "Review Trigger",
+            "Execution Owner",
+            "Blocked By",
+            "Target Date",
+            "Repository"
+          ]
+        },
+        {
+          "filter": "record-type:\"Review Run\",Finding,\"Security Finding\" status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred,Rejected,Superseded,Done",
+          "group_by": [],
+          "layout": "table",
+          "name": "09 Reviews and Findings",
+          "purpose": "Review runs and extracted records",
+          "sort_by": [],
+          "vertical_group_by": [],
+          "visible_fields": [
+            "Title",
+            "Status",
+            "Severity",
+            "Confidence",
+            "Source Review",
+            "Verification",
+            "Disposition",
+            "Repository"
+          ]
+        },
+        {
+          "filter": "verification:Pending,Failed,Blocked status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred,Rejected,Superseded,Done",
+          "group_by": [],
+          "layout": "table",
+          "name": "10 Verification",
+          "purpose": "Work awaiting or failing verification",
+          "sort_by": [],
+          "vertical_group_by": [],
+          "visible_fields": [
+            "Title",
+            "Status",
+            "Verification",
+            "Change ID",
+            "Delivery Stage",
+            "Repository"
+          ]
+        },
+        {
+          "filter": "delivery-stage:Documentation,Commissioning status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,\"On Hold\",Deferred,Rejected,Superseded,Done",
+          "group_by": [],
+          "layout": "table",
+          "name": "11 Documentation and Closeout",
+          "purpose": "Records awaiting documentation reconciliation or final closeout",
+          "sort_by": [],
+          "vertical_group_by": [],
+          "visible_fields": [
+            "Title",
+            "Status",
+            "Documentation Impact",
+            "Change ID",
+            "Delivery Stage",
+            "Repository"
+          ]
+        },
+        {
+          "filter": "status:Done",
+          "group_by": [],
+          "layout": "table",
+          "name": "12 Completed",
+          "purpose": "Closed records retained for history",
+          "sort_by": [],
+          "vertical_group_by": [],
+          "visible_fields": [
+            "Title",
+            "Record Type",
+            "Repository",
+            "Change ID",
+            "Delivery Stage",
+            "Verification",
+            "Authority Revision"
+          ]
+        }
+      ]
+    },
+    "principles": [
+      "Work Management owns command fields.",
+      "Repository change governance owns Change ID, Complexity, and Risk Triggers after a governed change exists.",
+      "GitHub owns provider-native source identity and observed dependency evidence.",
+      "Actions and governed verification evidence own source Verification.",
+      "Generated specifications are downstream review projections with no write-back authority.",
+      "Conflicts and unavailable evidence fail closed or remain explicitly unknown."
+    ],
+    "project_bindings": {
+      "backend_bindings": [
+        {
+          "binding_id": "github-default",
+          "owner": "NielPieterse0",
+          "owner_type": "user",
+          "project_number": 1,
+          "provider": "github-mcp"
+        }
+      ],
+      "enabled": true,
+      "evidence": {
+        "max_file_bytes": 1048576,
+        "max_total_bytes": 4194304
+      },
+      "features": {
+        "intake": "read_only",
+        "programme_status": "enabled",
+        "reconciliation": "enabled",
+        "review_import": "read_only"
+      },
+      "gates": {
+        "change_traceability": "required",
+        "decision_authority": "advisory",
+        "hold_integrity": "advisory",
+        "programme_drift": "advisory",
+        "project_schema_drift": "advisory",
+        "project_settings": "required",
+        "review_disposition": "advisory",
+        "verification_evidence": "required"
+      },
+      "managed_projects": [
+        {
+          "backend_binding": "github-default",
+          "display_name": "ChatGPT-skill",
+          "local_root": "C:\\Projects\\ChatGPT-skill",
+          "project_id": "chatgpt-skill",
+          "repository": "NielPieterse0/chatgpt-skill"
+        },
+        {
+          "backend_binding": "github-default",
+          "display_name": "college",
+          "local_root": "C:\\Projects\\college",
+          "project_id": "college",
+          "repository": "NielPieterse0/college"
+        },
+        {
+          "backend_binding": "github-default",
+          "display_name": "commodity",
+          "local_root": "C:\\Projects\\commodity",
+          "project_id": "commodity",
+          "repository": "NielPieterse0/commodity"
+        },
+        {
+          "backend_binding": "github-default",
+          "display_name": "import-isolate",
+          "local_root": "C:\\Projects\\import-isolate",
+          "project_id": "import-isolate",
+          "repository": "NielPieterse0/import-isolate"
+        },
+        {
+          "backend_binding": "github-default",
+          "display_name": "kis-mcp",
+          "local_root": "C:\\Projects\\kis-mcp",
+          "project_id": "kis-mcp",
+          "repository": "NielPieterse0/kis-mcp"
+        },
+        {
+          "backend_binding": "github-default",
+          "display_name": "kis-mcp-doc",
+          "local_root": "C:\\Projects\\kis-mcp-doc",
+          "project_id": "kis-mcp-doc",
+          "repository": "NielPieterse0/kis-mcp-doc"
+        }
+      ],
+      "portfolio_id": "default",
+      "schema_version": 1
+    },
+    "purpose": "Define authority ownership, repository handoff, Project reconciliation, and no-drift rules."
+  }
+}

--- a/mrd/work-management/06-svc.mrd.json
+++ b/mrd/work-management/06-svc.mrd.json
@@ -1,0 +1,359 @@
+{
+  "_mrd": {
+    "class": "CTR",
+    "dependencies": [
+      {
+        "mrd_id": "KIS-WORK-CON-POL-001",
+        "relationship": "depends_on"
+      },
+      {
+        "mrd_id": "KIS-WORK-WRK-WFL-001",
+        "relationship": "depends_on"
+      },
+      {
+        "relationship": "evidenced_by",
+        "source": "repo:evidence/work-management/canonical-snapshot.json"
+      }
+    ],
+    "id": "KIS-WORK-CTR-SVC-001",
+    "layer": "L3",
+    "module": "work-management",
+    "provenance": {
+      "fact_quality": "direct",
+      "source_fingerprint": "sha256:3a6da5488cfc8c782fb3ee38617de7ac28d0ba28d877c352033528bfca8797fa",
+      "sources": [
+        {
+          "kind": "repo_path",
+          "locator": "repo:evidence/work-management/canonical-snapshot.json",
+          "revision": "b1c7f00a90c063c6cae287669035e358a04295e0",
+          "role": "implementation_evidence",
+          "sha256": "343154fdc443d75d03b14feb9471331fe5c25c9f9bdfe7d38c8b179a1731d79d",
+          "source_id": "KIS-MCP-WORK-MANAGEMENT-SNAPSHOT"
+        }
+      ]
+    },
+    "record_mode": "prescriptive",
+    "schema_version": 1,
+    "status": "active",
+    "superseded_by": null,
+    "supersedes": [],
+    "title": "Provider and command-plane boundary",
+    "type": "SVC",
+    "version": "1.0.0"
+  },
+  "content": {
+    "command_plane": {
+      "claim": {
+        "auto_expiry": false,
+        "execution_owner_field": "Execution Owner"
+      },
+      "completion": {
+        "require_no_active_claim_after_close": false,
+        "terminal_state": "done"
+      },
+      "delivery": {
+        "change_created_stage": "change_created",
+        "change_id_field": "Change ID",
+        "complete_stage": "complete",
+        "complexity_field": "Complexity",
+        "risk_triggers_field": "Risk Triggers",
+        "stage_field": "Delivery Stage"
+      },
+      "delivery_stages": [
+        "none",
+        "change_created",
+        "implementing",
+        "pr_open",
+        "review",
+        "ci_pending",
+        "ci_failed",
+        "ci_passed",
+        "merged",
+        "documentation",
+        "commissioning",
+        "complete"
+      ],
+      "field_authority": {
+        "Authority Revision": {
+          "authority": "git",
+          "direction": "evidence"
+        },
+        "Blocked By": {
+          "authority": "github",
+          "direction": "evidence"
+        },
+        "Change ID": {
+          "authority": "repository_change",
+          "direction": "evidence"
+        },
+        "Commissioning Key": {
+          "authority": "derived",
+          "direction": "evidence"
+        },
+        "Complexity": {
+          "authority": "repository_change",
+          "direction": "evidence"
+        },
+        "Confidence": {
+          "authority": "work_management",
+          "direction": "command"
+        },
+        "Created": {
+          "authority": "github",
+          "direction": "evidence"
+        },
+        "Delivery Stage": {
+          "authority": "derived",
+          "direction": "evidence"
+        },
+        "Disposition": {
+          "authority": "work_management",
+          "direction": "command"
+        },
+        "Documentation Impact": {
+          "authority": "work_management_then_repository_change",
+          "direction": "handoff"
+        },
+        "Effort": {
+          "authority": "work_management",
+          "direction": "command"
+        },
+        "Execution Owner": {
+          "authority": "work_management",
+          "direction": "command"
+        },
+        "External Link": {
+          "authority": "work_management",
+          "direction": "command"
+        },
+        "Iteration": {
+          "authority": "work_management",
+          "direction": "command"
+        },
+        "Live Verification": {
+          "authority": "derived",
+          "direction": "evidence"
+        },
+        "Live Verification Evidence": {
+          "authority": "derived",
+          "direction": "evidence"
+        },
+        "Module": {
+          "authority": "work_management_then_repository_change",
+          "direction": "handoff"
+        },
+        "Origin": {
+          "authority": "work_management",
+          "direction": "command"
+        },
+        "Priority": {
+          "authority": "work_management",
+          "direction": "command"
+        },
+        "Project ID": {
+          "authority": "derived",
+          "direction": "evidence"
+        },
+        "Record Type": {
+          "authority": "work_management",
+          "direction": "command"
+        },
+        "Repository": {
+          "authority": "github",
+          "direction": "evidence"
+        },
+        "Review Trigger": {
+          "authority": "work_management",
+          "direction": "command"
+        },
+        "Risk Triggers": {
+          "authority": "repository_change",
+          "direction": "evidence"
+        },
+        "Severity": {
+          "authority": "work_management",
+          "direction": "command"
+        },
+        "Source Review": {
+          "authority": "work_management",
+          "direction": "command"
+        },
+        "Status": {
+          "authority": "work_management",
+          "direction": "command"
+        },
+        "Target Date": {
+          "authority": "work_management",
+          "direction": "command"
+        },
+        "Verification": {
+          "authority": "actions",
+          "direction": "evidence"
+        }
+      },
+      "intake_aliases": {
+        "todo": "inbox"
+      },
+      "queue": {
+        "blocked_by_field": "Blocked By",
+        "created_field": "Created",
+        "effort_field": "Effort",
+        "effort_order": [
+          "tiny",
+          "small",
+          "medium",
+          "large"
+        ],
+        "eligible_states": [
+          "ready"
+        ],
+        "priority_field": "Priority",
+        "priority_order": [
+          "critical",
+          "high",
+          "medium",
+          "low"
+        ],
+        "ranking": [
+          "priority",
+          "effort",
+          "created_order",
+          "record_id"
+        ],
+        "state_field": "Status"
+      },
+      "readiness": {
+        "required_issue_sections": [
+          "Outcome",
+          "Acceptance criteria"
+        ],
+        "required_project_fields": [
+          "Record Type",
+          "Priority",
+          "Effort",
+          "Documentation Impact"
+        ],
+        "requires_dependencies_understood": true
+      },
+      "schema_version": 1,
+      "transition_requirements": {
+        "deferred": [
+          "Review Trigger"
+        ],
+        "on_hold": [
+          "Review Trigger"
+        ]
+      },
+      "transitions": {
+        "active": [
+          "ready",
+          "review",
+          "blocked",
+          "on_hold",
+          "deferred",
+          "done",
+          "superseded"
+        ],
+        "approved": [
+          "ready",
+          "active",
+          "on_hold",
+          "deferred",
+          "superseded"
+        ],
+        "blocked": [
+          "ready",
+          "active",
+          "on_hold",
+          "deferred",
+          "superseded"
+        ],
+        "deferred": [
+          "triage",
+          "proposed",
+          "approved",
+          "rejected",
+          "superseded"
+        ],
+        "documentation": [
+          "done",
+          "active",
+          "blocked",
+          "superseded"
+        ],
+        "done": [],
+        "inbox": [
+          "triage",
+          "deferred",
+          "rejected",
+          "superseded"
+        ],
+        "on_hold": [
+          "ready",
+          "active",
+          "deferred",
+          "rejected",
+          "superseded"
+        ],
+        "proposed": [
+          "approved",
+          "deferred",
+          "rejected",
+          "superseded"
+        ],
+        "ready": [
+          "active",
+          "on_hold",
+          "deferred",
+          "superseded"
+        ],
+        "rejected": [
+          "triage",
+          "superseded"
+        ],
+        "review": [
+          "active",
+          "verification",
+          "blocked",
+          "on_hold",
+          "superseded"
+        ],
+        "superseded": [],
+        "triage": [
+          "proposed",
+          "approved",
+          "deferred",
+          "rejected",
+          "superseded"
+        ],
+        "verification": [
+          "active",
+          "documentation",
+          "blocked",
+          "superseded"
+        ]
+      },
+      "work_states": [
+        "inbox",
+        "triage",
+        "proposed",
+        "approved",
+        "ready",
+        "active",
+        "blocked",
+        "on_hold",
+        "deferred",
+        "rejected",
+        "superseded",
+        "done"
+      ]
+    },
+    "provider_contract": {
+      "live_observation": "not captured in this revision because provider inventory response was invalid",
+      "project": "NielPieterse0/1",
+      "read_model": "bounded inventory and schema observation",
+      "write_model": "preview or idempotent mutation"
+    },
+    "purpose": "Define the configured command plane and GitHub Project provider boundary."
+  }
+}

--- a/mrd/work-management/07-tst.mrd.json
+++ b/mrd/work-management/07-tst.mrd.json
@@ -1,0 +1,56 @@
+{
+  "_mrd": {
+    "class": "EVL",
+    "dependencies": [
+      {
+        "mrd_id": "KIS-WORK-CTR-SVC-001",
+        "relationship": "validated_by"
+      },
+      {
+        "mrd_id": "KIS-WORK-DEC-SCR-001",
+        "relationship": "validated_by"
+      },
+      {
+        "relationship": "evidenced_by",
+        "source": "repo:evidence/work-management/canonical-snapshot.json"
+      }
+    ],
+    "id": "KIS-WORK-EVL-TST-001",
+    "layer": "L4",
+    "module": "work-management",
+    "provenance": {
+      "fact_quality": "direct",
+      "source_fingerprint": "sha256:3a6da5488cfc8c782fb3ee38617de7ac28d0ba28d877c352033528bfca8797fa",
+      "sources": [
+        {
+          "kind": "repo_path",
+          "locator": "repo:evidence/work-management/canonical-snapshot.json",
+          "revision": "b1c7f00a90c063c6cae287669035e358a04295e0",
+          "role": "implementation_evidence",
+          "sha256": "343154fdc443d75d03b14feb9471331fe5c25c9f9bdfe7d38c8b179a1731d79d",
+          "source_id": "KIS-MCP-WORK-MANAGEMENT-SNAPSHOT"
+        }
+      ]
+    },
+    "record_mode": "prescriptive",
+    "schema_version": 1,
+    "status": "active",
+    "superseded_by": null,
+    "supersedes": [],
+    "title": "Work Management conformance",
+    "type": "TST",
+    "version": "1.0.0"
+  },
+  "content": {
+    "checks": [
+      "MRD envelopes validate against the KIS MRD core schema.",
+      "All MRD dependencies resolve and preserve one-owner authority.",
+      "Harvested source hashes match the pinned canonical snapshot.",
+      "Generated specification is byte deterministic.",
+      "Generated output is stale/tamper detectable.",
+      "Lifecycle transitions and selection rules are reproduced exactly from canonical contracts.",
+      "Unavailable live Project evidence remains explicit and does not become inferred authority."
+    ],
+    "purpose": "Define conformance requirements for the Work Management specification."
+  }
+}

--- a/publication/work-management-spec.json
+++ b/publication/work-management-spec.json
@@ -1,0 +1,9 @@
+{
+  "output_dir": "generated/work-management-spec",
+  "schema_version": 1,
+  "source_glob": "mrd/work-management/*.mrd.json",
+  "status": "draft",
+  "subtitle": "Governed operating specification for work intake, state, selection, delivery, reconciliation, and GitHub Project integration",
+  "title": "KIS Work Management Specification",
+  "version": "1.0.0"
+}

--- a/scripts/verify.ps1
+++ b/scripts/verify.ps1
@@ -20,11 +20,16 @@ if ($env:KIS_EXACT_SHA) {
     }
 }
 
-$AllowedGeneratedMarkdownPrefix = 'generated/governance-spec/'
+$AllowedGeneratedMarkdownPrefixes = @(
+    'generated/governance-spec/',
+    'generated/work-management-spec/'
+)
 $TrackedMarkdown = @(& git -C $RepositoryRoot ls-files '*.md')
 $UnexpectedMarkdown = @(
     $TrackedMarkdown | Where-Object {
-        $_ -ne 'AGENTS.md' -and -not $_.StartsWith($AllowedGeneratedMarkdownPrefix)
+        $Path = $_
+        $AllowedGenerated = @($AllowedGeneratedMarkdownPrefixes | Where-Object { $Path.StartsWith($_) }).Count -gt 0
+        $Path -ne 'AGENTS.md' -and -not $AllowedGenerated
     }
 )
 if ($UnexpectedMarkdown.Count -gt 0) {
@@ -60,6 +65,16 @@ try {
     & $PythonCommand -m kis_mcp_doc --root . check-generated
     if ($LASTEXITCODE -ne 0) {
         throw "Generated-output verification failed with exit code $LASTEXITCODE"
+    }
+
+    & $PythonCommand -m kis_mcp_doc --root . work-validate
+    if ($LASTEXITCODE -ne 0) {
+        throw "Work Management validation failed with exit code $LASTEXITCODE"
+    }
+
+    & $PythonCommand -m kis_mcp_doc --root . work-check-generated
+    if ($LASTEXITCODE -ne 0) {
+        throw "Work Management generated-output verification failed with exit code $LASTEXITCODE"
     }
 
     & git diff --check

--- a/src/kis_mcp_doc/cli.py
+++ b/src/kis_mcp_doc/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from .governance import GovernanceRepository
 from .render import build_governance_spec, verify_governance_spec
+from .work_management import WorkManagementRepository, build_work_management_spec, verify_work_management_spec
 
 
 def _repository(root: Path) -> GovernanceRepository:
@@ -17,6 +18,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--root", type=Path, default=Path.cwd())
     sub = parser.add_subparsers(dest="command", required=True)
     sub.add_parser("validate")
+    sub.add_parser("work-validate")
+    work_build = sub.add_parser("work-build")
+    work_build.add_argument("--output", type=Path)
+    work_build.add_argument("--replace", action="store_true")
+    work_check = sub.add_parser("work-check-generated")
+    work_check.add_argument("--output", type=Path)
     build = sub.add_parser("build")
     build.add_argument("--output", type=Path)
     build.add_argument("--replace", action="store_true")
@@ -31,6 +38,21 @@ def main(argv: list[str] | None = None) -> int:
     publication = root / "publication" / "governance-spec.json"
     if args.command == "validate":
         result = repo.validate()
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0 if result["status"] == "valid" else 1
+
+    if args.command == "work-validate":
+        result = WorkManagementRepository(root).validate()
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0 if result["status"] == "valid" else 1
+    if args.command == "work-build":
+        output = args.output or (root / "generated" / "work-management-spec")
+        manifest = build_work_management_spec(WorkManagementRepository(root), output, replace=args.replace)
+        print(json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+    if args.command == "work-check-generated":
+        output = args.output or (root / "generated" / "work-management-spec")
+        result = verify_work_management_spec(WorkManagementRepository(root), output)
         print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
         return 0 if result["status"] == "valid" else 1
 

--- a/src/kis_mcp_doc/work_management.py
+++ b/src/kis_mcp_doc/work_management.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from .governance import canonical_hash, canonical_source_bytes
+
+
+class WorkManagementRepository:
+    def __init__(self, root: Path, mrd_root: Path | None = None) -> None:
+        self.root = Path(root).resolve()
+        self.mrd_root = (mrd_root or self.root / "mrd" / "work-management").resolve()
+        self.schema_path = self.root / "contracts" / "mrd" / "v1" / "mrd.schema.json"
+
+    def load(self) -> dict[str, dict[str, Any]]:
+        docs: dict[str, dict[str, Any]] = {}
+        for path in sorted(self.mrd_root.glob("*.mrd.json")):
+            doc = json.loads(path.read_text(encoding="utf-8"))
+            doc_id = doc.get("_mrd", {}).get("id")
+            if not isinstance(doc_id, str) or not doc_id:
+                raise ValueError(f"MRD missing stable id: {path}")
+            if doc_id in docs:
+                raise ValueError(f"duplicate MRD id: {doc_id}")
+            docs[doc_id] = doc
+        return docs
+
+    def validate(self) -> dict[str, Any]:
+        diagnostics: list[dict[str, str]] = []
+        try:
+            schema = json.loads(self.schema_path.read_text(encoding="utf-8"))
+            Draft202012Validator.check_schema(schema)
+            validator = Draft202012Validator(schema)
+            docs = self.load()
+        except Exception as error:
+            return {"status":"invalid","diagnostics":[{"code":"WORK_MRD_LOAD_INVALID","message":str(error)}]}
+        for doc_id, doc in docs.items():
+            for error in sorted(validator.iter_errors(doc), key=lambda e: tuple(str(x) for x in e.absolute_path)):
+                diagnostics.append({"code":"WORK_MRD_SCHEMA_INVALID","message":f"{doc_id}: {error.message}"})
+        ids=set(docs)
+        for doc_id,doc in docs.items():
+            for dep in doc["_mrd"]["dependencies"]:
+                if "mrd_id" in dep and dep["mrd_id"] not in ids:
+                    diagnostics.append({"code":"WORK_MRD_DEPENDENCY_UNRESOLVED","message":f"{doc_id}: {dep['mrd_id']}"})
+                if "source" in dep:
+                    rel=dep["source"][5:]
+                    if not (self.root/rel).is_file():
+                        diagnostics.append({"code":"WORK_MRD_SOURCE_UNRESOLVED","message":f"{doc_id}: {rel}"})
+            sources=doc["_mrd"]["provenance"]["sources"]
+            expected="sha256:"+canonical_hash(sources)
+            if doc["_mrd"]["provenance"]["source_fingerprint"] != expected:
+                diagnostics.append({"code":"WORK_MRD_FINGERPRINT_MISMATCH","message":doc_id})
+            for source in sources:
+                if source["kind"]=="repo_path":
+                    path=self.root/source["locator"][5:]
+                    if not path.is_file() or hashlib.sha256(canonical_source_bytes(path)).hexdigest()!=source.get("sha256"):
+                        diagnostics.append({"code":"WORK_MRD_SOURCE_HASH_MISMATCH","message":f"{doc_id}: {source['locator']}"})
+        return {"status":"invalid" if diagnostics else "valid","diagnostics":diagnostics}
+
+
+def _page_name(index: int, doc: dict[str, Any]) -> str:
+    slug="-".join(x for x in ''.join(c.lower() if c.isalnum() else '-' for c in doc['_mrd']['title']).split('-') if x)
+    return f"{index:03d}-{slug}.md"
+
+
+def _inline_value(value: Any) -> str | None:
+    if value is None:
+        return "None"
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+    if isinstance(value, (str, int, float)):
+        return str(value)
+    if isinstance(value, list) and all(isinstance(item, (str, int, float, bool)) for item in value):
+        return ", ".join(str(item) for item in value) if value else "None"
+    return None
+
+
+def _item_label(item: dict[str, Any], index: int) -> str:
+    for key in ("name", "label", "title", "id", "token", "code", "operation_id", "rule_id"):
+        value = item.get(key)
+        if isinstance(value, (str, int)) and str(value):
+            return str(value).replace("_", " ")
+    if "order" in item:
+        return f"Step {item['order']}"
+    return f"Item {index}"
+
+
+def _render_value(value: Any, *, level: int = 3) -> list[str]:
+    if isinstance(value, str):
+        return [value, ""]
+    inline = _inline_value(value)
+    if inline is not None:
+        return [inline, ""]
+    if isinstance(value, list):
+        if not value:
+            return ["None.", ""]
+        if all(isinstance(item, str) for item in value):
+            return [*(f"- {item}" for item in value), ""]
+        if all(isinstance(item, dict) for item in value):
+            lines: list[str] = []
+            for index, item in enumerate(value, start=1):
+                lines.extend([f"{'#' * min(level, 6)} {_item_label(item, index)}", ""])
+                for key, nested in item.items():
+                    if key in {"name", "label", "title"}:
+                        continue
+                    label = key.replace("_", " ").capitalize()
+                    nested_inline = _inline_value(nested)
+                    if nested_inline is not None:
+                        lines.extend([f"**{label}:** {nested_inline}", ""])
+                    else:
+                        lines.extend([f"{'#' * min(level + 1, 6)} {label}", ""])
+                        lines.extend(_render_value(nested, level=level + 2))
+            return lines
+        return ["- " + str(item) for item in value] + [""]
+    if isinstance(value, dict):
+        lines = []
+        for key, nested in value.items():
+            label = key.replace("_", " ").capitalize()
+            nested_inline = _inline_value(nested)
+            if nested_inline is not None:
+                lines.extend([f"**{label}:** {nested_inline}", ""])
+            else:
+                lines.extend([f"{'#' * min(level, 6)} {label}", ""])
+                lines.extend(_render_value(nested, level=level + 1))
+        return lines
+    return [str(value), ""]
+
+
+def render_document(doc: dict[str, Any]) -> str:
+    content=doc["content"]
+    lines=["<!-- GENERATED — DO NOT EDIT -->",f"# {doc['_mrd']['title']}","",'<div id="enable-section-numbers" />',"","[Specification](001-specification.md) | [Documentation index](000-index.md)",""]
+    purpose=content.get("purpose")
+    if purpose: lines.extend([purpose,""])
+    for key,value in content.items():
+        if key=="purpose": continue
+        lines.extend([f"## {key.replace('_',' ').capitalize()}",""])
+        lines.extend(_render_value(value))
+    lines.extend(["## Source and authority","",f"This page projects `{doc['_mrd']['id']}` version `{doc['_mrd']['version']}`. The MRD is authoritative; this generated page has no write-back authority.",""])
+    return "\n".join(lines)
+
+
+def build_work_management_spec(repo: WorkManagementRepository, output: Path, *, replace: bool=False) -> dict[str, Any]:
+    validation=repo.validate()
+    if validation["status"]!="valid": raise ValueError(f"work-management MRDs invalid: {validation['diagnostics']}")
+    docs=list(repo.load().values())
+    output=Path(output)
+    staging=Path(tempfile.mkdtemp(prefix=f".{output.name}.",suffix=".tmp",dir=output.parent))
+    try:
+        pages=[]
+        for i,doc in enumerate(docs,2):
+            name=_page_name(i,doc); text=render_document(doc); (staging/name).write_text(text,encoding="utf-8"); pages.append((name,doc))
+        index=["<!-- GENERATED — DO NOT EDIT -->","# KIS Work Management Specification — documentation index","","The validated Work Management MRDs are authoritative. These pages are deterministic review projections.","","## Specification pages","","- [Specification](001-specification.md)"]+[f"- [{d['_mrd']['title']}]({n})" for n,d in pages]+["","## Traceability","","- [Build manifest](manifest.json)",""]
+        (staging/'000-index.md').write_text("\n".join(index),encoding='utf-8')
+        root=["<!-- GENERATED — DO NOT EDIT -->","# KIS Work Management Specification","",'<div id="enable-section-numbers" />',"","Governed operating specification for work intake, state, selection, delivery, reconciliation, and GitHub Project integration.","",'The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", and "OPTIONAL" are normative when they appear in all capitals.',"","## Overview","","Work Management separates command authority from evidence. It governs work-item semantics, lifecycle state, deterministic selection, provider reconciliation, delivery evidence, and closeout while keeping repository change governance authoritative for governed change facts.","","The specification is generated from seven prescriptive MRDs harvested from the pinned `kis-mcp` implementation contracts. Live GitHub Project evidence that could not be observed remains explicitly unavailable rather than inferred.","","## Detailed specification",""]+[f"- [{d['_mrd']['title']}]({n})" for n,d in pages]+["","## Traceability","","See the [documentation index](000-index.md) and [build manifest](manifest.json) for source identities and hashes.",""]
+        spec="\n".join(root); (staging/'001-specification.md').write_text(spec,encoding='utf-8'); (staging/'specification.md').write_text(spec,encoding='utf-8')
+        files=[]
+        for path in sorted(staging.rglob('*')):
+            if path.is_file():
+                b=path.read_bytes(); files.append({'path':path.relative_to(staging).as_posix(),'sha256':hashlib.sha256(b).hexdigest(),'bytes':len(b)})
+        mrds=[]
+        for path in sorted(repo.mrd_root.glob('*.mrd.json')):
+            b=canonical_source_bytes(path); d=json.loads(path.read_text(encoding='utf-8')); mrds.append({'id':d['_mrd']['id'],'path':path.relative_to(repo.root).as_posix(),'sha256':hashlib.sha256(b).hexdigest(),'version':d['_mrd']['version']})
+        manifest={'contract':{'name':'kis-work-management-spec-build','version':1},'specification':{'title':'KIS Work Management Specification','version':'1.0.0','status':'draft','layout_profile':'mcp-spec'},'inputs':{'mrds':mrds,'source_set_sha256':canonical_hash(mrds)},'validation':validation,'files':files,'bundle_sha256':canonical_hash(files)}
+        (staging/'manifest.json').write_text(json.dumps(manifest,indent=2,sort_keys=True)+'\n',encoding='utf-8')
+        if output.exists():
+            if not replace: raise FileExistsError(output)
+            shutil.rmtree(output)
+        output.parent.mkdir(parents=True,exist_ok=True); staging.replace(output); return manifest
+    except Exception:
+        shutil.rmtree(staging,ignore_errors=True); raise
+
+
+def verify_work_management_spec(repo: WorkManagementRepository, output: Path) -> dict[str, Any]:
+    output=Path(output)
+    if not (output/'manifest.json').is_file(): return {'status':'invalid','diagnostics':[{'code':'WORK_GENERATED_MANIFEST_MISSING','message':'manifest.json missing'}]}
+    temp=output.parent/(output.name+'.verify.tmp')
+    if temp.exists(): shutil.rmtree(temp)
+    try:
+        build_work_management_spec(repo,temp)
+        expected={p.relative_to(temp).as_posix():canonical_source_bytes(p) for p in temp.rglob('*') if p.is_file()}
+        actual={p.relative_to(output).as_posix():canonical_source_bytes(p) for p in output.rglob('*') if p.is_file()}
+        if expected!=actual: return {'status':'invalid','diagnostics':[{'code':'WORK_GENERATED_DRIFT','message':'generated Work Management specification differs from deterministic current output'}]}
+        return {'status':'valid','diagnostics':[]}
+    finally:
+        shutil.rmtree(temp,ignore_errors=True)

--- a/tests/test_work_management_spec.py
+++ b/tests/test_work_management_spec.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+import json
+
+from kis_mcp_doc.work_management import WorkManagementRepository, build_work_management_spec, verify_work_management_spec
+
+ROOT = Path(__file__).resolve().parents[1]
+
+def test_work_management_mrds_validate():
+    result = WorkManagementRepository(ROOT).validate()
+    assert result["status"] == "valid", result
+
+def test_work_management_spec_is_deterministic(tmp_path):
+    repo=WorkManagementRepository(ROOT)
+    first=tmp_path/"first"; second=tmp_path/"second"
+    build_work_management_spec(repo,first)
+    build_work_management_spec(repo,second)
+    a={p.relative_to(first).as_posix():p.read_bytes() for p in first.rglob("*") if p.is_file()}
+    b={p.relative_to(second).as_posix():p.read_bytes() for p in second.rglob("*") if p.is_file()}
+    assert a==b
+
+def test_work_management_generated_bundle_verifies(tmp_path):
+    repo=WorkManagementRepository(ROOT); out=tmp_path/"build"
+    build_work_management_spec(repo,out)
+    assert verify_work_management_spec(repo,out)["status"]=="valid"
+    (out/"specification.md").write_text("tampered\n",encoding="utf-8")
+    assert verify_work_management_spec(repo,out)["status"]=="invalid"
+
+def test_work_management_verifier_ignores_text_line_endings(tmp_path):
+    repo=WorkManagementRepository(ROOT); out=tmp_path/"build"
+    build_work_management_spec(repo,out)
+    for path in out.rglob("*"):
+        if path.is_file():
+            payload=path.read_bytes().replace(b"\r\n",b"\n").replace(b"\r",b"\n")
+            path.write_bytes(payload.replace(b"\n",b"\r\n"))
+    assert verify_work_management_spec(repo,out)["status"]=="valid"
+
+def test_generated_spec_is_human_readable(tmp_path):
+    repo=WorkManagementRepository(ROOT); out=tmp_path/"build"
+    build_work_management_spec(repo,out)
+    domain=(out/"002-work-management-domain-model.md").read_text(encoding="utf-8")
+    assert "<!-- GENERATED — DO NOT EDIT -->" in domain
+    assert "- `{\"" not in domain
+    assert "**Authority:** work_management" in domain
+    assert "### Status" in domain
+
+def test_snapshot_pins_parent_revision_and_live_project_state():
+    data=json.loads((ROOT/"evidence/work-management/canonical-snapshot.json").read_text(encoding="utf-8"))
+    assert data["source_revision"]=="b1c7f00a90c063c6cae287669035e358a04295e0"
+    observation=data["live_project_observation"]
+    assert observation["status"]=="observed"
+    assert observation["inventory_complete"] is True
+    assert observation["schema_status"]["ready"] is True
+    assert observation["schema_status"]["missing_fields"]==[]
+    assert observation["schema_status"]["type_mismatches"]==[]
+    assert observation["schema_status"]["missing_options"]==[]
+    assert observation["schema_status"]["missing_views"]==[]
+    assert observation["schema_status"]["view_mismatches"]==[]


### PR DESCRIPTION
Implements change 006-work-management-specification.

- captures pinned Work Management evidence
- adds prescriptive Work Management MRDs
- generates the MCP-style Work Management Specification
- integrates Work Management validation into canonical repository verification
- adds deterministic stale/tamper and line-ending-safe generated-output checks
- adds focused tests and CLI support
- records current live GitHub Project inventory/schema evidence; the configured Project is observed ready with no field, option, type, or view drift

Verification: canonical local verification passed and GitHub Actions Canonical Verification passed on exact head `54c4c4642c8b8070a8970fe8fff9cc227ee77961`.