### PR TITLE
Improve Work Management HRD readability

### DIFF
--- a/generated/work-management-spec/000-index.md
+++ b/generated/work-management-spec/000-index.md
@@ -1,7 +1,9 @@
 <!-- GENERATED — DO NOT EDIT -->
 # KIS Work Management Specification — documentation index
 
-The validated Work Management MRDs are authoritative. These pages are deterministic review projections.
+Start with the [Specification](001-specification.md) for the operating model. The remaining chapters provide the detailed lifecycle, selection, authority, provider, and conformance rules.
+
+The validated Work Management MRDs remain authoritative. These pages are deterministic review projections and have no write-back authority.
 
 ## Specification pages
 
@@ -16,4 +18,4 @@ The validated Work Management MRDs are authoritative. These pages are determinis
 
 ## Traceability
 
-- [Build manifest](manifest.json)
+- [Build manifest](manifest.json) — exact MRD and generated-file hashes

--- a/generated/work-management-spec/001-specification.md
+++ b/generated/work-management-spec/001-specification.md
@@ -3,15 +3,32 @@
 
 <div id="enable-section-numbers" />
 
-Governed operating specification for work intake, state, selection, delivery, reconciliation, and GitHub Project integration.
+Work Management is the governed KIS system for capturing, classifying, selecting, executing, verifying, and closing work across registered projects.
 
 The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", and "OPTIONAL" are normative when they appear in all capitals.
 
 ## Overview
 
-Work Management separates command authority from evidence. It governs work-item semantics, lifecycle state, deterministic selection, provider reconciliation, delivery evidence, and closeout while keeping repository change governance authoritative for governed change facts.
+Work Management gives work one shared lifecycle and one explicit authority model. It separates facts that Work Management may change from evidence observed from GitHub, repository change governance, verification, and derived delivery state.
 
-The specification is generated from seven prescriptive MRDs harvested from the pinned `kis-mcp` implementation contracts. Live GitHub Project evidence that could not be observed remains explicitly unavailable rather than inferred.
+A GitHub Project provides the shared provider surface, but it does not become the owner of every fact displayed there. Repository change governance remains authoritative for governed change identity, complexity, and risk; GitHub remains authoritative for provider-native source identity and dependency observations; verification systems own their evidence; and Work Management owns its command fields.
+
+The captured live GitHub Project evidence is observed. Inventory is complete, and the configured Project schema is ready with no reported field, option, type, or view drift.
+
+## Key concepts
+
+- **Command data** is changed through Work Management operations, such as status, priority, effort, claims, holds, and deferrals.
+- **Evidence data** is observed or projected from its owning source, such as GitHub source identity, repository change facts, verification, and delivery state.
+- **Handoff data** begins as Work Management planning data and becomes repository-owned evidence when a governed change takes authority for it.
+- **Generated documentation** explains and indexes the governed model. It never writes facts back to Work Management or its sources.
+
+## How work moves
+
+1. Capture work and classify it before it enters the executable queue.
+2. Admit work to Ready only after the required source sections, Project fields, and dependency evidence are present.
+3. Select Ready work deterministically, then establish an execution claim before activation.
+4. Track repository delivery and source verification as evidence without replacing the Work lifecycle state.
+5. After merge, reconcile any required documentation and live-verification obligations before the configured completion gates allow Done.
 
 ## Detailed specification
 
@@ -25,4 +42,4 @@ The specification is generated from seven prescriptive MRDs harvested from the p
 
 ## Traceability
 
-See the [documentation index](000-index.md) and [build manifest](manifest.json) for source identities and hashes.
+See the [documentation index](000-index.md) and [build manifest](manifest.json) for exact source identities, MRD versions, hashes, and generated-file declarations.

--- a/generated/work-management-spec/002-work-management-domain-model.md
+++ b/generated/work-management-spec/002-work-management-domain-model.md
@@ -5,1256 +5,241 @@
 
 [Specification](001-specification.md) | [Documentation index](000-index.md)
 
-Define canonical Work Management entities, fields, vocabularies, and authority directions.
-
-## Fields
-
-### Status
-
-**Applicable record types:** *
-
-**Authority:** work_management
-
-**Definition:** Operational Work lifecycle status.
-
-**Direction:** command
-
-**Id:** status
-
-**Managed:** Yes
-
-**Population:** Set by explicit Work lifecycle operations.
-
-**Provider type:** single_select
-
-**Required contexts:** None
-
-**Vocabulary:** status
-
-### Record Type
-
-**Applicable record types:** *
-
-**Authority:** work_management
-
-**Definition:** Purpose classification of the Work record.
-
-**Direction:** command
-
-**Id:** record_type
-
-**Managed:** Yes
-
-**Population:** Set during intake/triage and changed only by explicit Work authority.
-
-**Provider type:** single_select
-
-**Required contexts:** ready_metadata
-
-**Vocabulary:** record_type
-
-### Priority
-
-**Applicable record types:** *
-
-**Authority:** work_management
-
-**Definition:** Relative scheduling importance.
-
-**Direction:** command
-
-**Id:** priority
-
-**Managed:** Yes
-
-**Population:** Set by Work Management and consumed by selection ranking.
-
-**Provider type:** single_select
-
-**Required contexts:** ready_metadata
-
-**Vocabulary:** priority
-
-### Effort
-
-**Applicable record types:** *
-
-**Authority:** work_management
-
-**Definition:** Relative implementation or coordination effort.
-
-**Direction:** command
-
-**Id:** effort
-
-**Managed:** Yes
-
-**Population:** Set by Work Management and consumed by selection ranking.
-
-**Provider type:** single_select
-
-**Required contexts:** ready_metadata
-
-**Vocabulary:** effort
-
-### Delivery Stage
-
-**Applicable record types:** *
-
-**Authority:** derived
-
-**Definition:** Evidence-derived governed delivery stage.
-
-**Direction:** evidence
-
-**Id:** delivery_stage
-
-**Managed:** Yes
-
-**Population:** Projected from repository/GitHub delivery evidence.
-
-**Provider type:** single_select
-
-**Required contexts:** None
-
-**Vocabulary:** delivery_stage
-
-### Execution Owner
-
-**Applicable record types:** *
-
-**Authority:** work_management
-
-**Definition:** Stable identity of the current execution claimant.
-
-**Direction:** command
-
-**Id:** execution_owner
-
-**Managed:** Yes
-
-**Population:** Set and cleared only by claim/release lifecycle operations.
-
-**Provider type:** text
-
-**Required contexts:** active_claim
-
-**Vocabulary:** None
-
-### Blocked By
-
-**Applicable record types:** *
-
-**Authority:** github
-
-**Definition:** Provider-observed dependency or blocker reference; explicit empty differs from unavailable evidence.
-
-**Direction:** evidence
-
-**Id:** blocked_by
-
-**Managed:** Yes
-
-**Population:** Read from GitHub Project dependency evidence.
-
-**Provider type:** text
-
-**Required contexts:** None
-
-**Vocabulary:** None
-
-### Documentation Impact
-
-**Applicable record types:** *
-
-**Authority:** work_management_then_repository_change
-
-**Definition:** Expected or completed documentation impact for the work/change.
-
-**Direction:** handoff
-
-**Id:** documentation_impact
-
-**Managed:** Yes
-
-**Population:** Starts as Work command data and becomes governed change evidence.
-
-**Provider type:** single_select
-
-**Required contexts:** ready_metadata
-
-**Vocabulary:** documentation_impact
-
-### Complexity
-
-**Applicable record types:** *
-
-**Authority:** repository_change
-
-**Definition:** Repository change-governance complexity projected into Work.
-
-**Direction:** evidence
-
-**Id:** complexity
-
-**Managed:** Yes
-
-**Population:** Projected from authoritative schema-v4 governed change scope.
-
-**Provider type:** single_select
-
-**Required contexts:** None
-
-**Vocabulary:** complexity
-
-### Risk Triggers
-
-**Applicable record types:** *
-
-**Authority:** repository_change
-
-**Definition:** Comma-separated repository change-governance risk-trigger tokens.
-
-**Direction:** evidence
-
-**Id:** risk_triggers
-
-**Managed:** Yes
-
-**Population:** Projected from authoritative governed change scope.
-
-**Provider type:** text
-
-**Required contexts:** None
-
-**Vocabulary:** None
-
-### Project ID
-
-**Applicable record types:** *
-
-**Authority:** derived
-
-**Definition:** Stable KIS project registry identity for the work item.
-
-**Direction:** evidence
-
-**Id:** project_id
-
-**Managed:** Yes
-
-**Population:** Derived from the registered repository-to-project mapping.
-
-**Provider type:** text
-
-**Required contexts:** None
-
-**Vocabulary:** None
-
-### Repository
-
-**Applicable record types:** *
-
-**Authority:** github
-
-**Definition:** GitHub repository identity of the source item.
-
-**Direction:** evidence
-
-**Id:** repository
-
-**Managed:** Yes
-
-**Population:** Read from the GitHub source item/provider binding.
-
-**Provider type:** repository
-
-**Required contexts:** None
-
-**Vocabulary:** None
-
-### Module
-
-**Applicable record types:** *
-
-**Authority:** work_management_then_repository_change
-
-**Definition:** Optional bounded module or subsystem context for the work.
-
-**Direction:** handoff
-
-**Id:** module
-
-**Managed:** Yes
-
-**Population:** Set by Work and handed to governed change planning when applicable.
-
-**Provider type:** text
-
-**Required contexts:** None
-
-**Vocabulary:** None
-
-### Change ID
-
-**Applicable record types:** *
-
-**Authority:** repository_change
-
-**Definition:** Canonical governed repository change ID once one exists.
-
-**Direction:** evidence
-
-**Id:** change_id
-
-**Managed:** Yes
-
-**Population:** Projected from authoritative local change scope.
-
-**Provider type:** text
-
-**Required contexts:** governed_change
-
-**Vocabulary:** None
-
-### Origin
-
-**Applicable record types:** *
-
-**Authority:** work_management
-
-**Definition:** Context that originated the record.
-
-**Direction:** command
-
-**Id:** origin
-
-**Managed:** Yes
-
-**Population:** Set when the Work record is created or classified.
-
-**Provider type:** single_select
-
-**Required contexts:** None
-
-**Vocabulary:** origin
-
-### Disposition
-
-**Applicable record types:** *
-
-**Authority:** work_management
-
-**Definition:** Explicit decision disposition for records that use disposition semantics.
-
-**Direction:** command
-
-**Id:** disposition
-
-**Managed:** Yes
-
-**Population:** Set by explicit Work decision/review operations.
-
-**Provider type:** single_select
-
-**Required contexts:** None
-
-**Vocabulary:** disposition
-
-### Verification
-
-**Applicable record types:** *
-
-**Authority:** actions
-
-**Definition:** Repository/source verification state; never live-runtime commissioning state.
-
-**Direction:** evidence
-
-**Id:** verification
-
-**Managed:** Yes
-
-**Population:** Projected from provider-native or governed verification evidence.
-
-**Provider type:** single_select
-
-**Required contexts:** None
-
-**Vocabulary:** verification
-
-### Severity
-
-**Applicable record types:** finding, security_finding, risk
-
-**Authority:** work_management
-
-**Definition:** Relative material impact for finding/risk records.
-
-**Direction:** command
-
-**Id:** severity
-
-**Managed:** Yes
-
-**Population:** Set when a finding or risk is classified.
-
-**Provider type:** single_select
-
-**Required contexts:** finding_or_risk
-
-**Vocabulary:** severity
-
-### Confidence
-
-**Applicable record types:** finding, security_finding, assumption
-
-**Authority:** work_management
-
-**Definition:** Evidence confidence for finding/assumption records.
-
-**Direction:** command
-
-**Id:** confidence
-
-**Managed:** Yes
-
-**Population:** Set from the evidence quality supporting the record.
-
-**Provider type:** single_select
-
-**Required contexts:** finding_or_assumption
-
-**Vocabulary:** confidence
-
-### Review Trigger
-
-**Applicable record types:** *
-
-**Authority:** work_management
-
-**Definition:** Condition or date/event trigger for reconsidering paused work.
-
-**Direction:** command
-
-**Id:** review_trigger
-
-**Managed:** Yes
-
-**Population:** Required when work enters On Hold or Deferred.
-
-**Provider type:** text
-
-**Required contexts:** hold_or_defer
-
-**Vocabulary:** None
-
-### Target Date
-
-**Applicable record types:** *
-
-**Authority:** work_management
-
-**Definition:** Optional target date for planned work or reconsideration.
-
-**Direction:** command
-
-**Id:** target_date
-
-**Managed:** Yes
-
-**Population:** Set explicitly by Work Management.
-
-**Provider type:** date
-
-**Required contexts:** None
-
-**Vocabulary:** None
-
-### Iteration
-
-**Applicable record types:** *
-
-**Authority:** work_management
-
-**Definition:** Optional provider iteration assignment.
-
-**Direction:** command
-
-**Id:** iteration
-
-**Managed:** Yes
-
-**Population:** Set explicitly by Work Management.
-
-**Provider type:** iteration
-
-**Required contexts:** None
-
-**Vocabulary:** None
-
-### Source Review
-
-**Applicable record types:** *
-
-**Authority:** work_management
-
-**Definition:** Reference to the review source that produced or governs the record.
-
-**Direction:** command
-
-**Id:** source_review
-
-**Managed:** Yes
-
-**Population:** Set when review-derived records are captured.
-
-**Provider type:** text
-
-**Required contexts:** None
-
-**Vocabulary:** None
-
-### Authority Revision
-
-**Applicable record types:** *
-
-**Authority:** git
-
-**Definition:** Revision identity of the authority evidence used for the Work record.
-
-**Direction:** evidence
-
-**Id:** authority_revision
-
-**Managed:** Yes
-
-**Population:** Projected from Git/provider revision evidence.
-
-**Provider type:** text
-
-**Required contexts:** None
-
-**Vocabulary:** None
-
-### External Link
-
-**Applicable record types:** *
-
-**Authority:** work_management
-
-**Definition:** Optional bounded external reference associated with the work.
-
-**Direction:** command
-
-**Id:** external_link
-
-**Managed:** Yes
-
-**Population:** Set explicitly by Work Management.
-
-**Provider type:** text
-
-**Required contexts:** None
-
-**Vocabulary:** None
-
-### Created
-
-**Applicable record types:** *
-
-**Authority:** github
-
-**Definition:** Provider-native creation timestamp used as deterministic age evidence.
-
-**Direction:** evidence
-
-**Id:** created
-
-**Managed:** No
-
-**Population:** Read from GitHub native item metadata.
-
-**Provider type:** native_datetime
-
-**Required contexts:** None
-
-**Vocabulary:** None
-
-### Live Verification
-
-**Applicable record types:** *
-
-**Authority:** derived
-
-**Definition:** Post-merge live runtime verification state, distinct from source Verification.
-
-**Direction:** evidence
-
-**Id:** live_verification
-
-**Managed:** Yes
-
-**Population:** Projected by the deterministic commissioning lifecycle under #419.
-
-**Provider type:** single_select
-
-**Required contexts:** None
-
-**Vocabulary:** live_verification
-
-### Commissioning Key
-
-**Applicable record types:** *
-
-**Authority:** derived
-
-**Definition:** Deterministic commissioning identity: the exact obligation key for one required surface, or the deterministic set key for a source merge with multiple required surfaces.
-
-**Direction:** evidence
-
-**Id:** commissioning_key
-
-**Managed:** Yes
-
-**Population:** Derived by the commissioning classifier/runner under #419; source projection uses a set-<digest24> key when multiple obligations must be aggregated.
-
-**Provider type:** text
-
-**Required contexts:** None
-
-**Vocabulary:** None
-
-### Live Verification Evidence
-
-**Applicable record types:** *
-
-**Authority:** derived
-
-**Definition:** Compact reference to durable live-verification evidence or linked commissioning work; never free-form logs.
-
-**Direction:** evidence
-
-**Id:** live_verification_evidence
-
-**Managed:** Yes
-
-**Population:** Projected from commissioning evidence under #419.
-
-**Provider type:** text
-
-**Required contexts:** None
-
-**Vocabulary:** None
-
-## Rules
-
-Every managed field has one authority and one direction., Project-native evidence is observed, not redefined by generated documentation.
-
-## Vocabularies
-
-### status
-
-**Definition:** Operational Work lifecycle status projected to GitHub Project Status.
-
-**Id:** status
-
-#### Values
-
-##### Inbox
-
-**Definition:** Captured work not yet triaged.
-
-**Token:** inbox
-
-##### Triage
-
-**Definition:** Work being classified and prepared for a disposition.
-
-**Token:** triage
-
-##### Proposed
-
-**Definition:** Work proposed for acceptance but not yet approved.
-
-**Token:** proposed
-
-##### Approved
-
-**Definition:** Accepted work that is not yet admitted to the executable queue.
-
-**Token:** approved
-
-##### Ready
-
-**Definition:** Work admitted for deterministic next-work eligibility subject to readiness, claim, and dependency guards.
-
-**Token:** ready
-
-##### Active
-
-**Definition:** Work currently claimed for execution.
-
-**Token:** active
-
-##### Blocked
-
-**Definition:** Work that cannot proceed because a blocking condition is present.
-
-**Token:** blocked
-
-##### On Hold
-
-**Definition:** Work intentionally paused pending a declared review trigger.
-
-**Token:** on_hold
-
-##### Deferred
-
-**Definition:** Work postponed for later reconsideration with a declared review trigger.
-
-**Token:** deferred
-
-##### Rejected
-
-**Definition:** Work explicitly not accepted for execution in its current form.
-
-**Token:** rejected
-
-##### Superseded
-
-**Definition:** Work replaced by a newer authoritative record or outcome.
-
-**Token:** superseded
-
-##### Done
-
-**Definition:** Work whose required completion and closeout gates are satisfied.
-
-**Token:** done
-
-### record type
-
-**Definition:** Classification of the purpose of a Work record.
-
-**Id:** record_type
-
-#### Values
-
-##### Idea
-
-**Definition:** Uncommitted candidate work requiring triage before it becomes actionable.
-
-**Token:** idea
-
-##### Task
-
-**Definition:** A bounded actionable unit of work.
-
-**Token:** task
-
-##### Specification Slice
-
-**Definition:** A bounded specification or delivery slice tracked as work.
-
-**Token:** specification_slice
-
-##### Review Run
-
-**Definition:** A record representing one review execution and its evidence.
-
-**Token:** review_run
-
-##### Finding
-
-**Definition:** An actionable observation produced by review, verification, audit, or commissioning.
-
-**Token:** finding
-
-##### Decision
-
-**Definition:** A record of an explicit authoritative choice.
-
-**Token:** decision
-
-##### Assumption
-
-**Definition:** A proposition tracked because later evidence may validate or invalidate it.
-
-**Token:** assumption
-
-##### Risk
-
-**Definition:** A potential adverse condition tracked for mitigation or disposition.
-
-**Token:** risk
-
-##### Approval
-
-**Definition:** A record of an explicit approval decision.
-
-**Token:** approval
-
-##### Hold
-
-**Definition:** A record whose purpose is to track a pause or hold condition.
-
-**Token:** hold
-
-##### Research
-
-**Definition:** A bounded investigation intended to produce evidence or a decision.
-
-**Token:** research
-
-##### Defect
-
-**Definition:** A known incorrect or broken product or system behavior requiring correction.
-
-**Token:** defect
-
-##### Security Finding
-
-**Definition:** A finding whose material impact is security-related.
-
-**Token:** security_finding
-
-### priority
-
-**Definition:** Relative scheduling importance used by the current deterministic Work queue.
-
-**Id:** priority
-
-#### Values
-
-##### Critical
-
-**Definition:** Highest configured scheduling importance.
-
-**Token:** critical
-
-##### High
-
-**Definition:** High scheduling importance below Critical.
-
-**Token:** high
-
-##### Medium
-
-**Definition:** Normal scheduling importance below High.
-
-**Token:** medium
-
-##### Low
-
-**Definition:** Lowest configured scheduling importance.
-
-**Token:** low
-
-### effort
-
-**Definition:** Relative implementation or coordination size used by the current deterministic Work queue.
-
-**Id:** effort
-
-#### Values
-
-##### Tiny
-
-**Definition:** Smallest configured relative effort.
-
-**Token:** tiny
-
-##### Small
-
-**Definition:** Small relative effort.
-
-**Token:** small
-
-##### Medium
-
-**Definition:** Moderate relative effort.
-
-**Token:** medium
-
-##### Large
-
-**Definition:** Largest configured relative effort.
-
-**Token:** large
-
-### delivery stage
-
-**Definition:** Evidence-derived stage of governed repository delivery.
-
-**Id:** delivery_stage
-
-#### Values
-
-##### None
-
-**Definition:** No governed delivery stage has been established.
-
-**Token:** none
-
-##### Change Created
-
-**Definition:** A governed repository change has been created.
-
-**Token:** change_created
-
-##### Implementing
-
-**Definition:** Implementation is in progress.
-
-**Token:** implementing
-
-##### PR Open
-
-**Definition:** A pull request is open for the governed change.
-
-**Token:** pr_open
-
-##### Review
-
-**Definition:** The governed change is in review.
-
-**Token:** review
-
-##### CI Pending
-
-**Definition:** Provider-native verification is pending.
-
-**Token:** ci_pending
-
-##### CI Failed
-
-**Definition:** Provider-native verification failed.
-
-**Token:** ci_failed
-
-##### CI Passed
-
-**Definition:** Provider-native verification passed for the applicable head.
-
-**Token:** ci_passed
-
-##### Merged
-
-**Definition:** The governed change has been observed merged.
-
-**Token:** merged
-
-##### Documentation
-
-**Definition:** Post-merge documentation reconciliation is due or in progress.
-
-**Token:** documentation
-
-##### Commissioning
-
-**Definition:** Live verification or commissioning is pending or in progress.
-
-**Token:** commissioning
-
-##### Complete
-
-**Definition:** Delivery and required closeout evidence are complete.
-
-**Token:** complete
-
-### documentation impact
-
-**Definition:** Repository documentation impact projected from Work to governed change and back as evidence.
-
-**Id:** documentation_impact
-
-#### Values
-
-##### Not Assessed
-
-**Definition:** Documentation impact has not yet been assessed.
-
-**Token:** not_assessed
-
-##### None
-
-**Definition:** No documentation change is required, with rationale recorded where required.
-
-**Token:** none
-
-##### Planned
-
-**Definition:** Documentation changes are planned.
-
-**Token:** planned
-
-##### In Progress
-
-**Definition:** Documentation changes are being implemented.
-
-**Token:** in_progress
-
-##### Pre-merge Complete
-
-**Definition:** Required pre-merge documentation work is complete.
-
-**Token:** pre_merge_complete
-
-##### Post-merge Complete
-
-**Definition:** Required post-merge documentation reconciliation is complete.
-
-**Token:** post_merge_complete
-
-### complexity
-
-**Definition:** Projection of repository change-governance complexity; detailed classification criteria remain owned by change-governance settings.
-
-**Id:** complexity
-
-#### Values
-
-##### Small
-
-**Definition:** Repository change-governance Small classification.
-
-**Token:** small
-
-##### Medium
-
-**Definition:** Repository change-governance Medium classification.
-
-**Token:** medium
-
-##### Large
-
-**Definition:** Repository change-governance Large classification.
-
-**Token:** large
-
-### origin
-
-**Definition:** Source context that caused a Work record to be created.
-
-**Id:** origin
-
-#### Values
-
-##### Operator
-
-**Definition:** Created directly from operator intent.
-
-**Token:** operator
-
-##### Review
-
-**Definition:** Created from review evidence.
-
-**Token:** review
-
-##### Verification
-
-**Definition:** Created from verification evidence.
-
-**Token:** verification
-
-##### Implementation
-
-**Definition:** Created from implementation activity or discovery.
-
-**Token:** implementation
-
-##### Research
-
-**Definition:** Created from research activity or evidence.
-
-**Token:** research
-
-### disposition
-
-**Definition:** Current decision disposition for records that require an explicit disposition.
-
-**Id:** disposition
-
-#### Values
-
-##### Open
-
-**Definition:** No terminal disposition has been selected.
-
-**Token:** open
-
-##### Accepted
-
-**Definition:** The record or proposition is accepted.
-
-**Token:** accepted
-
-##### Rejected
-
-**Definition:** The record or proposition is rejected.
-
-**Token:** rejected
-
-##### Superseded
-
-**Definition:** A newer authoritative record replaces this one.
-
-**Token:** superseded
-
-##### Mitigated
-
-**Definition:** The tracked risk or finding has been mitigated.
-
-**Token:** mitigated
-
-##### Deferred
-
-**Definition:** Disposition is intentionally postponed.
-
-**Token:** deferred
-
-### verification
-
-**Definition:** Repository/source verification state; it does not represent post-merge live runtime proof.
-
-**Id:** verification
-
-#### Values
-
-##### Not Run
-
-**Definition:** Repository/source verification has not run.
-
-**Token:** not_run
-
-##### Pending
-
-**Definition:** Repository/source verification is pending or running.
-
-**Token:** pending
-
-##### Passed
-
-**Definition:** Repository/source verification passed for the applicable evidence identity.
-
-**Token:** passed
-
-##### Failed
-
-**Definition:** Repository/source verification failed.
-
-**Token:** failed
-
-##### Blocked
-
-**Definition:** Repository/source verification cannot currently complete.
-
-**Token:** blocked
-
-### severity
-
-**Definition:** Relative material impact of a finding or risk.
-
-**Id:** severity
-
-#### Values
-
-##### Critical
-
-**Definition:** Highest material impact requiring urgent attention.
-
-**Token:** critical
-
-##### High
-
-**Definition:** High material impact.
-
-**Token:** high
-
-##### Medium
-
-**Definition:** Moderate material impact.
-
-**Token:** medium
-
-##### Low
-
-**Definition:** Limited material impact.
-
-**Token:** low
-
-### confidence
-
-**Definition:** Relative confidence classification for finding and assumption evidence; current Work authority does not define quantitative or qualitative thresholds.
-
-**Id:** confidence
-
-#### Values
-
-##### High
-
-**Definition:** Highest configured confidence label; no additional threshold is defined by current Work authority.
-
-**Token:** high
-
-##### Medium
-
-**Definition:** Middle configured confidence label; no additional threshold is defined by current Work authority.
-
-**Token:** medium
-
-##### Low
-
-**Definition:** Lowest configured confidence label; no additional threshold is defined by current Work authority.
-
-**Token:** low
-
-### live verification
-
-**Definition:** Post-merge live runtime verification state, distinct from repository/source Verification.
-
-**Id:** live_verification
-
-#### Values
-
-##### Not Assessed
-
-**Definition:** The need for live verification has not yet been classified.
-
-**Token:** not_assessed
-
-##### Not Required
-
-**Definition:** Deterministic classification found no live verification obligation.
-
-**Token:** not_required
-
-##### Pending
-
-**Definition:** Live verification is required and has not yet completed.
-
-**Token:** pending
-
-##### Passed
-
-**Definition:** Required live verification passed against the actual exposed capability or runtime path.
-
-**Token:** passed
-
-##### Failed
-
-**Definition:** Required live verification ran and failed its expected invariant.
-
-**Token:** failed
-
-##### Blocked
-
-**Definition:** Required live verification cannot currently complete.
-
-**Token:** blocked
+Work Management defines the fields and controlled vocabularies used to describe a work record. The model keeps command data separate from observed evidence so that a generated view cannot silently become a second source of truth.
+
+## Field model
+
+Work Management uses three authority directions. **Command** fields are changed through Work Management. **Evidence** fields are observed or projected from their owning source. **Handoff** fields start in Work Management and later become governed repository-change facts.
+
+### Command fields
+
+| Field | Meaning | Authority | Direction | Details |
+|---|---|---|---|---|
+| Status | Operational Work lifecycle status. Set by explicit Work lifecycle operations. | `work_management` | `command` | ID `status`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `status` |
+| Record Type | Purpose classification of the Work record. Set during intake/triage and changed only by explicit Work authority. | `work_management` | `command` | ID `record_type`; provider `single_select`; KIS-managed; applies to all record types; required for `ready_metadata`; vocabulary `record_type` |
+| Priority | Relative scheduling importance. Set by Work Management and consumed by selection ranking. | `work_management` | `command` | ID `priority`; provider `single_select`; KIS-managed; applies to all record types; required for `ready_metadata`; vocabulary `priority` |
+| Effort | Relative implementation or coordination effort. Set by Work Management and consumed by selection ranking. | `work_management` | `command` | ID `effort`; provider `single_select`; KIS-managed; applies to all record types; required for `ready_metadata`; vocabulary `effort` |
+| Execution Owner | Stable identity of the current execution claimant. Set and cleared only by claim/release lifecycle operations. | `work_management` | `command` | ID `execution_owner`; provider `text`; KIS-managed; applies to all record types; required for `active_claim` |
+| Origin | Context that originated the record. Set when the Work record is created or classified. | `work_management` | `command` | ID `origin`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `origin` |
+| Disposition | Explicit decision disposition for records that use disposition semantics. Set by explicit Work decision/review operations. | `work_management` | `command` | ID `disposition`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `disposition` |
+| Severity | Relative material impact for finding/risk records. Set when a finding or risk is classified. | `work_management` | `command` | ID `severity`; provider `single_select`; KIS-managed; applies to finding, security_finding, risk; required for `finding_or_risk`; vocabulary `severity` |
+| Confidence | Evidence confidence for finding/assumption records. Set from the evidence quality supporting the record. | `work_management` | `command` | ID `confidence`; provider `single_select`; KIS-managed; applies to finding, security_finding, assumption; required for `finding_or_assumption`; vocabulary `confidence` |
+| Review Trigger | Condition or date/event trigger for reconsidering paused work. Required when work enters On Hold or Deferred. | `work_management` | `command` | ID `review_trigger`; provider `text`; KIS-managed; applies to all record types; required for `hold_or_defer` |
+| Target Date | Optional target date for planned work or reconsideration. Set explicitly by Work Management. | `work_management` | `command` | ID `target_date`; provider `date`; KIS-managed; applies to all record types |
+| Iteration | Optional provider iteration assignment. Set explicitly by Work Management. | `work_management` | `command` | ID `iteration`; provider `iteration`; KIS-managed; applies to all record types |
+| Source Review | Reference to the review source that produced or governs the record. Set when review-derived records are captured. | `work_management` | `command` | ID `source_review`; provider `text`; KIS-managed; applies to all record types |
+| External Link | Optional bounded external reference associated with the work. Set explicitly by Work Management. | `work_management` | `command` | ID `external_link`; provider `text`; KIS-managed; applies to all record types |
+
+### Evidence fields
+
+| Field | Meaning | Authority | Direction | Details |
+|---|---|---|---|---|
+| Delivery Stage | Evidence-derived governed delivery stage. Projected from repository/GitHub delivery evidence. | `derived` | `evidence` | ID `delivery_stage`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `delivery_stage` |
+| Blocked By | Provider-observed dependency or blocker reference; explicit empty differs from unavailable evidence. Read from GitHub Project dependency evidence. | `github` | `evidence` | ID `blocked_by`; provider `text`; KIS-managed; applies to all record types |
+| Complexity | Repository change-governance complexity projected into Work. Projected from authoritative schema-v4 governed change scope. | `repository_change` | `evidence` | ID `complexity`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `complexity` |
+| Risk Triggers | Comma-separated repository change-governance risk-trigger tokens. Projected from authoritative governed change scope. | `repository_change` | `evidence` | ID `risk_triggers`; provider `text`; KIS-managed; applies to all record types |
+| Project ID | Stable KIS project registry identity for the work item. Derived from the registered repository-to-project mapping. | `derived` | `evidence` | ID `project_id`; provider `text`; KIS-managed; applies to all record types |
+| Repository | GitHub repository identity of the source item. Read from the GitHub source item/provider binding. | `github` | `evidence` | ID `repository`; provider `repository`; KIS-managed; applies to all record types |
+| Change ID | Canonical governed repository change ID once one exists. Projected from authoritative local change scope. | `repository_change` | `evidence` | ID `change_id`; provider `text`; KIS-managed; applies to all record types; required for `governed_change` |
+| Verification | Repository/source verification state; never live-runtime commissioning state. Projected from provider-native or governed verification evidence. | `actions` | `evidence` | ID `verification`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `verification` |
+| Authority Revision | Revision identity of the authority evidence used for the Work record. Projected from Git/provider revision evidence. | `git` | `evidence` | ID `authority_revision`; provider `text`; KIS-managed; applies to all record types |
+| Created | Provider-native creation timestamp used as deterministic age evidence. Read from GitHub native item metadata. | `github` | `evidence` | ID `created`; provider `native_datetime`; provider-managed; applies to all record types |
+| Live Verification | Post-merge live runtime verification state, distinct from source Verification. Projected by the deterministic commissioning lifecycle under #419. | `derived` | `evidence` | ID `live_verification`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `live_verification` |
+| Commissioning Key | Deterministic commissioning identity: the exact obligation key for one required surface, or the deterministic set key for a source merge with multiple required surfaces. Derived by the commissioning classifier/runner under #419; source projection uses a set-<digest24> key when multiple obligations must be aggregated. | `derived` | `evidence` | ID `commissioning_key`; provider `text`; KIS-managed; applies to all record types |
+| Live Verification Evidence | Compact reference to durable live-verification evidence or linked commissioning work; never free-form logs. Projected from commissioning evidence under #419. | `derived` | `evidence` | ID `live_verification_evidence`; provider `text`; KIS-managed; applies to all record types |
+
+### Handoff fields
+
+| Field | Meaning | Authority | Direction | Details |
+|---|---|---|---|---|
+| Documentation Impact | Expected or completed documentation impact for the work/change. Starts as Work command data and becomes governed change evidence. | `work_management_then_repository_change` | `handoff` | ID `documentation_impact`; provider `single_select`; KIS-managed; applies to all record types; required for `ready_metadata`; vocabulary `documentation_impact` |
+| Module | Optional bounded module or subsystem context for the work. Set by Work and handed to governed change planning when applicable. | `work_management_then_repository_change` | `handoff` | ID `module`; provider `text`; KIS-managed; applies to all record types |
+
+## Authority rules
+
+These rules prevent field ownership from drifting between Work Management, repository change governance, GitHub, Actions, and generated documentation:
+
+- Every managed field has one authority and one direction.
+- Project-native evidence is observed, not redefined by generated documentation.
+
+## Controlled vocabularies
+
+Single-select fields use the following governed values. The display label is what readers see; the token is the stable machine value.
+
+### Status values
+
+Operational Work lifecycle status projected to GitHub Project Status.
+
+| Value | Token | Meaning |
+|---|---|---|
+| Inbox | `inbox` | Captured work not yet triaged. |
+| Triage | `triage` | Work being classified and prepared for a disposition. |
+| Proposed | `proposed` | Work proposed for acceptance but not yet approved. |
+| Approved | `approved` | Accepted work that is not yet admitted to the executable queue. |
+| Ready | `ready` | Work admitted for deterministic next-work eligibility subject to readiness, claim, and dependency guards. |
+| Active | `active` | Work currently claimed for execution. |
+| Blocked | `blocked` | Work that cannot proceed because a blocking condition is present. |
+| On Hold | `on_hold` | Work intentionally paused pending a declared review trigger. |
+| Deferred | `deferred` | Work postponed for later reconsideration with a declared review trigger. |
+| Rejected | `rejected` | Work explicitly not accepted for execution in its current form. |
+| Superseded | `superseded` | Work replaced by a newer authoritative record or outcome. |
+| Done | `done` | Work whose required completion and closeout gates are satisfied. |
+
+### Record type values
+
+Classification of the purpose of a Work record.
+
+| Value | Token | Meaning |
+|---|---|---|
+| Idea | `idea` | Uncommitted candidate work requiring triage before it becomes actionable. |
+| Task | `task` | A bounded actionable unit of work. |
+| Specification Slice | `specification_slice` | A bounded specification or delivery slice tracked as work. |
+| Review Run | `review_run` | A record representing one review execution and its evidence. |
+| Finding | `finding` | An actionable observation produced by review, verification, audit, or commissioning. |
+| Decision | `decision` | A record of an explicit authoritative choice. |
+| Assumption | `assumption` | A proposition tracked because later evidence may validate or invalidate it. |
+| Risk | `risk` | A potential adverse condition tracked for mitigation or disposition. |
+| Approval | `approval` | A record of an explicit approval decision. |
+| Hold | `hold` | A record whose purpose is to track a pause or hold condition. |
+| Research | `research` | A bounded investigation intended to produce evidence or a decision. |
+| Defect | `defect` | A known incorrect or broken product or system behavior requiring correction. |
+| Security Finding | `security_finding` | A finding whose material impact is security-related. |
+
+### Priority values
+
+Relative scheduling importance used by the current deterministic Work queue.
+
+| Value | Token | Meaning |
+|---|---|---|
+| Critical | `critical` | Highest configured scheduling importance. |
+| High | `high` | High scheduling importance below Critical. |
+| Medium | `medium` | Normal scheduling importance below High. |
+| Low | `low` | Lowest configured scheduling importance. |
+
+### Effort values
+
+Relative implementation or coordination size used by the current deterministic Work queue.
+
+| Value | Token | Meaning |
+|---|---|---|
+| Tiny | `tiny` | Smallest configured relative effort. |
+| Small | `small` | Small relative effort. |
+| Medium | `medium` | Moderate relative effort. |
+| Large | `large` | Largest configured relative effort. |
+
+### Delivery stage values
+
+Evidence-derived stage of governed repository delivery.
+
+| Value | Token | Meaning |
+|---|---|---|
+| None | `none` | No governed delivery stage has been established. |
+| Change Created | `change_created` | A governed repository change has been created. |
+| Implementing | `implementing` | Implementation is in progress. |
+| PR Open | `pr_open` | A pull request is open for the governed change. |
+| Review | `review` | The governed change is in review. |
+| CI Pending | `ci_pending` | Provider-native verification is pending. |
+| CI Failed | `ci_failed` | Provider-native verification failed. |
+| CI Passed | `ci_passed` | Provider-native verification passed for the applicable head. |
+| Merged | `merged` | The governed change has been observed merged. |
+| Documentation | `documentation` | Post-merge documentation reconciliation is due or in progress. |
+| Commissioning | `commissioning` | Live verification or commissioning is pending or in progress. |
+| Complete | `complete` | Delivery and required closeout evidence are complete. |
+
+### Documentation impact values
+
+Repository documentation impact projected from Work to governed change and back as evidence.
+
+| Value | Token | Meaning |
+|---|---|---|
+| Not Assessed | `not_assessed` | Documentation impact has not yet been assessed. |
+| None | `none` | No documentation change is required, with rationale recorded where required. |
+| Planned | `planned` | Documentation changes are planned. |
+| In Progress | `in_progress` | Documentation changes are being implemented. |
+| Pre-merge Complete | `pre_merge_complete` | Required pre-merge documentation work is complete. |
+| Post-merge Complete | `post_merge_complete` | Required post-merge documentation reconciliation is complete. |
+
+### Complexity values
+
+Projection of repository change-governance complexity; detailed classification criteria remain owned by change-governance settings.
+
+| Value | Token | Meaning |
+|---|---|---|
+| Small | `small` | Repository change-governance Small classification. |
+| Medium | `medium` | Repository change-governance Medium classification. |
+| Large | `large` | Repository change-governance Large classification. |
+
+### Origin values
+
+Source context that caused a Work record to be created.
+
+| Value | Token | Meaning |
+|---|---|---|
+| Operator | `operator` | Created directly from operator intent. |
+| Review | `review` | Created from review evidence. |
+| Verification | `verification` | Created from verification evidence. |
+| Implementation | `implementation` | Created from implementation activity or discovery. |
+| Research | `research` | Created from research activity or evidence. |
+
+### Disposition values
+
+Current decision disposition for records that require an explicit disposition.
+
+| Value | Token | Meaning |
+|---|---|---|
+| Open | `open` | No terminal disposition has been selected. |
+| Accepted | `accepted` | The record or proposition is accepted. |
+| Rejected | `rejected` | The record or proposition is rejected. |
+| Superseded | `superseded` | A newer authoritative record replaces this one. |
+| Mitigated | `mitigated` | The tracked risk or finding has been mitigated. |
+| Deferred | `deferred` | Disposition is intentionally postponed. |
+
+### Verification values
+
+Repository/source verification state; it does not represent post-merge live runtime proof.
+
+| Value | Token | Meaning |
+|---|---|---|
+| Not Run | `not_run` | Repository/source verification has not run. |
+| Pending | `pending` | Repository/source verification is pending or running. |
+| Passed | `passed` | Repository/source verification passed for the applicable evidence identity. |
+| Failed | `failed` | Repository/source verification failed. |
+| Blocked | `blocked` | Repository/source verification cannot currently complete. |
+
+### Severity values
+
+Relative material impact of a finding or risk.
+
+| Value | Token | Meaning |
+|---|---|---|
+| Critical | `critical` | Highest material impact requiring urgent attention. |
+| High | `high` | High material impact. |
+| Medium | `medium` | Moderate material impact. |
+| Low | `low` | Limited material impact. |
+
+### Confidence values
+
+Relative confidence classification for finding and assumption evidence; current Work authority does not define quantitative or qualitative thresholds.
+
+| Value | Token | Meaning |
+|---|---|---|
+| High | `high` | Highest configured confidence label; no additional threshold is defined by current Work authority. |
+| Medium | `medium` | Middle configured confidence label; no additional threshold is defined by current Work authority. |
+| Low | `low` | Lowest configured confidence label; no additional threshold is defined by current Work authority. |
+
+### Live verification values
+
+Post-merge live runtime verification state, distinct from repository/source Verification.
+
+| Value | Token | Meaning |
+|---|---|---|
+| Not Assessed | `not_assessed` | The need for live verification has not yet been classified. |
+| Not Required | `not_required` | Deterministic classification found no live verification obligation. |
+| Pending | `pending` | Live verification is required and has not yet completed. |
+| Passed | `passed` | Required live verification passed against the actual exposed capability or runtime path. |
+| Failed | `failed` | Required live verification ran and failed its expected invariant. |
+| Blocked | `blocked` | Required live verification cannot currently complete. |
 
 ## Source and authority
 
-This page projects `KIS-WORK-SEM-REG-001` version `1.0.0`. The MRD is authoritative; this generated page has no write-back authority.
+This page projects `KIS-WORK-SEM-REG-001` version `1.0.0`. The MRD remains authoritative; this generated page has no write-back authority.

--- a/generated/work-management-spec/003-work-lifecycle.md
+++ b/generated/work-management-spec/003-work-lifecycle.md
@@ -5,322 +5,87 @@
 
 [Specification](001-specification.md) | [Documentation index](000-index.md)
 
-Define Work states, transitions, readiness, claims, delivery stages, completion gates, and guards.
-
-## Claim
-
-**Auto expiry:** No
-
-**Execution owner field:** Execution Owner
-
-## Completion
-
-**Require no active claim after close:** No
-
-**Terminal state:** done
-
-## Delivery
-
-**Change created stage:** change_created
-
-**Change id field:** Change ID
-
-**Complete stage:** complete
-
-**Complexity field:** Complexity
-
-**Risk triggers field:** Risk Triggers
-
-**Stage field:** Delivery Stage
-
-**Stages:** none, change_created, implementing, pr_open, review, ci_pending, ci_failed, ci_passed, merged, documentation, commissioning, complete
-
-## Guards
-
-### approval-before-active
-
-**Condition:** approval_required_and_incomplete
-
-**Definition:** Reject activation when the record requires approval and approval is incomplete.
-
-**Disposition:** reject
-
-**Id:** approval-before-active
-
-**Reason code:** approval_incomplete
-
-**Target:** active
-
-### completion-no-active-claim
-
-**Condition:** completion_requires_no_active_claim_and_claim_present
-
-**Definition:** When configured, reject completion while an execution claim remains.
-
-**Disposition:** reject
-
-**Id:** completion-no-active-claim
-
-**Reason code:** active_claim_present
-
-**Target:** done
-
-### completion-documentation-due
-
-**Condition:** required_documentation_reconciliation_due
-
-**Definition:** Required post-merge documentation reconciliation must be completed before Done.
-
-**Disposition:** reject
-
-**Id:** completion-documentation-due
-
-**Reason code:** documentation_reconciliation_due
-
-**Target:** done
-
-### completion-documentation-due-advisory
-
-**Condition:** advisory_documentation_reconciliation_due
-
-**Definition:** Advisory post-merge documentation reconciliation may complete with an explicit advisory reason.
-
-**Disposition:** allow_with_reason
-
-**Id:** completion-documentation-due-advisory
-
-**Reason code:** documentation_reconciliation_advisory_due
-
-**Target:** done
-
-### completion-documentation-unrecorded
-
-**Condition:** required_documentation_reconciliation_unrecorded
-
-**Definition:** Required post-merge documentation milestone must be recorded before Done.
-
-**Disposition:** reject
-
-**Id:** completion-documentation-unrecorded
-
-**Reason code:** documentation_reconciliation_unrecorded
-
-**Target:** done
-
-### completion-documentation-unrecorded-advisory
-
-**Condition:** advisory_documentation_reconciliation_unrecorded
-
-**Definition:** Advisory documentation reconciliation may complete without a recorded post-merge milestone, with an explicit advisory reason.
-
-**Disposition:** allow_with_reason
-
-**Id:** completion-documentation-unrecorded-advisory
-
-**Reason code:** documentation_reconciliation_advisory_incomplete
-
-**Target:** done
-
-### completion-documentation-incomplete
-
-**Condition:** required_documentation_incomplete
-
-**Definition:** Required documentation impact must be complete before Done.
-
-**Disposition:** reject
-
-**Id:** completion-documentation-incomplete
-
-**Reason code:** documentation_incomplete
-
-**Target:** done
-
-### completion-documentation-incomplete-advisory
-
-**Condition:** advisory_documentation_incomplete
-
-**Definition:** Advisory documentation may complete while incomplete, with an explicit advisory reason.
-
-**Disposition:** allow_with_reason
-
-**Id:** completion-documentation-incomplete-advisory
-
-**Reason code:** documentation_advisory_incomplete
-
-**Target:** done
-
-## Intake aliases
-
-**Todo:** inbox
-
-## Readiness
-
-**Required issue sections:** Outcome, Acceptance criteria
-
-**Required project fields:** Record Type, Priority, Effort, Documentation Impact
-
-**Requires dependencies understood:** Yes
-
-## States
-
-### Inbox
-
-**Definition:** Captured work not yet triaged.
-
-**Project status:** Yes
-
-**Token:** inbox
-
-### Triage
-
-**Definition:** Work being classified.
-
-**Project status:** Yes
-
-**Token:** triage
-
-### Proposed
-
-**Definition:** Work proposed for approval.
-
-**Project status:** Yes
-
-**Token:** proposed
-
-### Approved
-
-**Definition:** Accepted work not yet admitted to Ready.
-
-**Project status:** Yes
-
-**Token:** approved
-
-### Ready
-
-**Definition:** Executable queue state subject to readiness guards.
-
-**Project status:** Yes
-
-**Token:** ready
-
-### Active
-
-**Definition:** Claimed execution state.
-
-**Project status:** Yes
-
-**Token:** active
-
-### Review
-
-**Definition:** Internal delivery state for review activity.
-
-**Project status:** No
-
-**Token:** review
-
-### Verification
-
-**Definition:** Internal delivery state for verification activity.
-
-**Project status:** No
-
-**Token:** verification
-
-### Documentation
-
-**Definition:** Internal delivery state for documentation reconciliation.
-
-**Project status:** No
-
-**Token:** documentation
-
-### Blocked
-
-**Definition:** Execution cannot proceed because a blocker is present.
-
-**Project status:** Yes
-
-**Token:** blocked
-
-### On Hold
-
-**Definition:** Intentionally paused pending a review trigger.
-
-**Project status:** Yes
-
-**Token:** on_hold
-
-### Deferred
-
-**Definition:** Postponed for later reconsideration.
-
-**Project status:** Yes
-
-**Token:** deferred
-
-### Rejected
-
-**Definition:** Not accepted for execution in current form.
-
-**Project status:** Yes
-
-**Token:** rejected
-
-### Superseded
-
-**Definition:** Replaced by newer authoritative work.
-
-**Project status:** Yes
-
-**Token:** superseded
-
-### Done
-
-**Definition:** Required completion gates are satisfied.
-
-**Project status:** Yes
-
-**Token:** done
-
-## Transition requirements
-
-**Deferred:** Review Trigger
-
-**On hold:** Review Trigger
+A work item moves through explicit states. Project-visible states describe the shared work queue, while internal states such as Review, Verification, and Documentation describe delivery activity without creating new GitHub Project status values.
+
+## State model
+
+| State | Meaning | GitHub Project status | Token |
+|---|---|---|---|
+| Inbox | Captured work not yet triaged. | Yes | `inbox` |
+| Triage | Work being classified. | Yes | `triage` |
+| Proposed | Work proposed for approval. | Yes | `proposed` |
+| Approved | Accepted work not yet admitted to Ready. | Yes | `approved` |
+| Ready | Executable queue state subject to readiness guards. | Yes | `ready` |
+| Active | Claimed execution state. | Yes | `active` |
+| Review | Internal delivery state for review activity. | No | `review` |
+| Verification | Internal delivery state for verification activity. | No | `verification` |
+| Documentation | Internal delivery state for documentation reconciliation. | No | `documentation` |
+| Blocked | Execution cannot proceed because a blocker is present. | Yes | `blocked` |
+| On Hold | Intentionally paused pending a review trigger. | Yes | `on_hold` |
+| Deferred | Postponed for later reconsideration. | Yes | `deferred` |
+| Rejected | Not accepted for execution in current form. | Yes | `rejected` |
+| Superseded | Replaced by newer authoritative work. | Yes | `superseded` |
+| Done | Required completion gates are satisfied. | Yes | `done` |
 
 ## Transitions
 
-**Active:** ready, review, blocked, on_hold, deferred, done, superseded
+Transitions are explicit. A work item **MUST** move only to a destination listed for its current state. On Hold and Deferred also require a Review Trigger.
 
-**Approved:** ready, active, on_hold, deferred, superseded
+| From | Allowed next states | Additional requirement |
+|---|---|---|
+| Active | Ready, Review, Blocked, On Hold, Deferred, Done, Superseded | None |
+| Approved | Ready, Active, On Hold, Deferred, Superseded | None |
+| Blocked | Ready, Active, On Hold, Deferred, Superseded | None |
+| Deferred | Triage, Proposed, Approved, Rejected, Superseded | Review Trigger |
+| Documentation | Done, Active, Blocked, Superseded | None |
+| Done | No transitions | None |
+| Inbox | Triage, Deferred, Rejected, Superseded | None |
+| On Hold | Ready, Active, Deferred, Rejected, Superseded | Review Trigger |
+| Proposed | Approved, Deferred, Rejected, Superseded | None |
+| Ready | Active, On Hold, Deferred, Superseded | None |
+| Rejected | Triage, Superseded | None |
+| Review | Active, Verification, Blocked, On Hold, Superseded | None |
+| Superseded | No transitions | None |
+| Triage | Proposed, Approved, Deferred, Rejected, Superseded | None |
+| Verification | Active, Documentation, Blocked, Superseded | None |
 
-**Blocked:** ready, active, on_hold, deferred, superseded
+## Readiness and claims
 
-**Deferred:** triage, proposed, approved, rejected, superseded
+Before a work item can enter Ready, it **MUST** satisfy all configured readiness requirements:
 
-**Documentation:** done, active, blocked, superseded
+- The source issue contains **Outcome** and **Acceptance criteria**.
+- The Project record contains **Record Type**, **Priority**, **Effort**, and **Documentation Impact**.
+- Dependencies are understood.
 
-**Done:** None
+Execution claims use the **Execution Owner** field. Claims do not expire automatically.
 
-**Inbox:** triage, deferred, rejected, superseded
+At intake, the alias `todo` is normalized to `inbox`.
 
-**On hold:** ready, active, deferred, rejected, superseded
+## Delivery and completion
 
-**Proposed:** approved, deferred, rejected, superseded
+Delivery is tracked separately from the work state. The configured delivery-stage sequence is:
 
-**Ready:** active, on_hold, deferred, superseded
+`none`, `change_created`, `implementing`, `pr_open`, `review`, `ci_pending`, `ci_failed`, `ci_passed`, `merged`, `documentation`, `commissioning`, `complete`
 
-**Rejected:** triage, superseded
+The **Delivery Stage** field stores that stage. **Change ID**, **Complexity**, and **Risk Triggers** connect the work record to repository change governance. The sequence starts its governed change at `change_created` and reaches `complete` when delivery is complete.
 
-**Review:** active, verification, blocked, on_hold, superseded
+Completion targets `done`. The current configuration does not require the execution claim to be absent after close.
 
-**Superseded:** None
+## Completion and activation guards
 
-**Triage:** proposed, approved, deferred, rejected, superseded
+Guards reject or qualify transitions when required evidence is missing or inconsistent:
 
-**Verification:** active, documentation, blocked, superseded
+| Guard | Applies when | Rule | Result | Reason |
+|---|---|---|---|---|
+| `approval-before-active` | `approval_required_and_incomplete` | Reject activation when the record requires approval and approval is incomplete. | `reject` to `active` | `approval_incomplete` |
+| `completion-no-active-claim` | `completion_requires_no_active_claim_and_claim_present` | When configured, reject completion while an execution claim remains. | `reject` to `done` | `active_claim_present` |
+| `completion-documentation-due` | `required_documentation_reconciliation_due` | Required post-merge documentation reconciliation must be completed before Done. | `reject` to `done` | `documentation_reconciliation_due` |
+| `completion-documentation-due-advisory` | `advisory_documentation_reconciliation_due` | Advisory post-merge documentation reconciliation may complete with an explicit advisory reason. | `allow_with_reason` to `done` | `documentation_reconciliation_advisory_due` |
+| `completion-documentation-unrecorded` | `required_documentation_reconciliation_unrecorded` | Required post-merge documentation milestone must be recorded before Done. | `reject` to `done` | `documentation_reconciliation_unrecorded` |
+| `completion-documentation-unrecorded-advisory` | `advisory_documentation_reconciliation_unrecorded` | Advisory documentation reconciliation may complete without a recorded post-merge milestone, with an explicit advisory reason. | `allow_with_reason` to `done` | `documentation_reconciliation_advisory_incomplete` |
+| `completion-documentation-incomplete` | `required_documentation_incomplete` | Required documentation impact must be complete before Done. | `reject` to `done` | `documentation_incomplete` |
+| `completion-documentation-incomplete-advisory` | `advisory_documentation_incomplete` | Advisory documentation may complete while incomplete, with an explicit advisory reason. | `allow_with_reason` to `done` | `documentation_advisory_incomplete` |
 
 ## Source and authority
 
-This page projects `KIS-WORK-WRK-STM-001` version `1.0.0`. The MRD is authoritative; this generated page has no write-back authority.
+This page projects `KIS-WORK-WRK-STM-001` version `1.0.0`. The MRD remains authoritative; this generated page has no write-back authority.

--- a/generated/work-management-spec/004-work-operations.md
+++ b/generated/work-management-spec/004-work-operations.md
@@ -5,170 +5,62 @@
 
 [Specification](001-specification.md) | [Documentation index](000-index.md)
 
-Define the bounded Work Management operations and their implementation surfaces.
+Work Management exposes a bounded set of operations for intake, claiming, state changes, verification, and post-merge commissioning. Each operation has a defined effect and implementation surface so callers can distinguish reads from mutations and evidence collection.
 
-## Mutation rule
+## Mutation safety
 
-External Project mutations require apply=true and an explicit idempotency key.
+External Project mutations require `apply=true` and an explicit idempotency key.
 
 ## Operations
 
-### capture work
-
-**Definition:** Capture one bounded source record into Work without duplicating source identity.
-
-**Effect:** external_or_local_change
-
-**Id:** capture_work
-
-**Implementation surface:** project_management_reconcile
-
-### create work
-
-**Definition:** Create or reconcile one new Work record through the configured provider boundary.
-
-**Effect:** external_or_local_change
-
-**Id:** create_work
-
-**Implementation surface:** project_management_reconcile
-
-### take next work
-
-**Definition:** Select the next eligible Ready item and establish its execution claim.
-
-**Effect:** external_or_local_change
-
-**Id:** take_next_work
-
-**Implementation surface:** project_management_take_next_work
-
-### claim work
-
-**Definition:** Establish one execution owner after revision and state guards pass.
-
-**Effect:** external_or_local_change
-
-**Id:** claim_work
-
-**Implementation surface:** project_management_claim_work
-
-### release work
-
-**Definition:** Clear an execution claim through the bounded command plane.
-
-**Effect:** external_or_local_change
-
-**Id:** release_work
-
-**Implementation surface:** project_management_release_work
-
-### hold work
-
-**Definition:** Move work to On Hold only with the required review trigger.
-
-**Effect:** external_or_local_change
-
-**Id:** hold_work
-
-**Implementation surface:** project_management_hold_work
-
-### defer work
-
-**Definition:** Move work to Deferred only with the required review trigger.
-
-**Effect:** external_or_local_change
-
-**Id:** defer_work
-
-**Implementation surface:** project_management_defer_work
-
-### complete work
-
-**Definition:** Complete work only after configured completion and evidence guards pass.
-
-**Effect:** external_or_local_change
-
-**Id:** complete_work
-
-**Implementation surface:** project_management_complete_work
-
-### readiness
-
-**Definition:** Evaluate deterministic queue eligibility and readiness evidence.
-
-**Effect:** read_only
-
-**Id:** readiness
-
-**Implementation surface:** project_management_next_work
-
-### assignment packet
-
-**Definition:** Bind execution to a generation-specific work packet and reservation fence.
-
-**Effect:** local_change
-
-**Id:** assignment_packet
-
-**Implementation surface:** coordinator_work_packet
-
-### verification
-
-**Definition:** Evaluate repository/source verification evidence for the exact delivery identity.
-
-**Effect:** read_only_or_external_evidence
-
-**Id:** verification
-
-**Implementation surface:** project_management_merge_readiness
-
-### commissioning
-
-**Definition:** Track post-merge live verification separately from source verification.
-
-**Effect:** external_or_local_change
-
-**Id:** commissioning
-
-**Implementation surface:** issue_419_commissioning
-
-### authority revision
-
-**Definition:** Retain provider/Git revision evidence used for optimistic concurrency and traceability.
-
-**Effect:** read_only
-
-**Id:** authority_revision
-
-**Implementation surface:** project_management_inventory
+| Operation | Purpose | Effect | Implementation surface |
+|---|---|---|---|
+| Capture work (`capture_work`) | Capture one bounded source record into Work without duplicating source identity. | `external_or_local_change` | `project_management_reconcile` |
+| Create work (`create_work`) | Create or reconcile one new Work record through the configured provider boundary. | `external_or_local_change` | `project_management_reconcile` |
+| Take next work (`take_next_work`) | Select the next eligible Ready item and establish its execution claim. | `external_or_local_change` | `project_management_take_next_work` |
+| Claim work (`claim_work`) | Establish one execution owner after revision and state guards pass. | `external_or_local_change` | `project_management_claim_work` |
+| Release work (`release_work`) | Clear an execution claim through the bounded command plane. | `external_or_local_change` | `project_management_release_work` |
+| Hold work (`hold_work`) | Move work to On Hold only with the required review trigger. | `external_or_local_change` | `project_management_hold_work` |
+| Defer work (`defer_work`) | Move work to Deferred only with the required review trigger. | `external_or_local_change` | `project_management_defer_work` |
+| Complete work (`complete_work`) | Complete work only after configured completion and evidence guards pass. | `external_or_local_change` | `project_management_complete_work` |
+| Readiness (`readiness`) | Evaluate deterministic queue eligibility and readiness evidence. | `read_only` | `project_management_next_work` |
+| Assignment packet (`assignment_packet`) | Bind execution to a generation-specific work packet and reservation fence. | `local_change` | `coordinator_work_packet` |
+| Verification (`verification`) | Evaluate repository/source verification evidence for the exact delivery identity. | `read_only_or_external_evidence` | `project_management_merge_readiness` |
+| Commissioning (`commissioning`) | Track post-merge live verification separately from source verification. | `external_or_local_change` | `issue_419_commissioning` |
+| Authority revision (`authority_revision`) | Retain provider/Git revision evidence used for optimistic concurrency and traceability. | `read_only` | `project_management_inventory` |
 
 ## Result envelope
 
-observed_at, resolved_target, provenance, result, next_actions
+Operation results use a common envelope so readers and tools can identify when the observation was made, what target was resolved, where the evidence came from, the operation result, and any valid next action.
+
+- `observed_at`
+- `resolved_target`
+- `provenance`
+- `result`
+- `next_actions`
 
 ## Typed errors
 
-provider_unavailable, project_not_commissioned, inventory_incomplete, conflict, invalid_transition, not_found, invalid_request, internal
+Failures use bounded error categories rather than unstructured provider text:
+
+- `provider_unavailable`
+- `project_not_commissioned`
+- `inventory_incomplete`
+- `conflict`
+- `invalid_transition`
+- `not_found`
+- `invalid_request`
+- `internal`
 
 ## Verification domains
 
-### source verification
+Source verification and live verification are separate evidence domains. A successful repository check does not by itself prove the post-merge runtime surface.
 
-**Definition:** Repository/source verification evidence tied to the delivery identity.
-
-**Field:** Verification
-
-**Id:** source_verification
-
-### live verification
-
-**Definition:** Post-merge runtime proof tied to the actual exposed capability or runtime path.
-
-**Field:** Live Verification
-
-**Id:** live_verification
+| Domain | Field | Meaning |
+|---|---|---|
+| `source_verification` | Verification | Repository/source verification evidence tied to the delivery identity. |
+| `live_verification` | Live Verification | Post-merge runtime proof tied to the actual exposed capability or runtime path. |
 
 ## Source and authority
 
-This page projects `KIS-WORK-WRK-WFL-001` version `1.0.0`. The MRD is authoritative; this generated page has no write-back authority.
+This page projects `KIS-WORK-WRK-WFL-001` version `1.0.0`. The MRD remains authoritative; this generated page has no write-back authority.

--- a/generated/work-management-spec/005-next-work-selection.md
+++ b/generated/work-management-spec/005-next-work-selection.md
@@ -5,186 +5,54 @@
 
 [Specification](001-specification.md) | [Documentation index](000-index.md)
 
-Define deterministic eligibility and ranking for selecting executable work.
-
-## Dependency evidence
-
-unavailable, partial, observed
-
-## Effort order
-
-tiny, small, medium, large
-
-## Eligible states
-
-ready
-
-## Fields
-
-**Blocked by:** Blocked By
-
-**Created:** Created
-
-**Effort:** Effort
-
-**Execution owner:** Execution Owner
-
-**Priority:** Priority
-
-**State:** Status
-
-## Priority order
-
-critical, high, medium, low
-
-## Profiles
-
-### Normalized domain
-
-#### Reason overrides
-
-**Dependencies clear:** dependency_incomplete:{dependency_id}
-
-**Eligible state:** state_not_executable
-
-**Rules:** project_match, eligible_state, unclaimed, approval_complete, dependencies_clear
-
-### Provider project
-
-#### Reason overrides
-
-**Dependencies clear:** native_dependency_blocking
-
-**Eligible state:** state_not_ready
-
-**Rules:** source_issue, source_open, eligible_state, valid_priority, valid_effort, required_fields, unclaimed, dependency_evidence, dependencies_clear
-
-## Ranking
-
-priority, effort, created_order, record_id
-
-## Rules
-
-### SEL-001
-
-**Definition:** Only issue records are eligible in the provider-backed next-work queue.
-
-**Id:** SEL-001
-
-**Kind:** source_issue
-
-**Reason code:** not_issue
-
-### SEL-002
-
-**Definition:** Provider-backed source issues must remain open.
-
-**Id:** SEL-002
-
-**Kind:** source_open
-
-**Reason code:** source_not_open
-
-### SEL-003
-
-**Definition:** Normalized-domain selection respects an explicit project scope.
-
-**Id:** SEL-003
-
-**Kind:** project_match
-
-**Reason code:** project_mismatch
-
-### SEL-004
-
-**Definition:** Candidate state must be one of the configured eligible states; domain adapters may preserve their existing equivalent reason code.
-
-**Id:** SEL-004
-
-**Kind:** eligible_state
-
-**Reason code:** state_not_ready
-
-### SEL-005
-
-**Definition:** Priority must be present in the canonical priority order.
-
-**Id:** SEL-005
-
-**Kind:** valid_priority
-
-**Reason code:** missing_or_invalid:{field}
-
-### SEL-006
-
-**Definition:** Effort must be present in the canonical effort order.
-
-**Id:** SEL-006
-
-**Kind:** valid_effort
-
-**Reason code:** missing_or_invalid:{field}
-
-### SEL-007
-
-**Definition:** Configured readiness fields must be present before provider-backed selection.
-
-**Id:** SEL-007
-
-**Kind:** required_fields
-
-**Reason code:** missing_required:{field}
-
-### SEL-008
-
-**Definition:** Already claimed work is excluded from next-work selection.
-
-**Id:** SEL-008
-
-**Kind:** unclaimed
-
-**Reason code:** already_claimed:{owner}
-
-### SEL-009
-
-**Definition:** Normalized-domain records that require approval must have completed approval.
-
-**Id:** SEL-009
-
-**Kind:** approval_complete
-
-**Reason code:** approval_incomplete
-
-### SEL-010
-
-**Definition:** Required provider dependency evidence must be observable.
-
-**Id:** SEL-010
-
-**Kind:** dependency_evidence
-
-**Reason code:** dependency_evidence_unavailable
-
-### SEL-011
-
-**Definition:** Provider-native blocker evidence must be empty; normalized-domain adapters preserve dependency-specific reason codes.
-
-**Id:** SEL-011
-
-**Kind:** dependencies_clear
-
-**Reason code:** native_dependency_blocking
-
-### SEL-012
-
-**Definition:** Eligible candidates rank by Priority, Effort, creation order, then stable record identity.
-
-**Id:** SEL-012
-
-**Kind:** ranking
-
-**Reason code:** None
+Selection is deterministic. Work Management first applies the eligibility rules for the active profile, then ranks only the candidates that remain.
+
+## Selection procedure
+
+1. Keep only candidates whose state is `ready`.
+2. Apply the active profile's rules in their declared order. These rules check source shape, open state, project scope, required metadata, claims, approval, dependency evidence, and blockers as applicable to that profile.
+3. Exclude any candidate that fails a rule and return the rule's stable reason code.
+4. Rank the remaining candidates by `priority`, `effort`, `created_order`, `record_id`.
+
+Priority order is `critical`, `high`, `medium`, `low`. Effort order is `tiny`, `small`, `medium`, `large`. Dependency evidence is classified as `unavailable`, `partial`, `observed`.
+
+## Selection inputs
+
+| Input | Project field |
+|---|---|
+| Blocked by | Blocked By |
+| Created | Created |
+| Effort | Effort |
+| Execution owner | Execution Owner |
+| Priority | Priority |
+| State | Status |
+
+## Selection profiles
+
+Profiles reuse the same rule catalog but apply different subsets and preserve profile-specific failure reasons where the source contract requires them.
+
+| Profile | Rules in order | Reason overrides |
+|---|---|---|
+| Normalized domain | `project_match`, `eligible_state`, `unclaimed`, `approval_complete`, `dependencies_clear` | `dependencies_clear` maps to `dependency_incomplete:{dependency_id}`; `eligible_state` maps to `state_not_executable` |
+| Provider project | `source_issue`, `source_open`, `eligible_state`, `valid_priority`, `valid_effort`, `required_fields`, `unclaimed`, `dependency_evidence`, `dependencies_clear` | `dependencies_clear` maps to `native_dependency_blocking`; `eligible_state` maps to `state_not_ready` |
+
+## Rule catalog
+
+| Rule | Kind | Requirement | Failure reason |
+|---|---|---|---|
+| `SEL-001` | `source_issue` | Only issue records are eligible in the provider-backed next-work queue. | `not_issue` |
+| `SEL-002` | `source_open` | Provider-backed source issues must remain open. | `source_not_open` |
+| `SEL-003` | `project_match` | Normalized-domain selection respects an explicit project scope. | `project_mismatch` |
+| `SEL-004` | `eligible_state` | Candidate state must be one of the configured eligible states; domain adapters may preserve their existing equivalent reason code. | `state_not_ready` |
+| `SEL-005` | `valid_priority` | Priority must be present in the canonical priority order. | `missing_or_invalid:{field}` |
+| `SEL-006` | `valid_effort` | Effort must be present in the canonical effort order. | `missing_or_invalid:{field}` |
+| `SEL-007` | `required_fields` | Configured readiness fields must be present before provider-backed selection. | `missing_required:{field}` |
+| `SEL-008` | `unclaimed` | Already claimed work is excluded from next-work selection. | `already_claimed:{owner}` |
+| `SEL-009` | `approval_complete` | Normalized-domain records that require approval must have completed approval. | `approval_incomplete` |
+| `SEL-010` | `dependency_evidence` | Required provider dependency evidence must be observable. | `dependency_evidence_unavailable` |
+| `SEL-011` | `dependencies_clear` | Provider-native blocker evidence must be empty; normalized-domain adapters preserve dependency-specific reason codes. | `native_dependency_blocking` |
+| `SEL-012` | `ranking` | Eligible candidates rank by Priority, Effort, creation order, then stable record identity. | None |
 
 ## Source and authority
 
-This page projects `KIS-WORK-DEC-SCR-001` version `1.0.0`. The MRD is authoritative; this generated page has no write-back authority.
+This page projects `KIS-WORK-DEC-SCR-001` version `1.0.0`. The MRD remains authoritative; this generated page has no write-back authority.

--- a/generated/work-management-spec/006-authority-and-reconciliation-policy.md
+++ b/generated/work-management-spec/006-authority-and-reconciliation-policy.md
@@ -5,618 +5,142 @@
 
 [Specification](001-specification.md) | [Documentation index](000-index.md)
 
-Define authority ownership, repository handoff, Project reconciliation, and no-drift rules.
+Authority determines which system may change a fact. Reconciliation then compares provider state with those owners and reports drift instead of choosing a new truth. Generated documentation stays downstream of every canonical source.
 
-## Change governance
+## Authority principles
 
-### Complexities
+- Work Management owns command fields.
+- Repository change governance owns Change ID, Complexity, and Risk Triggers after a governed change exists.
+- GitHub owns provider-native source identity and observed dependency evidence.
+- Actions and governed verification evidence own source Verification.
+- Generated specifications are downstream review projections with no write-back authority.
+- Conflicts and unavailable evidence fail closed or remain explicitly unknown.
 
-#### Large
+## Change-governance handoff
 
-**Artifacts:** scope.json, spec.md, plan.md, tasks.md, closeout.md
+Work Management carries change-planning data into repository governance, but repository change governance owns the governed change facts once a change exists. This projection uses change-governance schema version `1`.
 
-**Base reviews:** code-quality
+| Complexity | Meaning | Artifacts | Base reviews | Max verifications |
+|---|---|---|---|---|
+| Large | Work spanning components or system boundaries, independently reviewable subwork, substantial state or architecture change, a new integration, or significant release or commissioning coordination. | scope.json, spec.md, plan.md, tasks.md, closeout.md | code-quality | 20 |
+| Medium | Several dependent steps or bounded design/shared-interface work in one contained area. | scope.json, spec.md, plan.md, tasks.md, closeout.md | code-quality | 20 |
+| Small | One bounded straightforward outcome with no material design or interface redesign. | scope.json, change.md | None | 6 |
 
-**Description:** Work spanning components or system boundaries, independently reviewable subwork, substantial state or architecture change, a new integration, or significant release or commissioning coordination.
-
-**Max verifications:** 20
-
-#### Medium
-
-**Artifacts:** scope.json, spec.md, plan.md, tasks.md, closeout.md
-
-**Base reviews:** code-quality
-
-**Description:** Several dependent steps or bounded design/shared-interface work in one contained area.
-
-**Max verifications:** 20
-
-#### Small
-
-**Artifacts:** scope.json, change.md
-
-**Base reviews:** None
-
-**Description:** One bounded straightforward outcome with no material design or interface redesign.
-
-**Max verifications:** 6
-
-**Review types:** code-quality, safety-security, architecture, performance, test-quality, documentation, api-contracts
+Supported review types: `code-quality`, `safety-security`, `architecture`, `performance`, `test-quality`, `documentation`, `api-contracts`.
 
 ### Risk triggers
 
-#### Architecture boundary
-
-**Description:** A module, provider, subsystem, ownership, dependency-direction, or system-boundary contract changes.
-
-**Reviews:** architecture
-
-#### Deployment
-
-**Description:** Deployment, release, environment promotion, or commissioning behavior changes.
-
-**Reviews:** None
-
-#### Destructive
-
-**Description:** The change can remove, replace, invalidate, or irreversibly transform durable resources or state.
-
-**Reviews:** None
-
-#### External action
-
-**Description:** The change can cause externally observable actions through an approved provider or integration.
-
-**Reviews:** None
-
-#### Migration
-
-**Description:** Existing state, schema, configuration, or users require migration or compatibility handling.
-
-**Reviews:** None
-
-#### Money
-
-**Description:** Payments, balances, billing, settlement, or other monetary-value behavior changes.
-
-**Reviews:** None
-
-#### Persistent state
-
-**Description:** Durable state, stored records, or persistence semantics change.
-
-**Reviews:** None
-
-#### Public contract
-
-**Description:** A public or externally consumed interface, schema, command, tool, API, or contract changes.
-
-**Reviews:** api-contracts
-
-#### Secrets
-
-**Description:** Secret material, credentials, key handling, or secret-storage behavior changes.
-
-**Reviews:** safety-security
-
-#### Security
-
-**Description:** Authentication, authorization, trust-boundary, or security-control behavior changes.
-
-**Reviews:** safety-security
-
-#### Sensitive data
-
-**Description:** Personal, regulated, confidential, or otherwise sensitive data handling changes.
-
-**Reviews:** safety-security
-
-**Schema version:** 1
-
-## Github project schema
-
-### Fields
-
-#### Status
-
-**Options:** Inbox, Triage, Proposed, Approved, Ready, Active, Blocked, On Hold, Deferred, Rejected, Superseded, Done
-
-**Type:** single_select
-
-#### Record Type
-
-**Options:** Idea, Task, Specification Slice, Review Run, Finding, Decision, Assumption, Risk, Approval, Hold, Research, Defect, Security Finding
-
-**Type:** single_select
-
-#### Priority
-
-**Options:** Critical, High, Medium, Low
-
-**Type:** single_select
-
-#### Effort
-
-**Options:** Tiny, Small, Medium, Large
-
-**Type:** single_select
-
-#### Delivery Stage
-
-**Options:** None, Change Created, Implementing, PR Open, Review, CI Pending, CI Failed, CI Passed, Merged, Documentation, Commissioning, Complete
-
-**Type:** single_select
-
-#### Execution Owner
-
-**Options:** None
-
-**Type:** text
-
-#### Blocked By
-
-**Options:** None
-
-**Type:** text
-
-#### Documentation Impact
-
-**Options:** Not Assessed, None, Planned, In Progress, Pre-merge Complete, Post-merge Complete
-
-**Type:** single_select
-
-#### Complexity
-
-**Options:** Small, Medium, Large
-
-**Type:** single_select
-
-#### Risk Triggers
-
-**Options:** None
-
-**Type:** text
-
-#### Project ID
-
-**Options:** None
-
-**Type:** text
-
-#### Repository
-
-**Options:** None
-
-**Type:** repository
-
-#### Module
-
-**Options:** None
-
-**Type:** text
-
-#### Change ID
-
-**Options:** None
-
-**Type:** text
-
-#### Origin
-
-**Options:** Operator, Review, Verification, Implementation, Research
-
-**Type:** single_select
-
-#### Disposition
-
-**Options:** Open, Accepted, Rejected, Superseded, Mitigated, Deferred
-
-**Type:** single_select
-
-#### Verification
-
-**Options:** Not Run, Pending, Passed, Failed, Blocked
-
-**Type:** single_select
-
-#### Severity
-
-**Options:** Critical, High, Medium, Low
-
-**Type:** single_select
-
-#### Confidence
-
-**Options:** High, Medium, Low
-
-**Type:** single_select
-
-#### Review Trigger
-
-**Options:** None
-
-**Type:** text
-
-#### Target Date
-
-**Options:** None
-
-**Type:** date
-
-#### Iteration
-
-**Options:** None
-
-**Type:** iteration
-
-#### Source Review
-
-**Options:** None
-
-**Type:** text
-
-#### Authority Revision
-
-**Options:** None
-
-**Type:** text
-
-#### External Link
-
-**Options:** None
-
-**Type:** text
-
-#### Live Verification
-
-**Options:** Not Assessed, Not Required, Pending, Passed, Failed, Blocked
-
-**Type:** single_select
-
-#### Commissioning Key
-
-**Options:** None
-
-**Type:** text
-
-#### Live Verification Evidence
-
-**Options:** None
-
-**Type:** text
-
-**Portfolio id:** default
-
-**Schema version:** 1
-
-### Views
-
-#### 01 Inbox
-
-**Filter:** status:Inbox
-
-**Group by:** None
-
-**Layout:** table
-
-**Purpose:** Untriaged ideas and tasks
-
-**Sort by:** None
-
-**Vertical group by:** None
-
-**Visible fields:** Title, Status, Record Type, Priority, Effort, Repository
-
-#### 02 Programme Table
-
-**Filter:** status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred
-
-**Group by:** None
-
-**Layout:** table
-
-**Purpose:** All active records and key fields
-
-**Sort by:** None
-
-**Vertical group by:** None
-
-**Visible fields:** Title, Status, Record Type, Priority, Effort, Execution Owner, Repository, Change ID, Delivery Stage
-
-#### 03 Delivery Board
-
-**Filter:** status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred
-
-**Group by:** None
-
-**Layout:** board
-
-**Purpose:** Delivery flow grouped by lifecycle status
-
-**Sort by:** None
-
-**Vertical group by:** Status
-
-**Visible fields:** Title, Priority, Effort, Execution Owner, Repository, Delivery Stage
-
-#### 04 Roadmap
-
-**Filter:** record-type:"Specification Slice",Task status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done
-
-**Group by:** None
-
-**Layout:** roadmap
-
-**Purpose:** Dated or iterated specification and implementation slices
-
-**Sort by:** None
-
-**Vertical group by:** None
-
-**Visible fields:** None
-
-#### 05 Specification Slices
-
-**Filter:** record-type:"Specification Slice" status:Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done
-
-**Group by:** None
-
-**Layout:** table
-
-**Purpose:** Proposed through completed specification records
-
-**Sort by:** None
-
-**Vertical group by:** None
-
-**Visible fields:** Title, Status, Priority, Change ID, Delivery Stage, Repository
-
-#### 06 Decisions
-
-**Filter:** record-type:Decision status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done
-
-**Group by:** None
-
-**Layout:** table
-
-**Purpose:** Proposed, accepted, rejected, and superseded decisions
-
-**Sort by:** None
-
-**Vertical group by:** None
-
-**Visible fields:** Title, Status, Disposition, Review Trigger, Authority Revision, Repository
-
-#### 07 Assumptions and Risks
-
-**Filter:** record-type:Assumption,Risk status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred
-
-**Group by:** None
-
-**Layout:** table
-
-**Purpose:** Open validation and mitigation work
-
-**Sort by:** None
-
-**Vertical group by:** None
-
-**Visible fields:** Title, Status, Severity, Confidence, Review Trigger, Disposition, Repository
-
-#### 08 Holds and Deferred
-
-**Filter:** status:"On Hold",Deferred
-
-**Group by:** None
-
-**Layout:** table
-
-**Purpose:** Paused items with review triggers
-
-**Sort by:** None
-
-**Vertical group by:** None
-
-**Visible fields:** Title, Status, Review Trigger, Execution Owner, Blocked By, Target Date, Repository
-
-#### 09 Reviews and Findings
-
-**Filter:** record-type:"Review Run",Finding,"Security Finding" status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done
-
-**Group by:** None
-
-**Layout:** table
-
-**Purpose:** Review runs and extracted records
-
-**Sort by:** None
-
-**Vertical group by:** None
-
-**Visible fields:** Title, Status, Severity, Confidence, Source Review, Verification, Disposition, Repository
-
-#### 10 Verification
-
-**Filter:** verification:Pending,Failed,Blocked status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done
-
-**Group by:** None
-
-**Layout:** table
-
-**Purpose:** Work awaiting or failing verification
-
-**Sort by:** None
-
-**Vertical group by:** None
-
-**Visible fields:** Title, Status, Verification, Change ID, Delivery Stage, Repository
-
-#### 11 Documentation and Closeout
-
-**Filter:** delivery-stage:Documentation,Commissioning status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done
-
-**Group by:** None
-
-**Layout:** table
-
-**Purpose:** Records awaiting documentation reconciliation or final closeout
-
-**Sort by:** None
-
-**Vertical group by:** None
-
-**Visible fields:** Title, Status, Documentation Impact, Change ID, Delivery Stage, Repository
-
-#### 12 Completed
-
-**Filter:** status:Done
-
-**Group by:** None
-
-**Layout:** table
-
-**Purpose:** Closed records retained for history
-
-**Sort by:** None
-
-**Vertical group by:** None
-
-**Visible fields:** Title, Record Type, Repository, Change ID, Delivery Stage, Verification, Authority Revision
-
-## Principles
-
-Work Management owns command fields., Repository change governance owns Change ID, Complexity, and Risk Triggers after a governed change exists., GitHub owns provider-native source identity and observed dependency evidence., Actions and governed verification evidence own source Verification., Generated specifications are downstream review projections with no write-back authority., Conflicts and unavailable evidence fail closed or remain explicitly unknown.
+| Risk trigger | When it applies | Required review |
+|---|---|---|
+| Architecture boundary | A module, provider, subsystem, ownership, dependency-direction, or system-boundary contract changes. | `architecture` |
+| Deployment | Deployment, release, environment promotion, or commissioning behavior changes. | None |
+| Destructive | The change can remove, replace, invalidate, or irreversibly transform durable resources or state. | None |
+| External action | The change can cause externally observable actions through an approved provider or integration. | None |
+| Migration | Existing state, schema, configuration, or users require migration or compatibility handling. | None |
+| Money | Payments, balances, billing, settlement, or other monetary-value behavior changes. | None |
+| Persistent state | Durable state, stored records, or persistence semantics change. | None |
+| Public contract | A public or externally consumed interface, schema, command, tool, API, or contract changes. | `api-contracts` |
+| Secrets | Secret material, credentials, key handling, or secret-storage behavior changes. | `safety-security` |
+| Security | Authentication, authorization, trust-boundary, or security-control behavior changes. | `safety-security` |
+| Sensitive data | Personal, regulated, confidential, or otherwise sensitive data handling changes. | `safety-security` |
+
+## GitHub Project schema
+
+The configured Project schema belongs to portfolio `default` and uses schema version `1`. Fields and allowed single-select options are explicit so provider drift can be detected.
+
+| Field | Type | Options |
+|---|---|---|
+| Status | `single_select` | Inbox, Triage, Proposed, Approved, Ready, Active, Blocked, On Hold, Deferred, Rejected, Superseded, Done |
+| Record Type | `single_select` | Idea, Task, Specification Slice, Review Run, Finding, Decision, Assumption, Risk, Approval, Hold, Research, Defect, Security Finding |
+| Priority | `single_select` | Critical, High, Medium, Low |
+| Effort | `single_select` | Tiny, Small, Medium, Large |
+| Delivery Stage | `single_select` | None, Change Created, Implementing, PR Open, Review, CI Pending, CI Failed, CI Passed, Merged, Documentation, Commissioning, Complete |
+| Execution Owner | `text` | Not applicable |
+| Blocked By | `text` | Not applicable |
+| Documentation Impact | `single_select` | Not Assessed, None, Planned, In Progress, Pre-merge Complete, Post-merge Complete |
+| Complexity | `single_select` | Small, Medium, Large |
+| Risk Triggers | `text` | Not applicable |
+| Project ID | `text` | Not applicable |
+| Repository | `repository` | Not applicable |
+| Module | `text` | Not applicable |
+| Change ID | `text` | Not applicable |
+| Origin | `single_select` | Operator, Review, Verification, Implementation, Research |
+| Disposition | `single_select` | Open, Accepted, Rejected, Superseded, Mitigated, Deferred |
+| Verification | `single_select` | Not Run, Pending, Passed, Failed, Blocked |
+| Severity | `single_select` | Critical, High, Medium, Low |
+| Confidence | `single_select` | High, Medium, Low |
+| Review Trigger | `text` | Not applicable |
+| Target Date | `date` | Not applicable |
+| Iteration | `iteration` | Not applicable |
+| Source Review | `text` | Not applicable |
+| Authority Revision | `text` | Not applicable |
+| External Link | `text` | Not applicable |
+| Live Verification | `single_select` | Not Assessed, Not Required, Pending, Passed, Failed, Blocked |
+| Commissioning Key | `text` | Not applicable |
+| Live Verification Evidence | `text` | Not applicable |
+
+### Project views
+
+Views are derived navigation surfaces over the same Project data. Their filters and visible fields do not create new authority.
+
+| View | Purpose | Layout | Filter | Grouping / sort | Visible fields |
+|---|---|---|---|---|---|
+| 01 Inbox | Untriaged ideas and tasks | `table` | status:Inbox | None | Title, Status, Record Type, Priority, Effort, Repository |
+| 02 Programme Table | All active records and key fields | `table` | status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred | None | Title, Status, Record Type, Priority, Effort, Execution Owner, Repository, Change ID, Delivery Stage |
+| 03 Delivery Board | Delivery flow grouped by lifecycle status | `board` | status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred | vertical group by Status | Title, Priority, Effort, Execution Owner, Repository, Delivery Stage |
+| 04 Roadmap | Dated or iterated specification and implementation slices | `roadmap` | record-type:"Specification Slice",Task status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | None |
+| 05 Specification Slices | Proposed through completed specification records | `table` | record-type:"Specification Slice" status:Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | Title, Status, Priority, Change ID, Delivery Stage, Repository |
+| 06 Decisions | Proposed, accepted, rejected, and superseded decisions | `table` | record-type:Decision status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | Title, Status, Disposition, Review Trigger, Authority Revision, Repository |
+| 07 Assumptions and Risks | Open validation and mitigation work | `table` | record-type:Assumption,Risk status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred | None | Title, Status, Severity, Confidence, Review Trigger, Disposition, Repository |
+| 08 Holds and Deferred | Paused items with review triggers | `table` | status:"On Hold",Deferred | None | Title, Status, Review Trigger, Execution Owner, Blocked By, Target Date, Repository |
+| 09 Reviews and Findings | Review runs and extracted records | `table` | record-type:"Review Run",Finding,"Security Finding" status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | Title, Status, Severity, Confidence, Source Review, Verification, Disposition, Repository |
+| 10 Verification | Work awaiting or failing verification | `table` | verification:Pending,Failed,Blocked status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | Title, Status, Verification, Change ID, Delivery Stage, Repository |
+| 11 Documentation and Closeout | Records awaiting documentation reconciliation or final closeout | `table` | delivery-stage:Documentation,Commissioning status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | Title, Status, Documentation Impact, Change ID, Delivery Stage, Repository |
+| 12 Completed | Closed records retained for history | `table` | status:Done | None | Title, Record Type, Repository, Change ID, Delivery Stage, Verification, Authority Revision |
 
 ## Project bindings
 
+Project integration is enabled for portfolio `default` under schema version `1`.
+
 ### Backend bindings
 
-#### Item 1
-
-**Binding id:** github-default
-
-**Owner:** NielPieterse0
-
-**Owner type:** user
-
-**Project number:** 1
-
-**Provider:** github-mcp
-
-**Enabled:** Yes
-
-### Evidence
-
-**Max file bytes:** 1048576
-
-**Max total bytes:** 4194304
-
-### Features
-
-**Intake:** read_only
-
-**Programme status:** enabled
-
-**Reconciliation:** enabled
-
-**Review import:** read_only
-
-### Gates
-
-**Change traceability:** required
-
-**Decision authority:** advisory
-
-**Hold integrity:** advisory
-
-**Programme drift:** advisory
-
-**Project schema drift:** advisory
-
-**Project settings:** required
-
-**Review disposition:** advisory
-
-**Verification evidence:** required
+| Binding | Provider | Owner | Owner type | Project |
+|---|---|---|---|---|
+| github-default | `github-mcp` | NielPieterse0 | user | 1 |
 
 ### Managed projects
 
-#### Item 1
+| Project ID | Display name | Repository | Local root | Backend |
+|---|---|---|---|---|
+| chatgpt-skill | ChatGPT-skill | NielPieterse0/chatgpt-skill | `C:\Projects\ChatGPT-skill` | github-default |
+| college | college | NielPieterse0/college | `C:\Projects\college` | github-default |
+| commodity | commodity | NielPieterse0/commodity | `C:\Projects\commodity` | github-default |
+| import-isolate | import-isolate | NielPieterse0/import-isolate | `C:\Projects\import-isolate` | github-default |
+| kis-mcp | kis-mcp | NielPieterse0/kis-mcp | `C:\Projects\kis-mcp` | github-default |
+| kis-mcp-doc | kis-mcp-doc | NielPieterse0/kis-mcp-doc | `C:\Projects\kis-mcp-doc` | github-default |
 
-**Backend binding:** github-default
+### Features and gates
 
-**Display name:** ChatGPT-skill
+| Feature | Mode |
+|---|---|
+| Intake | `read_only` |
+| Programme status | `enabled` |
+| Reconciliation | `enabled` |
+| Review import | `read_only` |
 
-**Local root:** C:\Projects\ChatGPT-skill
+| Gate | Strength |
+|---|---|
+| Change traceability | `required` |
+| Decision authority | `advisory` |
+| Hold integrity | `advisory` |
+| Programme drift | `advisory` |
+| Project schema drift | `advisory` |
+| Project settings | `required` |
+| Review disposition | `advisory` |
+| Verification evidence | `required` |
 
-**Project id:** chatgpt-skill
-
-**Repository:** NielPieterse0/chatgpt-skill
-
-#### Item 2
-
-**Backend binding:** github-default
-
-**Display name:** college
-
-**Local root:** C:\Projects\college
-
-**Project id:** college
-
-**Repository:** NielPieterse0/college
-
-#### Item 3
-
-**Backend binding:** github-default
-
-**Display name:** commodity
-
-**Local root:** C:\Projects\commodity
-
-**Project id:** commodity
-
-**Repository:** NielPieterse0/commodity
-
-#### Item 4
-
-**Backend binding:** github-default
-
-**Display name:** import-isolate
-
-**Local root:** C:\Projects\import-isolate
-
-**Project id:** import-isolate
-
-**Repository:** NielPieterse0/import-isolate
-
-#### Item 5
-
-**Backend binding:** github-default
-
-**Display name:** kis-mcp
-
-**Local root:** C:\Projects\kis-mcp
-
-**Project id:** kis-mcp
-
-**Repository:** NielPieterse0/kis-mcp
-
-#### Item 6
-
-**Backend binding:** github-default
-
-**Display name:** kis-mcp-doc
-
-**Local root:** C:\Projects\kis-mcp-doc
-
-**Project id:** kis-mcp-doc
-
-**Repository:** NielPieterse0/kis-mcp-doc
-
-**Portfolio id:** default
-
-**Schema version:** 1
+Evidence collection is bounded to `1048576` bytes per file and `4194304` bytes in total.
 
 ## Source and authority
 
-This page projects `KIS-WORK-CON-POL-001` version `1.0.0`. The MRD is authoritative; this generated page has no write-back authority.
+This page projects `KIS-WORK-CON-POL-001` version `1.0.0`. The MRD remains authoritative; this generated page has no write-back authority.

--- a/generated/work-management-spec/007-provider-and-command-plane-boundary.md
+++ b/generated/work-management-spec/007-provider-and-command-plane-boundary.md
@@ -5,298 +5,98 @@
 
 [Specification](001-specification.md) | [Documentation index](000-index.md)
 
-Define the configured command plane and GitHub Project provider boundary.
+The command plane defines the work states and fields that KIS may change. The provider boundary observes and mutates GitHub Project only through the configured read and write models; provider state does not redefine repository-owned facts.
 
-## Command plane
+## Command-plane model
 
-### Claim
+Claims use **Execution Owner** and do not expire automatically. The completion policy targets `done` and does not require the claim to be absent after close.
 
-**Auto expiry:** No
+The command plane exposes these work states: `inbox`, `triage`, `proposed`, `approved`, `ready`, `active`, `blocked`, `on_hold`, `deferred`, `rejected`, `superseded`, `done`. Delivery uses `none`, `change_created`, `implementing`, `pr_open`, `review`, `ci_pending`, `ci_failed`, `ci_passed`, `merged`, `documentation`, `commissioning`, `complete`.
 
-**Execution owner field:** Execution Owner
-
-### Completion
-
-**Require no active claim after close:** No
-
-**Terminal state:** done
-
-### Delivery
-
-**Change created stage:** change_created
-
-**Change id field:** Change ID
-
-**Complete stage:** complete
-
-**Complexity field:** Complexity
-
-**Risk triggers field:** Risk Triggers
-
-**Stage field:** Delivery Stage
-
-**Delivery stages:** none, change_created, implementing, pr_open, review, ci_pending, ci_failed, ci_passed, merged, documentation, commissioning, complete
+The intake alias `todo` maps to `inbox`.
 
 ### Field authority
 
-#### Authority revision
-
-**Authority:** git
-
-**Direction:** evidence
-
-#### Blocked by
-
-**Authority:** github
-
-**Direction:** evidence
-
-#### Change id
-
-**Authority:** repository_change
-
-**Direction:** evidence
-
-#### Commissioning key
-
-**Authority:** derived
-
-**Direction:** evidence
-
-#### Complexity
-
-**Authority:** repository_change
-
-**Direction:** evidence
-
-#### Confidence
-
-**Authority:** work_management
-
-**Direction:** command
-
-#### Created
-
-**Authority:** github
-
-**Direction:** evidence
-
-#### Delivery stage
-
-**Authority:** derived
-
-**Direction:** evidence
-
-#### Disposition
-
-**Authority:** work_management
-
-**Direction:** command
-
-#### Documentation impact
-
-**Authority:** work_management_then_repository_change
-
-**Direction:** handoff
-
-#### Effort
-
-**Authority:** work_management
-
-**Direction:** command
-
-#### Execution owner
-
-**Authority:** work_management
-
-**Direction:** command
-
-#### External link
-
-**Authority:** work_management
-
-**Direction:** command
-
-#### Iteration
-
-**Authority:** work_management
-
-**Direction:** command
-
-#### Live verification
-
-**Authority:** derived
-
-**Direction:** evidence
-
-#### Live verification evidence
-
-**Authority:** derived
-
-**Direction:** evidence
-
-#### Module
-
-**Authority:** work_management_then_repository_change
-
-**Direction:** handoff
-
-#### Origin
-
-**Authority:** work_management
-
-**Direction:** command
-
-#### Priority
-
-**Authority:** work_management
-
-**Direction:** command
-
-#### Project id
-
-**Authority:** derived
-
-**Direction:** evidence
-
-#### Record type
-
-**Authority:** work_management
-
-**Direction:** command
-
-#### Repository
-
-**Authority:** github
-
-**Direction:** evidence
-
-#### Review trigger
-
-**Authority:** work_management
-
-**Direction:** command
-
-#### Risk triggers
-
-**Authority:** repository_change
-
-**Direction:** evidence
-
-#### Severity
-
-**Authority:** work_management
-
-**Direction:** command
-
-#### Source review
-
-**Authority:** work_management
-
-**Direction:** command
-
-#### Status
-
-**Authority:** work_management
-
-**Direction:** command
-
-#### Target date
-
-**Authority:** work_management
-
-**Direction:** command
-
-#### Verification
-
-**Authority:** actions
-
-**Direction:** evidence
-
-### Intake aliases
-
-**Todo:** inbox
-
-### Queue
-
-**Blocked by field:** Blocked By
-
-**Created field:** Created
-
-**Effort field:** Effort
-
-**Effort order:** tiny, small, medium, large
-
-**Eligible states:** ready
-
-**Priority field:** Priority
-
-**Priority order:** critical, high, medium, low
-
-**Ranking:** priority, effort, created_order, record_id
-
-**State field:** Status
-
-### Readiness
-
-**Required issue sections:** Outcome, Acceptance criteria
-
-**Required project fields:** Record Type, Priority, Effort, Documentation Impact
-
-**Requires dependencies understood:** Yes
-
-**Schema version:** 1
-
-### Transition requirements
-
-**Deferred:** Review Trigger
-
-**On hold:** Review Trigger
-
-### Transitions
-
-**Active:** ready, review, blocked, on_hold, deferred, done, superseded
-
-**Approved:** ready, active, on_hold, deferred, superseded
-
-**Blocked:** ready, active, on_hold, deferred, superseded
-
-**Deferred:** triage, proposed, approved, rejected, superseded
-
-**Documentation:** done, active, blocked, superseded
-
-**Done:** None
-
-**Inbox:** triage, deferred, rejected, superseded
-
-**On hold:** ready, active, deferred, rejected, superseded
-
-**Proposed:** approved, deferred, rejected, superseded
-
-**Ready:** active, on_hold, deferred, superseded
-
-**Rejected:** triage, superseded
-
-**Review:** active, verification, blocked, on_hold, superseded
-
-**Superseded:** None
-
-**Triage:** proposed, approved, deferred, rejected, superseded
-
-**Verification:** active, documentation, blocked, superseded
-
-**Work states:** inbox, triage, proposed, approved, ready, active, blocked, on_hold, deferred, rejected, superseded, done
+Each field keeps the authority and direction defined by the Work Management domain model:
+
+| Field | Authority | Direction |
+|---|---|---|
+| Authority Revision | `git` | `evidence` |
+| Blocked By | `github` | `evidence` |
+| Change ID | `repository_change` | `evidence` |
+| Commissioning Key | `derived` | `evidence` |
+| Complexity | `repository_change` | `evidence` |
+| Confidence | `work_management` | `command` |
+| Created | `github` | `evidence` |
+| Delivery Stage | `derived` | `evidence` |
+| Disposition | `work_management` | `command` |
+| Documentation Impact | `work_management_then_repository_change` | `handoff` |
+| Effort | `work_management` | `command` |
+| Execution Owner | `work_management` | `command` |
+| External Link | `work_management` | `command` |
+| Iteration | `work_management` | `command` |
+| Live Verification | `derived` | `evidence` |
+| Live Verification Evidence | `derived` | `evidence` |
+| Module | `work_management_then_repository_change` | `handoff` |
+| Origin | `work_management` | `command` |
+| Priority | `work_management` | `command` |
+| Project ID | `derived` | `evidence` |
+| Record Type | `work_management` | `command` |
+| Repository | `github` | `evidence` |
+| Review Trigger | `work_management` | `command` |
+| Risk Triggers | `repository_change` | `evidence` |
+| Severity | `work_management` | `command` |
+| Source Review | `work_management` | `command` |
+| Status | `work_management` | `command` |
+| Target Date | `work_management` | `command` |
+| Verification | `actions` | `evidence` |
+
+## Queue and readiness
+
+The executable queue accepts state `ready`. It ranks by `priority`, `effort`, `created_order`, `record_id`, using priority order `critical`, `high`, `medium`, `low` and effort order `tiny`, `small`, `medium`, `large`.
+
+Queue inputs come from **Status**, **Priority**, **Effort**, **Created**, and **Blocked By**.
+
+Before the provider-backed command plane can treat work as Ready, the record **MUST** satisfy its configured readiness requirements:
+
+- The source issue contains **Outcome** and **Acceptance criteria**.
+- The Project record contains **Record Type**, **Priority**, **Effort**, and **Documentation Impact**.
+- Dependencies are understood.
+
+## State transitions
+
+The provider-facing command plane uses the same transition graph as the Work lifecycle chapter. The table is repeated here because the provider adapter validates these exact transitions.
+
+| From | Allowed next states | Additional requirement |
+|---|---|---|
+| `active` | `ready`, `review`, `blocked`, `on_hold`, `deferred`, `done`, `superseded` | None |
+| `approved` | `ready`, `active`, `on_hold`, `deferred`, `superseded` | None |
+| `blocked` | `ready`, `active`, `on_hold`, `deferred`, `superseded` | None |
+| `deferred` | `triage`, `proposed`, `approved`, `rejected`, `superseded` | Review Trigger |
+| `documentation` | `done`, `active`, `blocked`, `superseded` | None |
+| `done` | No transitions | None |
+| `inbox` | `triage`, `deferred`, `rejected`, `superseded` | None |
+| `on_hold` | `ready`, `active`, `deferred`, `rejected`, `superseded` | Review Trigger |
+| `proposed` | `approved`, `deferred`, `rejected`, `superseded` | None |
+| `ready` | `active`, `on_hold`, `deferred`, `superseded` | None |
+| `rejected` | `triage`, `superseded` | None |
+| `review` | `active`, `verification`, `blocked`, `on_hold`, `superseded` | None |
+| `superseded` | No transitions | None |
+| `triage` | `proposed`, `approved`, `deferred`, `rejected`, `superseded` | None |
+| `verification` | `active`, `documentation`, `blocked`, `superseded` | None |
+
+## Delivery projection
+
+**Delivery Stage** carries the derived delivery stage. **Change ID**, **Complexity**, and **Risk Triggers** are projected from repository change governance. The change-created stage is `change_created` and the complete stage is `complete`.
 
 ## Provider contract
 
-**Live observation:** not captured in this revision because provider inventory response was invalid
+The configured Project is `NielPieterse0/1`. Reads use bounded inventory and schema observation; writes use preview or idempotent mutation.
 
-**Project:** NielPieterse0/1
+Live Project evidence was observed; inventory is complete; the configured Project schema is ready with no field, option, type, or view drift in the captured evidence.
 
-**Read model:** bounded inventory and schema observation
-
-**Write model:** preview or idempotent mutation
+Command-plane schema version: `1`.
 
 ## Source and authority
 
-This page projects `KIS-WORK-CTR-SVC-001` version `1.0.0`. The MRD is authoritative; this generated page has no write-back authority.
+This page projects `KIS-WORK-CTR-SVC-001` version `1.0.1`. The MRD remains authoritative; this generated page has no write-back authority.

--- a/generated/work-management-spec/008-work-management-conformance.md
+++ b/generated/work-management-spec/008-work-management-conformance.md
@@ -5,12 +5,18 @@
 
 [Specification](001-specification.md) | [Documentation index](000-index.md)
 
-Define conformance requirements for the Work Management specification.
+A Work Management implementation conforms to this specification only when its source MRDs, dependencies, evidence, generated views, and lifecycle behavior pass the checks below. These checks keep human-readable documentation aligned with machine-readable authority.
 
-## Checks
+## Conformance requirements
 
-MRD envelopes validate against the KIS MRD core schema., All MRD dependencies resolve and preserve one-owner authority., Harvested source hashes match the pinned canonical snapshot., Generated specification is byte deterministic., Generated output is stale/tamper detectable., Lifecycle transitions and selection rules are reproduced exactly from canonical contracts., Unavailable live Project evidence remains explicit and does not become inferred authority.
+1. MRD envelopes validate against the KIS MRD core schema.
+2. All MRD dependencies resolve and preserve one-owner authority.
+3. Harvested source hashes match the pinned canonical snapshot.
+4. Generated specification is byte deterministic.
+5. Generated output is stale/tamper detectable.
+6. Lifecycle transitions and selection rules are reproduced exactly from canonical contracts.
+7. Unavailable live Project evidence remains explicit and does not become inferred authority.
 
 ## Source and authority
 
-This page projects `KIS-WORK-EVL-TST-001` version `1.0.0`. The MRD is authoritative; this generated page has no write-back authority.
+This page projects `KIS-WORK-EVL-TST-001` version `1.0.0`. The MRD remains authoritative; this generated page has no write-back authority.

--- a/generated/work-management-spec/manifest.json
+++ b/generated/work-management-spec/manifest.json
@@ -1,59 +1,59 @@
 {
-  "bundle_sha256": "a74e185bacc5372a7ffefebd819ead38090469695c049c79cc9c048e253b621c",
+  "bundle_sha256": "d16a7b4ecd29d02a6d0d40103bad70e2d959daf69b9054baea1477bdd94399ad",
   "contract": {
     "name": "kis-work-management-spec-build",
     "version": 1
   },
   "files": [
     {
-      "bytes": 780,
+      "bytes": 1047,
       "path": "000-index.md",
-      "sha256": "7bdd16776e4db148096d96eca8094777ba751554d68beec389aeb2f232c6c2a7"
+      "sha256": "45237e7931a739472945647ec0312bcc8d43ee504cbde58b1f025dc65fb43433"
     },
     {
-      "bytes": 1516,
+      "bytes": 3052,
       "path": "001-specification.md",
-      "sha256": "4b90e222164801bbb7e7370c1c41d1af6c709fe2ffef87351dfdc144a219f810"
+      "sha256": "af16af714b1a446b96cf9f90b6ba43e7ff0eb3d89bf2596563ad0cb2d51c176e"
     },
     {
-      "bytes": 23896,
+      "bytes": 18510,
       "path": "002-work-management-domain-model.md",
-      "sha256": "25b14dafd0a6ebfeeb079ea310a2e30fb34a66d5f21274488ca57154ca1d0dbf"
+      "sha256": "5c37c948bd6d0576baaaff26470b04e533f6705167115271d198062ff9ebc32f"
     },
     {
-      "bytes": 6917,
+      "bytes": 6264,
       "path": "003-work-lifecycle.md",
-      "sha256": "f8dea98c659bdab5efb9fa74792c64ced2f8e183ddc26fb8072059d4fb0810d5"
+      "sha256": "e211d1041219390a50572485cdbb9b38c70f24d4a4f9157f269845f47ed337cb"
     },
     {
-      "bytes": 4213,
+      "bytes": 4096,
       "path": "004-work-operations.md",
-      "sha256": "310f64aa32606427bde125ba32156a9cf8efec7a45ccbf46f99fee6f60ce779b"
+      "sha256": "17413f9980560090b5aa4953a455847a0f6383a08c1c1a653a4242073362ee93"
     },
     {
-      "bytes": 3785,
+      "bytes": 3859,
       "path": "005-next-work-selection.md",
-      "sha256": "243f2fcf4faae34e39b2bb043b22baa480a56a3f0c444fcacc8ff8ee614beb0e"
+      "sha256": "f9b126e24454e35063249ddab32ee968198e500a992a186466181103c82a4c8f"
     },
     {
-      "bytes": 12945,
+      "bytes": 10732,
       "path": "006-authority-and-reconciliation-policy.md",
-      "sha256": "e16ede2f461b86a40459b2954a3780df4c1e5b6436d28790f1d83dcdd318080f"
+      "sha256": "9e0e59f59399b29b6c8709b424944ee395f37e107ab3b7187ed8b434a4a470f3"
     },
     {
-      "bytes": 5322,
+      "bytes": 5492,
       "path": "007-provider-and-command-plane-boundary.md",
-      "sha256": "533211f83b23ea5f19915521ebf151aebbfeff8a1cd6f228fdf8dbe94189799b"
+      "sha256": "0665aea5a22b76d8cc2369d31f45ef45db6c50539ce4ec7c3dde867ab2058619"
     },
     {
-      "bytes": 899,
+      "bytes": 1138,
       "path": "008-work-management-conformance.md",
-      "sha256": "5dc644e111b06f20df0436804b7053314e507262a355b78ac133b3fd4bd40287"
+      "sha256": "c178810c40e72de20468ab942ac82d689467a7aad98aa6fdcef343fc4474542d"
     },
     {
-      "bytes": 1516,
+      "bytes": 3052,
       "path": "specification.md",
-      "sha256": "4b90e222164801bbb7e7370c1c41d1af6c709fe2ffef87351dfdc144a219f810"
+      "sha256": "af16af714b1a446b96cf9f90b6ba43e7ff0eb3d89bf2596563ad0cb2d51c176e"
     }
   ],
   "inputs": {
@@ -91,8 +91,8 @@
       {
         "id": "KIS-WORK-CTR-SVC-001",
         "path": "mrd/work-management/06-svc.mrd.json",
-        "sha256": "efda40ea7a1918ed077bc3c6782089046daf4e7d0f0587d031d375476851e7e9",
-        "version": "1.0.0"
+        "sha256": "948f9370ec4c751085131bda230d469c23c2ec379a8004cfbfb92b01d4a1d1d5",
+        "version": "1.0.1"
       },
       {
         "id": "KIS-WORK-EVL-TST-001",
@@ -101,7 +101,7 @@
         "version": "1.0.0"
       }
     ],
-    "source_set_sha256": "8b0bfecf145821e6481e388e57a0f5673d39b181b6f022a46a1d69b91cefd182"
+    "source_set_sha256": "43470929a16053378938ebf19ea5c4a6251d0cd7a0e77cc863ad527ffec14caa"
   },
   "specification": {
     "layout_profile": "mcp-spec",

--- a/generated/work-management-spec/specification.md
+++ b/generated/work-management-spec/specification.md
@@ -3,15 +3,32 @@
 
 <div id="enable-section-numbers" />
 
-Governed operating specification for work intake, state, selection, delivery, reconciliation, and GitHub Project integration.
+Work Management is the governed KIS system for capturing, classifying, selecting, executing, verifying, and closing work across registered projects.
 
 The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", and "OPTIONAL" are normative when they appear in all capitals.
 
 ## Overview
 
-Work Management separates command authority from evidence. It governs work-item semantics, lifecycle state, deterministic selection, provider reconciliation, delivery evidence, and closeout while keeping repository change governance authoritative for governed change facts.
+Work Management gives work one shared lifecycle and one explicit authority model. It separates facts that Work Management may change from evidence observed from GitHub, repository change governance, verification, and derived delivery state.
 
-The specification is generated from seven prescriptive MRDs harvested from the pinned `kis-mcp` implementation contracts. Live GitHub Project evidence that could not be observed remains explicitly unavailable rather than inferred.
+A GitHub Project provides the shared provider surface, but it does not become the owner of every fact displayed there. Repository change governance remains authoritative for governed change identity, complexity, and risk; GitHub remains authoritative for provider-native source identity and dependency observations; verification systems own their evidence; and Work Management owns its command fields.
+
+The captured live GitHub Project evidence is observed. Inventory is complete, and the configured Project schema is ready with no reported field, option, type, or view drift.
+
+## Key concepts
+
+- **Command data** is changed through Work Management operations, such as status, priority, effort, claims, holds, and deferrals.
+- **Evidence data** is observed or projected from its owning source, such as GitHub source identity, repository change facts, verification, and delivery state.
+- **Handoff data** begins as Work Management planning data and becomes repository-owned evidence when a governed change takes authority for it.
+- **Generated documentation** explains and indexes the governed model. It never writes facts back to Work Management or its sources.
+
+## How work moves
+
+1. Capture work and classify it before it enters the executable queue.
+2. Admit work to Ready only after the required source sections, Project fields, and dependency evidence are present.
+3. Select Ready work deterministically, then establish an execution claim before activation.
+4. Track repository delivery and source verification as evidence without replacing the Work lifecycle state.
+5. After merge, reconcile any required documentation and live-verification obligations before the configured completion gates allow Done.
 
 ## Detailed specification
 
@@ -25,4 +42,4 @@ The specification is generated from seven prescriptive MRDs harvested from the p
 
 ## Traceability
 
-See the [documentation index](000-index.md) and [build manifest](manifest.json) for source identities and hashes.
+See the [documentation index](000-index.md) and [build manifest](manifest.json) for exact source identities, MRD versions, hashes, and generated-file declarations.

--- a/mrd/work-management/06-svc.mrd.json
+++ b/mrd/work-management/06-svc.mrd.json
@@ -39,7 +39,7 @@
     "supersedes": [],
     "title": "Provider and command-plane boundary",
     "type": "SVC",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "content": {
     "command_plane": {
@@ -349,7 +349,7 @@
       ]
     },
     "provider_contract": {
-      "live_observation": "not captured in this revision because provider inventory response was invalid",
+      "live_observation": "Live Project evidence was observed; inventory is complete; the configured Project schema is ready with no field, option, type, or view drift in the captured evidence.",
       "project": "NielPieterse0/1",
       "read_model": "bounded inventory and schema observation",
       "write_model": "preview or idempotent mutation"

--- a/src/kis_mcp_doc/work_management.py
+++ b/src/kis_mcp_doc/work_management.py
@@ -80,68 +80,528 @@ def _inline_value(value: Any) -> str | None:
     return None
 
 
-def _item_label(item: dict[str, Any], index: int) -> str:
-    for key in ("name", "label", "title", "id", "token", "code", "operation_id", "rule_id"):
-        value = item.get(key)
-        if isinstance(value, (str, int)) and str(value):
-            return str(value).replace("_", " ")
-    if "order" in item:
-        return f"Step {item['order']}"
-    return f"Item {index}"
+def _human_name(value: str) -> str:
+    return value.replace("_", " ").strip().capitalize()
 
 
-def _render_value(value: Any, *, level: int = 3) -> list[str]:
-    if isinstance(value, str):
-        return [value, ""]
-    inline = _inline_value(value)
-    if inline is not None:
-        return [inline, ""]
-    if isinstance(value, list):
-        if not value:
-            return ["None.", ""]
-        if all(isinstance(item, str) for item in value):
-            return [*(f"- {item}" for item in value), ""]
-        if all(isinstance(item, dict) for item in value):
-            lines: list[str] = []
-            for index, item in enumerate(value, start=1):
-                lines.extend([f"{'#' * min(level, 6)} {_item_label(item, index)}", ""])
-                for key, nested in item.items():
-                    if key in {"name", "label", "title"}:
-                        continue
-                    label = key.replace("_", " ").capitalize()
-                    nested_inline = _inline_value(nested)
-                    if nested_inline is not None:
-                        lines.extend([f"**{label}:** {nested_inline}", ""])
-                    else:
-                        lines.extend([f"{'#' * min(level + 1, 6)} {label}", ""])
-                        lines.extend(_render_value(nested, level=level + 2))
-            return lines
-        return ["- " + str(item) for item in value] + [""]
-    if isinstance(value, dict):
-        lines = []
-        for key, nested in value.items():
-            label = key.replace("_", " ").capitalize()
-            nested_inline = _inline_value(nested)
-            if nested_inline is not None:
-                lines.extend([f"**{label}:** {nested_inline}", ""])
-            else:
-                lines.extend([f"{'#' * min(level, 6)} {label}", ""])
-                lines.extend(_render_value(nested, level=level + 1))
-        return lines
-    return [str(value), ""]
+def _code_list(values: list[Any]) -> str:
+    return ", ".join(f"`{value}`" for value in values) if values else "None"
+
+
+def _text_list(values: list[Any]) -> str:
+    return ", ".join(str(value) for value in values) if values else "None"
+
+
+def _natural_list(values: list[Any], *, code: bool=False, bold: bool=False) -> str:
+    items = []
+    for value in values:
+        text = str(value)
+        if code:
+            text = f"`{text}`"
+        elif bold:
+            text = f"**{text}**"
+        items.append(text)
+    if not items:
+        return "none"
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 2:
+        return f"{items[0]} and {items[1]}"
+    return ", ".join(items[:-1]) + f", and {items[-1]}"
+
+
+def _markdown_cell(value: Any) -> str:
+    if value is None or value == "":
+        return "None"
+    return str(value).replace("|", "\\|").replace("\n", "<br>")
+
+
+def _append_table(lines: list[str], headers: list[str], rows: list[list[Any]]) -> None:
+    lines.append("| " + " | ".join(headers) + " |")
+    lines.append("|" + "|".join("---" for _ in headers) + "|")
+    for row in rows:
+        lines.append("| " + " | ".join(_markdown_cell(value) for value in row) + " |")
+    lines.append("")
+
+
+def _source_and_authority(doc: dict[str, Any]) -> list[str]:
+    return [
+        "## Source and authority",
+        "",
+        f"This page projects `{doc['_mrd']['id']}` version `{doc['_mrd']['version']}`. The MRD remains authoritative; this generated page has no write-back authority.",
+        "",
+    ]
+
+
+def _render_domain_model(content: dict[str, Any]) -> list[str]:
+    lines = [
+        "Work Management defines the fields and controlled vocabularies used to describe a work record. The model keeps command data separate from observed evidence so that a generated view cannot silently become a second source of truth.",
+        "",
+        "## Field model",
+        "",
+        "Work Management uses three authority directions. **Command** fields are changed through Work Management. **Evidence** fields are observed or projected from their owning source. **Handoff** fields start in Work Management and later become governed repository-change facts.",
+        "",
+    ]
+    direction_labels = {
+        "command": "Command fields",
+        "evidence": "Evidence fields",
+        "handoff": "Handoff fields",
+    }
+    for direction in ("command", "evidence", "handoff"):
+        fields = [item for item in content["fields"] if item["direction"] == direction]
+        if not fields:
+            continue
+        lines.extend([f"### {direction_labels[direction]}", ""])
+        rows = []
+        for field in fields:
+            scope = "all record types" if field["applicable_record_types"] == ["*"] else _text_list(field["applicable_record_types"])
+            details = [
+                f"ID `{field['id']}`",
+                f"provider `{field['provider_type']}`",
+                "KIS-managed" if field["managed"] else "provider-managed",
+                f"applies to {scope}",
+            ]
+            if field["required_contexts"]:
+                details.append(f"required for {_code_list(field['required_contexts'])}")
+            if field["vocabulary"]:
+                details.append(f"vocabulary `{field['vocabulary']}`")
+            meaning = f"{field['definition']} {field['population']}"
+            rows.append([
+                field["name"],
+                meaning,
+                f"`{field['authority']}`",
+                f"`{field['direction']}`",
+                "; ".join(details),
+            ])
+        _append_table(lines, ["Field", "Meaning", "Authority", "Direction", "Details"], rows)
+
+    lines.extend([
+        "## Authority rules",
+        "",
+        "These rules prevent field ownership from drifting between Work Management, repository change governance, GitHub, Actions, and generated documentation:",
+        "",
+    ])
+    lines.extend(f"- {rule}" for rule in content["rules"])
+    lines.append("")
+
+    lines.extend([
+        "## Controlled vocabularies",
+        "",
+        "Single-select fields use the following governed values. The display label is what readers see; the token is the stable machine value.",
+        "",
+    ])
+    for vocabulary in content["vocabularies"]:
+        lines.extend([
+            f"### {_human_name(vocabulary['id'])} values",
+            "",
+            vocabulary["definition"],
+            "",
+        ])
+        rows = [
+            [value["label"], f"`{value['token']}`", value["definition"]]
+            for value in vocabulary["values"]
+        ]
+        _append_table(lines, ["Value", "Token", "Meaning"], rows)
+    return lines
+
+
+def _render_lifecycle(content: dict[str, Any]) -> list[str]:
+    state_by_token = {state["token"]: state["label"] for state in content["states"]}
+    lines = [
+        "A work item moves through explicit states. Project-visible states describe the shared work queue, while internal states such as Review, Verification, and Documentation describe delivery activity without creating new GitHub Project status values.",
+        "",
+        "## State model",
+        "",
+    ]
+    _append_table(
+        lines,
+        ["State", "Meaning", "GitHub Project status", "Token"],
+        [[state["label"], state["definition"], "Yes" if state["project_status"] else "No", f"`{state['token']}`"] for state in content["states"]],
+    )
+
+    lines.extend([
+        "## Transitions",
+        "",
+        "Transitions are explicit. A work item **MUST** move only to a destination listed for its current state. On Hold and Deferred also require a Review Trigger.",
+        "",
+    ])
+    transition_rows = []
+    for source, targets in content["transitions"].items():
+        requirement = content["transition_requirements"].get(source, [])
+        transition_rows.append([
+            state_by_token.get(source, _human_name(source)),
+            ", ".join(state_by_token.get(target, _human_name(target)) for target in targets) if targets else "No transitions",
+            _text_list(requirement),
+        ])
+    _append_table(lines, ["From", "Allowed next states", "Additional requirement"], transition_rows)
+
+    readiness = content["readiness"]
+    lines.extend([
+        "## Readiness and claims",
+        "",
+        "Before a work item can enter Ready, it **MUST** satisfy all configured readiness requirements:",
+        "",
+        f"- The source issue contains {_natural_list(readiness['required_issue_sections'], bold=True)}.",
+        f"- The Project record contains {_natural_list(readiness['required_project_fields'], bold=True)}.",
+    ])
+    if readiness["requires_dependencies_understood"]:
+        lines.append("- Dependencies are understood.")
+    lines.extend([
+        "",
+        f"Execution claims use the **{content['claim']['execution_owner_field']}** field. Claims {'expire automatically' if content['claim']['auto_expiry'] else 'do not expire automatically'}.",
+        "",
+        f"At intake, the alias `{next(iter(content['intake_aliases']))}` is normalized to `{next(iter(content['intake_aliases'].values()))}`.",
+        "",
+        "## Delivery and completion",
+        "",
+        "Delivery is tracked separately from the work state. The configured delivery-stage sequence is:",
+        "",
+        _code_list(content["delivery"]["stages"]),
+        "",
+        f"The **{content['delivery']['stage_field']}** field stores that stage. **{content['delivery']['change_id_field']}**, **{content['delivery']['complexity_field']}**, and **{content['delivery']['risk_triggers_field']}** connect the work record to repository change governance. The sequence starts its governed change at `{content['delivery']['change_created_stage']}` and reaches `{content['delivery']['complete_stage']}` when delivery is complete.",
+        "",
+        f"Completion targets `{content['completion']['terminal_state']}`. The current configuration {'requires' if content['completion']['require_no_active_claim_after_close'] else 'does not require'} the execution claim to be absent after close.",
+        "",
+        "## Completion and activation guards",
+        "",
+        "Guards reject or qualify transitions when required evidence is missing or inconsistent:",
+        "",
+    ])
+    _append_table(
+        lines,
+        ["Guard", "Applies when", "Rule", "Result", "Reason"],
+        [[f"`{guard['id']}`", f"`{guard['condition']}`", guard["definition"], f"`{guard['disposition']}` to `{guard['target']}`", f"`{guard['reason_code']}`"] for guard in content["guards"]],
+    )
+    return lines
+
+
+def _render_operations(content: dict[str, Any]) -> list[str]:
+    mutation_rule = content["mutation_rule"].replace("apply=true", "`apply=true`")
+    lines = [
+        "Work Management exposes a bounded set of operations for intake, claiming, state changes, verification, and post-merge commissioning. Each operation has a defined effect and implementation surface so callers can distinguish reads from mutations and evidence collection.",
+        "",
+        "## Mutation safety",
+        "",
+        mutation_rule,
+        "",
+        "## Operations",
+        "",
+    ]
+    _append_table(
+        lines,
+        ["Operation", "Purpose", "Effect", "Implementation surface"],
+        [[f"{_human_name(op['id'])} (`{op['id']}`)", op["definition"], f"`{op['effect']}`", f"`{op['implementation_surface']}`"] for op in content["operations"]],
+    )
+    lines.extend([
+        "## Result envelope",
+        "",
+        "Operation results use a common envelope so readers and tools can identify when the observation was made, what target was resolved, where the evidence came from, the operation result, and any valid next action.",
+        "",
+    ])
+    lines.extend(f"- `{item}`" for item in content["result_envelope"])
+    lines.extend([
+        "",
+        "## Typed errors",
+        "",
+        "Failures use bounded error categories rather than unstructured provider text:",
+        "",
+    ])
+    lines.extend(f"- `{item}`" for item in content["typed_errors"])
+    lines.extend([
+        "",
+        "## Verification domains",
+        "",
+        "Source verification and live verification are separate evidence domains. A successful repository check does not by itself prove the post-merge runtime surface.",
+        "",
+    ])
+    _append_table(
+        lines,
+        ["Domain", "Field", "Meaning"],
+        [[f"`{item['id']}`", item["field"], item["definition"]] for item in content["verification_domains"]],
+    )
+    return lines
+
+
+def _render_selection(content: dict[str, Any]) -> list[str]:
+    eligible = content["eligible_states"]
+    eligible_text = _natural_list(eligible, code=True)
+    lines = [
+        "Selection is deterministic. Work Management first applies the eligibility rules for the active profile, then ranks only the candidates that remain.",
+        "",
+        "## Selection procedure",
+        "",
+        f"1. Keep only candidates whose state is {eligible_text}.",
+        "2. Apply the active profile's rules in their declared order. These rules check source shape, open state, project scope, required metadata, claims, approval, dependency evidence, and blockers as applicable to that profile.",
+        "3. Exclude any candidate that fails a rule and return the rule's stable reason code.",
+        f"4. Rank the remaining candidates by {_code_list(content['ranking'])}.",
+        "",
+        f"Priority order is {_code_list(content['priority_order'])}. Effort order is {_code_list(content['effort_order'])}. Dependency evidence is classified as {_code_list(content['dependency_evidence'])}.",
+        "",
+        "## Selection inputs",
+        "",
+    ]
+    _append_table(
+        lines,
+        ["Input", "Project field"],
+        [[_human_name(key), value] for key, value in content["fields"].items()],
+    )
+    lines.extend([
+        "## Selection profiles",
+        "",
+        "Profiles reuse the same rule catalog but apply different subsets and preserve profile-specific failure reasons where the source contract requires them.",
+        "",
+    ])
+    profile_rows = []
+    for name, profile in content["profiles"].items():
+        overrides = "; ".join(f"`{key}` maps to `{value}`" for key, value in profile["reason_overrides"].items()) or "None"
+        profile_rows.append([_human_name(name), _code_list(profile["rules"]), overrides])
+    _append_table(lines, ["Profile", "Rules in order", "Reason overrides"], profile_rows)
+    lines.extend([
+        "## Rule catalog",
+        "",
+    ])
+    _append_table(
+        lines,
+        ["Rule", "Kind", "Requirement", "Failure reason"],
+        [[f"`{rule['id']}`", f"`{rule['kind']}`", rule["definition"], f"`{rule['reason_code']}`" if rule["reason_code"] is not None else "None"] for rule in content["rules"]],
+    )
+    return lines
+
+
+def _render_authority_policy(content: dict[str, Any]) -> list[str]:
+    lines = [
+        "Authority determines which system may change a fact. Reconciliation then compares provider state with those owners and reports drift instead of choosing a new truth. Generated documentation stays downstream of every canonical source.",
+        "",
+        "## Authority principles",
+        "",
+    ]
+    lines.extend(f"- {item}" for item in content["principles"])
+    lines.extend(["", "## Change-governance handoff", ""])
+    change = content["change_governance"]
+    lines.append(f"Work Management carries change-planning data into repository governance, but repository change governance owns the governed change facts once a change exists. This projection uses change-governance schema version `{change['schema_version']}`.")
+    lines.append("")
+    complexity_rows = []
+    for name, value in change["complexities"].items():
+        complexity_rows.append([
+            _human_name(name),
+            value["description"],
+            _text_list(value["artifacts"]),
+            _text_list(value["base_reviews"]),
+            value["max_verifications"],
+        ])
+    _append_table(lines, ["Complexity", "Meaning", "Artifacts", "Base reviews", "Max verifications"], complexity_rows)
+    lines.extend([
+        f"Supported review types: {_code_list(change['review_types'])}.",
+        "",
+        "### Risk triggers",
+        "",
+    ])
+    risk_rows = [[_human_name(name), value["description"], _code_list(value["reviews"])] for name, value in change["risk_triggers"].items()]
+    _append_table(lines, ["Risk trigger", "When it applies", "Required review"], risk_rows)
+
+    schema = content["github_project_schema"]
+    lines.extend([
+        "## GitHub Project schema",
+        "",
+        f"The configured Project schema belongs to portfolio `{schema['portfolio_id']}` and uses schema version `{schema['schema_version']}`. Fields and allowed single-select options are explicit so provider drift can be detected.",
+        "",
+    ])
+    _append_table(
+        lines,
+        ["Field", "Type", "Options"],
+        [[field["name"], f"`{field['type']}`", _text_list(field["options"]) if field["options"] else "Not applicable"] for field in schema["fields"]],
+    )
+    lines.extend([
+        "### Project views",
+        "",
+        "Views are derived navigation surfaces over the same Project data. Their filters and visible fields do not create new authority.",
+        "",
+    ])
+    view_rows = []
+    for view in schema["views"]:
+        grouping_parts = []
+        if view["group_by"]:
+            grouping_parts.append(f"group by {_text_list(view['group_by'])}")
+        if view["vertical_group_by"]:
+            grouping_parts.append(f"vertical group by {_text_list(view['vertical_group_by'])}")
+        if view["sort_by"]:
+            grouping_parts.append(f"sort by {_text_list(view['sort_by'])}")
+        grouping = "; ".join(grouping_parts) or "None"
+        view_rows.append([view["name"], view["purpose"], f"`{view['layout']}`", view["filter"], grouping, _text_list(view["visible_fields"])])
+    _append_table(lines, ["View", "Purpose", "Layout", "Filter", "Grouping / sort", "Visible fields"], view_rows)
+
+    bindings = content["project_bindings"]
+    lines.extend([
+        "## Project bindings",
+        "",
+        f"Project integration is {'enabled' if bindings['enabled'] else 'disabled'} for portfolio `{bindings['portfolio_id']}` under schema version `{bindings['schema_version']}`.",
+        "",
+        "### Backend bindings",
+        "",
+    ])
+    _append_table(
+        lines,
+        ["Binding", "Provider", "Owner", "Owner type", "Project"],
+        [[item["binding_id"], f"`{item['provider']}`", item["owner"], item["owner_type"], item["project_number"]] for item in bindings["backend_bindings"]],
+    )
+    lines.extend(["### Managed projects", ""])
+    _append_table(
+        lines,
+        ["Project ID", "Display name", "Repository", "Local root", "Backend"],
+        [[item["project_id"], item["display_name"], item["repository"], f"`{item['local_root']}`", item["backend_binding"]] for item in bindings["managed_projects"]],
+    )
+    lines.extend(["### Features and gates", ""])
+    _append_table(lines, ["Feature", "Mode"], [[_human_name(key), f"`{value}`"] for key, value in bindings["features"].items()])
+    _append_table(lines, ["Gate", "Strength"], [[_human_name(key), f"`{value}`"] for key, value in bindings["gates"].items()])
+    lines.extend([
+        f"Evidence collection is bounded to `{bindings['evidence']['max_file_bytes']}` bytes per file and `{bindings['evidence']['max_total_bytes']}` bytes in total.",
+        "",
+    ])
+    return lines
+
+
+def _render_provider_boundary(content: dict[str, Any]) -> list[str]:
+    command = content["command_plane"]
+    provider = content["provider_contract"]
+    lines = [
+        "The command plane defines the work states and fields that KIS may change. The provider boundary observes and mutates GitHub Project only through the configured read and write models; provider state does not redefine repository-owned facts.",
+        "",
+        "## Command-plane model",
+        "",
+        f"Claims use **{command['claim']['execution_owner_field']}** and {'expire automatically' if command['claim']['auto_expiry'] else 'do not expire automatically'}. The completion policy targets `{command['completion']['terminal_state']}` and {'requires' if command['completion']['require_no_active_claim_after_close'] else 'does not require'} the claim to be absent after close.",
+        "",
+        f"The command plane exposes these work states: {_code_list(command['work_states'])}. Delivery uses {_code_list(command['delivery_stages'])}.",
+        "",
+        f"The intake alias `{next(iter(command['intake_aliases']))}` maps to `{next(iter(command['intake_aliases'].values()))}`.",
+        "",
+        "### Field authority",
+        "",
+        "Each field keeps the authority and direction defined by the Work Management domain model:",
+        "",
+    ]
+    _append_table(
+        lines,
+        ["Field", "Authority", "Direction"],
+        [[field, f"`{rule['authority']}`", f"`{rule['direction']}`"] for field, rule in command["field_authority"].items()],
+    )
+
+    queue = command["queue"]
+    readiness = command["readiness"]
+    queue_state_label = "state" if len(queue["eligible_states"]) == 1 else "states"
+    lines.extend([
+        "## Queue and readiness",
+        "",
+        f"The executable queue accepts {queue_state_label} {_natural_list(queue['eligible_states'], code=True)}. It ranks by {_code_list(queue['ranking'])}, using priority order {_code_list(queue['priority_order'])} and effort order {_code_list(queue['effort_order'])}.",
+        "",
+        f"Queue inputs come from **{queue['state_field']}**, **{queue['priority_field']}**, **{queue['effort_field']}**, **{queue['created_field']}**, and **{queue['blocked_by_field']}**.",
+        "",
+        "Before the provider-backed command plane can treat work as Ready, the record **MUST** satisfy its configured readiness requirements:",
+        "",
+        f"- The source issue contains {_natural_list(readiness['required_issue_sections'], bold=True)}.",
+        f"- The Project record contains {_natural_list(readiness['required_project_fields'], bold=True)}.",
+    ])
+    if readiness["requires_dependencies_understood"]:
+        lines.append("- Dependencies are understood.")
+    lines.extend([
+        "",
+        "## State transitions",
+        "",
+        "The provider-facing command plane uses the same transition graph as the Work lifecycle chapter. The table is repeated here because the provider adapter validates these exact transitions.",
+        "",
+    ])
+    transition_rows=[]
+    for source, targets in command["transitions"].items():
+        requirement=command["transition_requirements"].get(source, [])
+        target_text = _code_list(targets) if targets else "No transitions"
+        transition_rows.append([f"`{source}`", target_text, _text_list(requirement)])
+    _append_table(lines, ["From", "Allowed next states", "Additional requirement"], transition_rows)
+
+    delivery = command["delivery"]
+    lines.extend([
+        "## Delivery projection",
+        "",
+        f"**{delivery['stage_field']}** carries the derived delivery stage. **{delivery['change_id_field']}**, **{delivery['complexity_field']}**, and **{delivery['risk_triggers_field']}** are projected from repository change governance. The change-created stage is `{delivery['change_created_stage']}` and the complete stage is `{delivery['complete_stage']}`.",
+        "",
+        "## Provider contract",
+        "",
+        f"The configured Project is `{provider['project']}`. Reads use {provider['read_model']}; writes use {provider['write_model']}.",
+        "",
+        provider["live_observation"],
+        "",
+        f"Command-plane schema version: `{command['schema_version']}`.",
+        "",
+    ])
+    return lines
+
+
+def _render_conformance(content: dict[str, Any]) -> list[str]:
+    lines = [
+        "A Work Management implementation conforms to this specification only when its source MRDs, dependencies, evidence, generated views, and lifecycle behavior pass the checks below. These checks keep human-readable documentation aligned with machine-readable authority.",
+        "",
+        "## Conformance requirements",
+        "",
+    ]
+    for index, check in enumerate(content["checks"], start=1):
+        lines.append(f"{index}. {check}")
+    lines.append("")
+    return lines
+
+
+def _render_generic(content: dict[str, Any]) -> list[str]:
+    lines = [content.get("purpose", ""), ""] if content.get("purpose") else []
+    for key, value in content.items():
+        if key == "purpose":
+            continue
+        lines.extend([f"## {_human_name(key)}", ""])
+        inline = _inline_value(value)
+        if inline is not None:
+            lines.extend([inline, ""])
+        elif isinstance(value, list):
+            lines.extend(f"- {_inline_value(item) or str(item)}" for item in value)
+            lines.append("")
+        elif isinstance(value, dict):
+            rows = [[_human_name(str(name)), _inline_value(item) or str(item)] for name, item in value.items()]
+            _append_table(lines, ["Name", "Value"], rows)
+    return lines
 
 
 def render_document(doc: dict[str, Any]) -> str:
-    content=doc["content"]
-    lines=["<!-- GENERATED — DO NOT EDIT -->",f"# {doc['_mrd']['title']}","",'<div id="enable-section-numbers" />',"","[Specification](001-specification.md) | [Documentation index](000-index.md)",""]
-    purpose=content.get("purpose")
-    if purpose: lines.extend([purpose,""])
-    for key,value in content.items():
-        if key=="purpose": continue
-        lines.extend([f"## {key.replace('_',' ').capitalize()}",""])
-        lines.extend(_render_value(value))
-    lines.extend(["## Source and authority","",f"This page projects `{doc['_mrd']['id']}` version `{doc['_mrd']['version']}`. The MRD is authoritative; this generated page has no write-back authority.",""])
+    renderers = {
+        "KIS-WORK-SEM-REG-001": _render_domain_model,
+        "KIS-WORK-WRK-STM-001": _render_lifecycle,
+        "KIS-WORK-WRK-WFL-001": _render_operations,
+        "KIS-WORK-DEC-SCR-001": _render_selection,
+        "KIS-WORK-CON-POL-001": _render_authority_policy,
+        "KIS-WORK-CTR-SVC-001": _render_provider_boundary,
+        "KIS-WORK-EVL-TST-001": _render_conformance,
+    }
+    lines = [
+        "<!-- GENERATED — DO NOT EDIT -->",
+        f"# {doc['_mrd']['title']}",
+        "",
+        '<div id="enable-section-numbers" />',
+        "",
+        "[Specification](001-specification.md) | [Documentation index](000-index.md)",
+        "",
+    ]
+    renderer = renderers.get(doc["_mrd"]["id"], _render_generic)
+    lines.extend(renderer(doc["content"]))
+    lines.extend(_source_and_authority(doc))
     return "\n".join(lines)
+
+
+def _live_project_summary(repo: WorkManagementRepository) -> str:
+    path = repo.root / "evidence" / "work-management" / "canonical-snapshot.json"
+    try:
+        observation = json.loads(path.read_text(encoding="utf-8"))["live_project_observation"]
+    except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError):
+        return "Live GitHub Project evidence is unavailable in the captured evidence set. The specification does not infer missing provider state."
+    if observation.get("status") != "observed":
+        return "Live GitHub Project evidence is unavailable in the captured evidence set. The specification does not infer missing provider state."
+    schema = observation.get("schema_status", {})
+    if observation.get("inventory_complete") is True and schema.get("ready") is True:
+        return "The captured live GitHub Project evidence is observed. Inventory is complete, and the configured Project schema is ready with no reported field, option, type, or view drift."
+    return "The captured live GitHub Project evidence is observed, but the captured inventory or schema status is not fully ready. The detailed evidence remains authoritative for the observed state."
 
 
 def build_work_management_spec(repo: WorkManagementRepository, output: Path, *, replace: bool=False) -> dict[str, Any]:
@@ -154,9 +614,67 @@ def build_work_management_spec(repo: WorkManagementRepository, output: Path, *, 
         pages=[]
         for i,doc in enumerate(docs,2):
             name=_page_name(i,doc); text=render_document(doc); (staging/name).write_text(text,encoding="utf-8"); pages.append((name,doc))
-        index=["<!-- GENERATED — DO NOT EDIT -->","# KIS Work Management Specification — documentation index","","The validated Work Management MRDs are authoritative. These pages are deterministic review projections.","","## Specification pages","","- [Specification](001-specification.md)"]+[f"- [{d['_mrd']['title']}]({n})" for n,d in pages]+["","## Traceability","","- [Build manifest](manifest.json)",""]
+        index = [
+            "<!-- GENERATED — DO NOT EDIT -->",
+            "# KIS Work Management Specification — documentation index",
+            "",
+            "Start with the [Specification](001-specification.md) for the operating model. The remaining chapters provide the detailed lifecycle, selection, authority, provider, and conformance rules.",
+            "",
+            "The validated Work Management MRDs remain authoritative. These pages are deterministic review projections and have no write-back authority.",
+            "",
+            "## Specification pages",
+            "",
+            "- [Specification](001-specification.md)",
+        ] + [f"- [{d['_mrd']['title']}]({n})" for n, d in pages] + [
+            "",
+            "## Traceability",
+            "",
+            "- [Build manifest](manifest.json) — exact MRD and generated-file hashes",
+            "",
+        ]
         (staging/'000-index.md').write_text("\n".join(index),encoding='utf-8')
-        root=["<!-- GENERATED — DO NOT EDIT -->","# KIS Work Management Specification","",'<div id="enable-section-numbers" />',"","Governed operating specification for work intake, state, selection, delivery, reconciliation, and GitHub Project integration.","",'The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", and "OPTIONAL" are normative when they appear in all capitals.',"","## Overview","","Work Management separates command authority from evidence. It governs work-item semantics, lifecycle state, deterministic selection, provider reconciliation, delivery evidence, and closeout while keeping repository change governance authoritative for governed change facts.","","The specification is generated from seven prescriptive MRDs harvested from the pinned `kis-mcp` implementation contracts. Live GitHub Project evidence that could not be observed remains explicitly unavailable rather than inferred.","","## Detailed specification",""]+[f"- [{d['_mrd']['title']}]({n})" for n,d in pages]+["","## Traceability","","See the [documentation index](000-index.md) and [build manifest](manifest.json) for source identities and hashes.",""]
+        root = [
+            "<!-- GENERATED — DO NOT EDIT -->",
+            "# KIS Work Management Specification",
+            "",
+            '<div id="enable-section-numbers" />',
+            "",
+            "Work Management is the governed KIS system for capturing, classifying, selecting, executing, verifying, and closing work across registered projects.",
+            "",
+            'The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", and "OPTIONAL" are normative when they appear in all capitals.',
+            "",
+            "## Overview",
+            "",
+            "Work Management gives work one shared lifecycle and one explicit authority model. It separates facts that Work Management may change from evidence observed from GitHub, repository change governance, verification, and derived delivery state.",
+            "",
+            "A GitHub Project provides the shared provider surface, but it does not become the owner of every fact displayed there. Repository change governance remains authoritative for governed change identity, complexity, and risk; GitHub remains authoritative for provider-native source identity and dependency observations; verification systems own their evidence; and Work Management owns its command fields.",
+            "",
+            _live_project_summary(repo),
+            "",
+            "## Key concepts",
+            "",
+            "- **Command data** is changed through Work Management operations, such as status, priority, effort, claims, holds, and deferrals.",
+            "- **Evidence data** is observed or projected from its owning source, such as GitHub source identity, repository change facts, verification, and delivery state.",
+            "- **Handoff data** begins as Work Management planning data and becomes repository-owned evidence when a governed change takes authority for it.",
+            "- **Generated documentation** explains and indexes the governed model. It never writes facts back to Work Management or its sources.",
+            "",
+            "## How work moves",
+            "",
+            "1. Capture work and classify it before it enters the executable queue.",
+            "2. Admit work to Ready only after the required source sections, Project fields, and dependency evidence are present.",
+            "3. Select Ready work deterministically, then establish an execution claim before activation.",
+            "4. Track repository delivery and source verification as evidence without replacing the Work lifecycle state.",
+            "5. After merge, reconcile any required documentation and live-verification obligations before the configured completion gates allow Done.",
+            "",
+            "## Detailed specification",
+            "",
+        ] + [f"- [{d['_mrd']['title']}]({n})" for n, d in pages] + [
+            "",
+            "## Traceability",
+            "",
+            "See the [documentation index](000-index.md) and [build manifest](manifest.json) for exact source identities, MRD versions, hashes, and generated-file declarations.",
+            "",
+        ]
         spec="\n".join(root); (staging/'001-specification.md').write_text(spec,encoding='utf-8'); (staging/'specification.md').write_text(spec,encoding='utf-8')
         files=[]
         for path in sorted(staging.rglob('*')):

--- a/tests/test_work_management_spec.py
+++ b/tests/test_work_management_spec.py
@@ -38,10 +38,77 @@ def test_generated_spec_is_human_readable(tmp_path):
     repo=WorkManagementRepository(ROOT); out=tmp_path/"build"
     build_work_management_spec(repo,out)
     domain=(out/"002-work-management-domain-model.md").read_text(encoding="utf-8")
+    lifecycle=(out/"003-work-lifecycle.md").read_text(encoding="utf-8")
+    operations=(out/"004-work-operations.md").read_text(encoding="utf-8")
+    selection=(out/"005-next-work-selection.md").read_text(encoding="utf-8")
+    authority=(out/"006-authority-and-reconciliation-policy.md").read_text(encoding="utf-8")
+    conformance=(out/"008-work-management-conformance.md").read_text(encoding="utf-8")
+
     assert "<!-- GENERATED — DO NOT EDIT -->" in domain
+    assert "Work Management uses three authority directions" in domain
+    assert "| Field | Meaning | Authority | Direction |" in domain
+    assert "\n### Status\n" not in domain
+    assert "**Id:**" not in domain
+    assert "A work item moves through explicit states" in lifecycle
+    assert "| State | Meaning | GitHub Project status |" in lifecycle
+    assert "Work Management exposes a bounded set of operations" in operations
+    assert "| Operation | Purpose | Effect | Implementation surface |" in operations
+    assert "Selection is deterministic" in selection
+    assert "1. Keep only candidates" in selection
+    assert "Authority determines which system may change a fact" in authority
+    assert "| Field | Type | Options |" in authority
+    assert "A Work Management implementation conforms" in conformance
+    assert "1. MRD envelopes validate" in conformance
     assert "- `{\"" not in domain
-    assert "**Authority:** work_management" in domain
-    assert "### Status" in domain
+    for page in (domain, lifecycle, operations, selection, authority, conformance):
+        assert " | ? |" not in page
+        assert " ? " not in page
+
+
+def test_root_spec_reports_observed_project_evidence(tmp_path):
+    repo=WorkManagementRepository(ROOT); out=tmp_path/"build"
+    build_work_management_spec(repo,out)
+    spec=(out/"001-specification.md").read_text(encoding="utf-8")
+    assert "The captured live GitHub Project evidence is observed" in spec
+    assert "could not be observed" not in spec
+
+def test_generated_spec_preserves_reference_facts(tmp_path):
+    repo=WorkManagementRepository(ROOT); out=tmp_path/"build"
+    build_work_management_spec(repo,out)
+    docs=repo.load()
+
+    domain=(out/"002-work-management-domain-model.md").read_text(encoding="utf-8")
+    for field in docs["KIS-WORK-SEM-REG-001"]["content"]["fields"]:
+        assert field["name"] in domain
+        assert f"`{field['id']}`" in domain
+    for vocabulary in docs["KIS-WORK-SEM-REG-001"]["content"]["vocabularies"]:
+        for value in vocabulary["values"]:
+            assert value["label"] in domain
+            assert f"`{value['token']}`" in domain
+
+    lifecycle=(out/"003-work-lifecycle.md").read_text(encoding="utf-8")
+    for guard in docs["KIS-WORK-WRK-STM-001"]["content"]["guards"]:
+        assert f"`{guard['id']}`" in lifecycle
+        assert f"`{guard['reason_code']}`" in lifecycle
+
+    operations=(out/"004-work-operations.md").read_text(encoding="utf-8")
+    for operation in docs["KIS-WORK-WRK-WFL-001"]["content"]["operations"]:
+        assert f"`{operation['id']}`" in operations
+        assert f"`{operation['implementation_surface']}`" in operations
+
+    selection=(out/"005-next-work-selection.md").read_text(encoding="utf-8")
+    for rule in docs["KIS-WORK-DEC-SCR-001"]["content"]["rules"]:
+        assert f"`{rule['id']}`" in selection
+        if rule["reason_code"] is not None:
+            assert f"`{rule['reason_code']}`" in selection
+
+    authority=(out/"006-authority-and-reconciliation-policy.md").read_text(encoding="utf-8")
+    policy=docs["KIS-WORK-CON-POL-001"]["content"]
+    for field in policy["github_project_schema"]["fields"]:
+        assert field["name"] in authority
+    for view in policy["github_project_schema"]["views"]:
+        assert view["name"] in authority
+
 
 def test_snapshot_pins_parent_revision_and_live_project_state():
     data=json.loads((ROOT/"evidence/work-management/canonical-snapshot.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- make the generated Work Management Specification prose-first rather than a recursive MRD/schema rendering
- add concern-specific chapters for the domain model, lifecycle, operations, selection, authority/reconciliation, provider boundary, and conformance
- preserve governed identifiers and reference facts in compact tables while removing repetitive field-by-field headings
- correct the stale live GitHub Project observation wording
- keep generated documentation downstream of MRD authority with deterministic stale/tamper checks

## Verification

- `scripts/verify.ps1` passes on exact commit `22f19eb8cc627aec60e8c975ad56e64797e4a671`
- full `pytest -q` passes
- focused Work Management HRD tests pass, including reference-fact preservation and live-evidence wording
- manual exact-diff documentation review found no raw JSON/schema-dump artifacts or malformed placeholder cells

The automated documentation review backend was not invoked because its evidence projector omitted changed files; the required manual exact-diff fallback was completed instead.