### PR TITLE
008 — Documentation Reference Standard

### DIFF
--- a/.work/changes/008-documentation-reference-standard/change.mrd.json
+++ b/.work/changes/008-documentation-reference-standard/change.mrd.json
@@ -1,251 +1,448 @@
 {
-  "_mrd": {
-    "schema_version": 1,
-    "id": "KIS-CHG008-WRK-WFL-001",
-    "title": "Documentation Reference Standard preparation",
-    "module": "change-008",
-    "class": "WRK",
-    "type": "WFL",
-    "layer": "L3",
-    "record_mode": "descriptive",
-    "status": "active",
-    "version": "1.0.0",
-    "dependencies": [
-      {"mrd_id": "KIS-KNOW-WRK-WFL-001", "relationship": "depends_on"},
-      {"mrd_id": "KIS-KNOW-CON-POL-002", "relationship": "depends_on"},
-      {"mrd_id": "KIS-CHG005-WRK-WFL-001", "relationship": "depends_on"},
-      {"mrd_id": "KIS-KNOW-EVL-TST-001", "relationship": "validated_by"}
-    ],
-    "provenance": {
-      "sources": [
-        {
-          "source_id": "KIS-OPERATOR-DIRECTION-2026-08-26-DOCUMENTATION-REFERENCE-STANDARD",
-          "kind": "operator_direction",
-          "role": "approved_change_basis",
-          "locator": "conversation:2026-08-26",
-          "revision": "documentation-reference-standard-approved",
-          "sha256": null
-        },
-        {
-          "source_id": "GH-ISSUE-12",
-          "kind": "operator_approved_work_item",
-          "role": "approved_change_basis",
-          "locator": "github:NielPieterse0/kis-mcp-doc#12",
-          "revision": "2026-08-26",
-          "sha256": null
-        },
-        {
-          "source_id": "MCP-SPEC-2026-07-28",
-          "kind": "external_reference",
-          "role": "normative_protocol_reference",
-          "locator": "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean",
-          "revision": "2026-07-28",
-          "sha256": null
-        },
-        {
-          "source_id": "GOOGLE-DEVELOPER-DOCUMENTATION-STYLE-GUIDE",
-          "kind": "external_reference",
-          "role": "prescriptive_writing_reference",
-          "locator": "C:/Projects/References/google-developer-style-guide",
-          "revision": "captured-corpus",
-          "sha256": null
-        },
-        {
-          "source_id": "KIS-EXTERNAL-MCP-DOC-RESEARCH-2026-08-26",
-          "kind": "research_evidence",
-          "role": "implementation_reference_selection",
-          "locator": "conversation:2026-08-26",
-          "revision": "comparative-mcp-documentation-research",
-          "sha256": null
-        }
-      ],
-      "source_fingerprint": "sha256:d77b758a7d1cd8c8c4372fb66b45e0750a4511219d83c4a47e38370f01df3bfe",
-      "fact_quality": "direct"
-    },
-    "supersedes": [],
-    "superseded_by": null
-  },
-  "content": {
-    "change_id": "008-documentation-reference-standard",
-    "work_item": {
-      "repository": "NielPieterse0/kis-mcp-doc",
-      "issue": 12,
-      "project": "NielPieterse0/1",
-      "record_id": "SPEC-008"
-    },
-    "outcome": "Prepare a governed Documentation Reference Standard so future KIS documentation can use normative protocol sources, writing guidance, and external MCP implementation examples without confusing evidence with authority.",
-    "preparation_boundary": [
-      "This change currently creates planning and change-definition records only.",
-      "No canonical MRD, contract, schema, harvest registry, publication profile, generator, renderer, generated document, runtime behavior, or test behavior is changed during preparation.",
-      "The later implementation MUST enter through a separately approved implementation step within this governed change or a successor change, depending on review outcome."
-    ],
-    "problem": [
-      "KIS has authoritative source and provenance rules, a captured MCP 2026 reference corpus, a captured Google style corpus, and an existing harvest-source registry, but it does not yet prescribe one documentation-specific contract for how those sources and external implementation examples may influence generated documentation.",
-      "Without that contract, useful external patterns can become informal tribal knowledge, reference roles can overlap, and future generators can accidentally duplicate source facts or elevate non-normative evidence into apparent KIS authority.",
-      "The standard must make the source role, permitted use, provenance, freshness, and conflict behavior explicit before the external reference set is used to reshape additional KIS HRDs."
-    ],
-    "authority_model": [
-      "KIS canonical sources and adopted KIS MRDs own KIS-specific facts, behavior, policy, configuration, and lifecycle semantics.",
-      "The pinned MCP 2026-07-28 specification is normative for MCP protocol conformance within the protocol concerns it defines. It is not authority for unrelated KIS product behavior.",
-      "KIS repository and documentation governance controls how KIS-owned documentation is produced and how external evidence is classified.",
-      "The Google Developer Documentation Style Guide is prescriptive presentation guidance for human-facing prose where higher KIS authority does not prescribe a different form. It does not define KIS behavior.",
-      "External MCP implementations are non-normative evidence and design references. They may demonstrate useful documentation structures and engineering patterns, but they cannot create or override KIS facts.",
-      "Model-generated, semantic-provider, DeepWiki/Litho, Graphify, and similar inferred material remains advisory or inferred evidence until verified against an owning source and explicitly adopted through KIS governance."
-    ],
-    "candidate_source_roles": [
-      {"role": "canonical_kis", "meaning": "KIS-owned canonical fact or adopted prescriptive MRD", "may_define_kis_facts": true},
-      {"role": "normative_external", "meaning": "External standard that is normative within a bounded conformance domain such as MCP", "may_define_kis_facts": false},
-      {"role": "prescriptive_external", "meaning": "External guidance that prescribes presentation or practice without owning KIS behavior", "may_define_kis_facts": false},
-      {"role": "implementation_reference", "meaning": "External implementation used to study reusable patterns", "may_define_kis_facts": false},
-      {"role": "inferred_evidence", "meaning": "Derived, semantic, or model-generated evidence requiring verification", "may_define_kis_facts": false}
-    ],
-    "requirements": [
-      "R1: The future Documentation Reference Standard MUST define source roles, authority boundaries, permitted uses, provenance requirements, freshness requirements, and conflict behavior for every admitted documentation reference.",
-      "R2: KIS-owned behavior and factual generated reference content MUST remain sourced from the current canonical KIS owner or an adopted KIS MRD; a documentation reference MUST NOT become a second fact owner.",
-      "R3: MCP 2026-07-28 MUST be treated as normative within its applicable protocol-conformance domain, while remaining non-authoritative for KIS-specific behavior outside that domain.",
-      "R4: Google Developer Documentation Style Guide material MUST be treated as prescriptive writing guidance only and MUST NOT define KIS semantics, state, policy, or runtime behavior.",
-      "R5: External implementation references MUST be explicitly non-normative and MUST NOT populate canonical KIS facts, generated factual reference tables, or normative requirements without a separate evidence-backed adoption decision.",
-      "R6: Each external implementation reference MUST have a bounded role that states which documentation concern it may inform; the repository MUST NOT adopt an external project as a general undocumented template.",
-      "R7: The future standard MUST provide a versioned machine-readable reference registry whose semantic role is distinct from acquisition metadata in publication/harvest-sources.json and whose entries can reference existing harvest-source identities instead of duplicating them.",
-      "R8: Material used by deterministic builds MUST be pinned to reproducible revisions or content hashes when the source supports them; documentation builds MUST NOT silently depend on live moving web content.",
-      "R9: The reference registry MUST support add, update, deprecate, supersede, and remove lifecycle states without erasing historical provenance.",
-      "R10: The documentation system MUST distinguish human task/concept documentation, human-readable normative specifications, and exact generated reference material because each output class has different source and presentation rules.",
-      "R11: Exact generated reference material for tools, schemas, settings, policies, states, relationships, capabilities, and permissions MUST derive from canonical KIS facts rather than external examples or independently maintained prose.",
-      "R12: Human-readable normative specifications MUST preserve the strength and meaning of adopted KIS requirements while explaining concepts in prose before dense reference detail where appropriate.",
-      "R13: Human task and concept documentation MAY use workflow and presentation patterns from approved implementation references but MUST preserve KIS terminology, behavior, authority, and provenance.",
-      "R14: Contradictions between a reference and a canonical owner MUST surface as diagnostics or review findings; the system MUST NOT silently normalize the canonical fact to match the reference.",
-      "R15: Validation MUST prevent implementation_reference, prescriptive_external, and inferred_evidence material from being promoted to canonical KIS fact solely because it appears in generated documentation.",
-      "R16: A generated human-review page MUST explain the official reference set, each source role, permitted uses, authority limits, provenance, and lifecycle without becoming write-back authority.",
-      "R17: External-source licensing, attribution, and copying constraints MUST be recorded before source material is harvested beyond metadata or small evidence excerpts.",
-      "R18: This preparation slice MUST NOT implement any of the future registry, schema, generator, validator, renderer, harvest, or publication behavior described by these requirements."
-    ],
-    "reference_set": [
-      {"id": "mcp-2026", "name": "Model Context Protocol 2026-07-28", "role": "normative_external", "use_for": ["protocol_conformance", "specification_structure", "normative_presentation", "schema_reference"]},
-      {"id": "google-developer-style", "name": "Google Developer Documentation Style Guide", "role": "prescriptive_external", "use_for": ["human_prose", "task_documentation", "headings", "lists", "tables", "cross_references"]},
-      {"id": "sentry-mcp", "name": "Sentry MCP", "role": "implementation_reference", "use_for": ["documentation_architecture", "engineering_documentation", "operations", "security"]},
-      {"id": "github-mcp", "name": "GitHub MCP Server", "role": "implementation_reference", "use_for": ["tool_reference", "configuration_reference", "generated_documentation", "stale_detection"]},
-      {"id": "azure-mcp", "name": "Azure MCP Server", "role": "implementation_reference", "use_for": ["large_scale_reference", "generated_reference", "drift_control"]},
-      {"id": "playwright-mcp", "name": "Playwright MCP", "role": "implementation_reference", "use_for": ["task_oriented_documentation", "getting_started", "generated_tool_reference"]},
-      {"id": "atlassian-rovo-mcp", "name": "Atlassian Rovo MCP", "role": "implementation_reference", "use_for": ["permissions_presentation", "capability_catalogue", "discover_execute_patterns"]},
-      {"id": "figma-mcp", "name": "Figma MCP", "role": "implementation_reference", "use_for": ["workflow_oriented_documentation", "task_grouping"]},
-      {"id": "aws-labs-mcp", "name": "AWS Labs MCP", "role": "implementation_reference", "use_for": ["multi_module_consistency", "repeatable_server_documentation"]},
-      {"id": "cloudflare-mcp", "name": "Cloudflare MCP", "role": "implementation_reference", "use_for": ["tool_surface_scaling", "context_budget", "dynamic_discovery"]}
-    ],
-    "reference_locators": [
-      {"id": "sentry-mcp", "locator": "https://github.com/getsentry/sentry-mcp"},
-      {"id": "github-mcp", "locator": "https://github.com/github/github-mcp-server"},
-      {"id": "azure-mcp", "locator": "https://github.com/microsoft/mcp"},
-      {"id": "playwright-mcp", "locator": "https://github.com/microsoft/playwright-mcp"},
-      {"id": "atlassian-rovo-mcp", "locator": "https://developer.atlassian.com/cloud/rovo-mcp/guides/supported-tools/"},
-      {"id": "figma-mcp", "locator": "https://developers.figma.com/docs/figma-mcp-server/"},
-      {"id": "aws-labs-mcp", "locator": "https://github.com/awslabs/mcp"},
-      {"id": "cloudflare-mcp", "locator": "https://github.com/cloudflare/mcp"}
-    ],
-    "decisions": [
-      "D1: Use domain-scoped authority rather than a single total precedence list. KIS owns KIS facts; MCP owns MCP conformance requirements within its domain; writing guidance and implementation references cannot override either owner.",
-      "D2: Register external implementation references by bounded documentation concern instead of treating any repository as the KIS documentation template.",
-      "D3: Keep documentation-reference semantics distinct from harvest/acquisition semantics. The future reference registry should reference harvest-source identities and provenance rather than duplicate retrieval configuration.",
-      "D4: Require pinned or hashed evidence for deterministic generation; live web access may support research and refresh workflows but not silent build-time authority.",
-      "D5: Define three human output classes: task/concept documentation, human-readable specification, and generated reference. Their presentation may differ, but each remains downstream of governed sources.",
-      "D6: Adopt the initial ten-source reference set in this change as the proposed official baseline for later implementation review, with MCP and Google carrying specialized external roles and the eight implementation sources remaining non-normative.",
-      "D7: Do not copy external documentation wholesale. Harvest only the bounded patterns, metadata, or evidence needed for an approved use and preserve source provenance and licensing constraints.",
-      "D8: The standard itself must be machine-readable authority first and a generated human-review surface second. No hand-authored durable Markdown is introduced."
-    ],
-    "output_classes": [
-      {
-        "class": "human_documentation",
-        "purpose": "Teach concepts, tasks, workflows, examples, architecture, and operations in reader-oriented prose.",
-        "source_rule": "Canonical KIS facts provide factual content; approved external references may inform organization and presentation only."
-      },
-      {
-        "class": "human_readable_specification",
-        "purpose": "Explain adopted normative KIS behavior while preserving requirement strength, identifiers, ownership, and traceability.",
-        "source_rule": "Adopted KIS MRDs and applicable normative external standards provide requirements; presentation remains generated and non-authoritative."
-      },
-      {
-        "class": "generated_reference",
-        "purpose": "Expose exact tools, schemas, settings, policies, states, relationships, capabilities, permissions, and provenance.",
-        "source_rule": "Only canonical KIS facts or explicitly applicable normative protocol facts may populate factual reference data."
-      }
-    ],
-    "reference_basis": [
-      "C:/Projects/kis-mcp-doc/AGENTS.md for source classification, authority, harvest posture, generated-view rules, and the MCP 2026 presentation mandate.",
-      "C:/Projects/kis-mcp-doc/mrd/governance/** for KIS MRD classification, ownership, provenance, lifecycle, dependencies, applicability, and validation semantics.",
-      "C:/Projects/kis-mcp-doc/publication/harvest-sources.json for the existing machine-readable acquisition/source inventory that the future semantic reference registry must complement rather than duplicate.",
-      "C:/Projects/kis-mcp-doc/.work/changes/005-mcp-spec-2026-baseline/change.mrd.json for the adopted MCP 2026-07-28 documentation/specification baseline.",
-      "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean/markdown/025-specification-specification.md for specification vocabulary and normative-keyword conventions.",
-      "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean/markdown/029-specification-overview.md for protocol structure and current MCP request/result conventions.",
-      "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean/markdown/030-specification-versioning-and-compatibility.md for date-based protocol versioning and compatibility presentation.",
-      "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean/markdown/055-specification-schema-reference.md for the current MCP 2026 schema-reference model.",
-      "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean/markdown/056-extensions-extensions-overview.md for bounded optional-extension and explicit-negotiation patterns.",
-      "C:/Projects/References/google-developer-style-guide/014-prescriptive-documentation.md for task-focused prescriptive documentation.",
-      "C:/Projects/References/google-developer-style-guide/017-tone.md and 019-voice.md for professional tone and active voice.",
-      "C:/Projects/References/google-developer-style-guide/030-sentence-structure.md and 052-paragraph-structure.md for focused sentence and paragraph construction.",
-      "C:/Projects/References/google-developer-style-guide/046-headings.md, 048-lists.md, 055-tables.md, and 057-cross-references.md for scannable structure and references.",
-      "Comparative research completed on 2026-08-26 for Sentry MCP, GitHub MCP Server, Azure MCP Server, Playwright MCP, Atlassian Rovo MCP, Figma MCP, AWS Labs MCP, and Cloudflare MCP."
-    ],
-    "future_implementation_plan": [
-      "P1: Define the machine-readable Documentation Reference Standard and reference-registry schema using the minimum sufficient existing MRD types and repository contract conventions.",
-      "P2: Bind the reference registry to existing harvest-source identities and add role, bounded-use, provenance, freshness, lifecycle, licensing, and supersession semantics without duplicating acquisition configuration.",
-      "P3: Pin the approved external implementation evidence to exact revisions or content hashes and record refresh policy.",
-      "P4: Add validation that blocks non-normative or inferred reference material from becoming canonical KIS facts without explicit adoption through the owning authority.",
-      "P5: Add deterministic generation of the human-readable Documentation Reference Standard and reference catalogue from validated machine-readable authority.",
-      "P6: Add tests for authority separation, provenance, deterministic generation, stale/tamper detection, reference lifecycle, and conflict diagnostics.",
-      "P7: After the standard is reviewed and implemented, use it as the governed basis for later HRD/documentation refinements rather than changing Work Management HRDs in this change."
-    ],
-    "tasks": [
-      {"id": "T0", "status": "done", "text": "Raise the governed change and GitHub issue, load the documentation skill, and review the applicable MCP 2026 and Google Developer Documentation references."},
-      {"id": "T1", "status": "pending", "text": "Select the minimum sufficient KIS MRD types and define the prescriptive Documentation Reference Standard authority model."},
-      {"id": "T2", "status": "pending", "text": "Define the versioned reference-registry contract and its relationship to publication/harvest-sources.json."},
-      {"id": "T3", "status": "pending", "text": "Pin and classify the approved external implementation reference evidence, including licensing and refresh metadata."},
-      {"id": "T4", "status": "pending", "text": "Implement validation and deterministic generation for the standard and human review surface."},
-      {"id": "T5", "status": "pending", "text": "Verify authority separation, source coverage, provenance, determinism, drift handling, and generated readability before review."}
-    ],
-    "risks": [
-      "Authority confusion: readers or generators could mistake an external implementation example for KIS authority unless source roles are explicit and enforced.",
-      "Registry duplication: a new semantic reference registry could drift from publication/harvest-sources.json if identities and ownership are not linked cleanly.",
-      "Reference churn: external repositories and product documentation change independently and can make unpinned examples stale.",
-      "Overfitting: copying one external project's information architecture could distort KIS concepts or create unnecessary structure.",
-      "Licensing and attribution: harvested external content may carry reuse restrictions that differ from metadata-only reference use.",
-      "Generated-authority inversion: a polished HRD can appear authoritative unless the publication contract keeps write-back and fact ownership explicit."
-    ],
-    "future_acceptance": [
-      "Every admitted documentation source has one explicit role, bounded permitted use, provenance identity, freshness strategy, and lifecycle state.",
-      "The official reference set distinguishes MCP normative protocol authority, Google prescriptive writing guidance, and non-normative implementation references.",
-      "The semantic reference registry does not duplicate harvest acquisition facts and can resolve its source identities to reproducible evidence.",
-      "No implementation reference or inferred evidence can populate canonical KIS factual reference content without an explicit governed adoption path.",
-      "Task documentation, human-readable specification, and generated reference have distinct source and presentation contracts.",
-      "The human-readable Documentation Reference Standard is generated from validated machine-readable authority and explains the model in plain English.",
-      "External-reference conflicts, stale evidence, missing hashes, and unsupported authority promotions fail visibly rather than being silently accepted.",
-      "Deterministic generation, provenance, stale/tamper checks, schema validation, and repository verification pass."
-    ],
-    "preparation_acceptance": [
-      "Change 008 exists in an isolated branch-backed worktree and owns only .work/changes/008-documentation-reference-standard/**.",
-      "GitHub issue 12 records the same preparation-only outcome and reference basis.",
-      "The change records the approved initial reference set and bounded roles for every reference.",
-      "The change records the MCP 2026, Google Developer Documentation, KIS governance, harvest-registry, and external comparative research basis used to prepare it.",
-      "The change defines authority separation, future registry semantics, output classes, validation expectations, implementation plan, risks, and later acceptance criteria without implementing them.",
-      "No tracked file outside the change directory is modified by this preparation."
-    ],
-    "out_of_scope_for_preparation": [
-      "Creating or adopting prescriptive documentation-reference MRDs outside this change directory.",
-      "Creating the future reference-registry schema or modifying publication/harvest-sources.json.",
-      "Harvesting or vendoring external implementation documentation into the repository.",
-      "Changing the publication contract, generator, renderer, generated HRDs, or generated reference pages.",
-      "Changing Work Management documentation, Work Management behavior, or GitHub Project configuration.",
-      "Changing MCP/FastMCP runtime protocol behavior or adopting new MCP 2026 runtime features.",
-      "Adding validators, tests, CI behavior, or source-code implementation for the future standard."
-    ],
-    "closeout": {
-      "state": "prepared_for_review",
-      "verification": [],
-      "reviews": [],
-      "publication": null,
-      "merge": null,
-      "unresolved": [
-        "GitHub issue 12 is created, but governed Work Management Project capture is blocked by GITHUB_PROJECT_MANAGEMENT_INVALID_COMMAND because the source repository NielPieterse0/kis-mcp-doc does not match the current kis-mcp Project repository binding. Do not bypass this boundary; resolve it through Work Management governance before relying on Project state for this change.",
-        "The exact MRD type set and canonical on-disk location for the future semantic reference registry remain implementation-design decisions to resolve in T1-T2 using minimum-sufficient selection and existing ownership rules."
-      ]
-    }
-  }
+    "_mrd":  {
+                 "schema_version":  1,
+                 "id":  "KIS-CHG008-WRK-WFL-001",
+                 "title":  "Documentation Reference Standard",
+                 "module":  "change-008",
+                 "class":  "WRK",
+                 "type":  "WFL",
+                 "layer":  "L3",
+                 "record_mode":  "descriptive",
+                 "status":  "active",
+                 "version":  "1.1.0",
+                 "dependencies":  [
+                                      {
+                                          "mrd_id":  "KIS-KNOW-WRK-WFL-001",
+                                          "relationship":  "depends_on"
+                                      },
+                                      {
+                                          "mrd_id":  "KIS-KNOW-CON-POL-002",
+                                          "relationship":  "depends_on"
+                                      },
+                                      {
+                                          "mrd_id":  "KIS-CHG005-WRK-WFL-001",
+                                          "relationship":  "depends_on"
+                                      },
+                                      {
+                                          "mrd_id":  "KIS-KNOW-EVL-TST-001",
+                                          "relationship":  "validated_by"
+                                      }
+                                  ],
+                 "provenance":  {
+                                    "sources":  [
+                                                    {
+                                                        "source_id":  "KIS-OPERATOR-DIRECTION-2026-08-26-DOCUMENTATION-REFERENCE-STANDARD",
+                                                        "kind":  "operator_direction",
+                                                        "role":  "approved_change_basis",
+                                                        "locator":  "conversation:2026-08-26",
+                                                        "revision":  "documentation-reference-standard-approved",
+                                                        "sha256":  null
+                                                    },
+                                                    {
+                                                        "source_id":  "GH-ISSUE-12",
+                                                        "kind":  "operator_approved_work_item",
+                                                        "role":  "approved_change_basis",
+                                                        "locator":  "github:NielPieterse0/kis-mcp-doc#12",
+                                                        "revision":  "2026-08-26",
+                                                        "sha256":  null
+                                                    },
+                                                    {
+                                                        "source_id":  "MCP-SPEC-2026-07-28",
+                                                        "kind":  "external_reference",
+                                                        "role":  "normative_protocol_reference",
+                                                        "locator":  "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean",
+                                                        "revision":  "2026-07-28",
+                                                        "sha256":  null
+                                                    },
+                                                    {
+                                                        "source_id":  "GOOGLE-DEVELOPER-DOCUMENTATION-STYLE-GUIDE",
+                                                        "kind":  "external_reference",
+                                                        "role":  "prescriptive_writing_reference",
+                                                        "locator":  "C:/Projects/References/google-developer-style-guide",
+                                                        "revision":  "captured-corpus",
+                                                        "sha256":  null
+                                                    },
+                                                    {
+                                                        "source_id":  "KIS-EXTERNAL-MCP-DOC-RESEARCH-2026-08-26",
+                                                        "kind":  "research_evidence",
+                                                        "role":  "implementation_reference_selection",
+                                                        "locator":  "conversation:2026-08-26",
+                                                        "revision":  "comparative-mcp-documentation-research",
+                                                        "sha256":  null
+                                                    }
+                                                ],
+                                    "source_fingerprint":  "sha256:d77b758a7d1cd8c8c4372fb66b45e0750a4511219d83c4a47e38370f01df3bfe",
+                                    "fact_quality":  "direct"
+                                },
+                 "supersedes":  [
+
+                                ],
+                 "superseded_by":  null
+             },
+    "content":  {
+                    "change_id":  "008-documentation-reference-standard",
+                    "work_item":  {
+                                      "repository":  "NielPieterse0/kis-mcp-doc",
+                                      "issue":  12,
+                                      "project":  "NielPieterse0/1",
+                                      "record_id":  "SPEC-008"
+                                  },
+                    "outcome":  "Implement a governed Documentation Reference Standard so KIS documentation can use normative protocol sources, writing guidance, and external MCP implementation evidence without confusing evidence with authority.",
+                    "preparation_boundary":  [
+                                                 "Preparation was completed and preserved at commit 2785a3b7a6f42b22ef48e8b151473717a7af5a1e.",
+                                                 "The operator separately authorized implementation in this governed change on 2026-08-26.",
+                                                 "Implementation remains bounded by scope.json and does not change Work Management behavior, parent KIS, reference corpora, or existing governance/work-management MRDs."
+                                             ],
+                    "problem":  [
+                                    "KIS has authoritative source and provenance rules, a captured MCP 2026 reference corpus, a captured Google style corpus, and an existing harvest-source registry, but it does not yet prescribe one documentation-specific contract for how those sources and external implementation examples may influence generated documentation.",
+                                    "Without that contract, useful external patterns can become informal tribal knowledge, reference roles can overlap, and future generators can accidentally duplicate source facts or elevate non-normative evidence into apparent KIS authority.",
+                                    "The standard must make the source role, permitted use, provenance, freshness, and conflict behavior explicit before the external reference set is used to reshape additional KIS HRDs."
+                                ],
+                    "authority_model":  [
+                                            "KIS canonical sources and adopted KIS MRDs own KIS-specific facts, behavior, policy, configuration, and lifecycle semantics.",
+                                            "The pinned MCP 2026-07-28 specification is normative for MCP protocol conformance within the protocol concerns it defines. It is not authority for unrelated KIS product behavior.",
+                                            "KIS repository and documentation governance controls how KIS-owned documentation is produced and how external evidence is classified.",
+                                            "The Google Developer Documentation Style Guide is prescriptive presentation guidance for human-facing prose where higher KIS authority does not prescribe a different form. It does not define KIS behavior.",
+                                            "External MCP implementations are non-normative evidence and design references. They may demonstrate useful documentation structures and engineering patterns, but they cannot create or override KIS facts.",
+                                            "Model-generated, semantic-provider, DeepWiki/Litho, Graphify, and similar inferred material remains advisory or inferred evidence until verified against an owning source and explicitly adopted through KIS governance."
+                                        ],
+                    "candidate_source_roles":  [
+                                                   {
+                                                       "role":  "canonical_kis",
+                                                       "meaning":  "KIS-owned canonical fact or adopted prescriptive MRD",
+                                                       "may_define_kis_facts":  true
+                                                   },
+                                                   {
+                                                       "role":  "normative_external",
+                                                       "meaning":  "External standard that is normative within a bounded conformance domain such as MCP",
+                                                       "may_define_kis_facts":  false
+                                                   },
+                                                   {
+                                                       "role":  "prescriptive_external",
+                                                       "meaning":  "External guidance that prescribes presentation or practice without owning KIS behavior",
+                                                       "may_define_kis_facts":  false
+                                                   },
+                                                   {
+                                                       "role":  "implementation_reference",
+                                                       "meaning":  "External implementation used to study reusable patterns",
+                                                       "may_define_kis_facts":  false
+                                                   },
+                                                   {
+                                                       "role":  "inferred_evidence",
+                                                       "meaning":  "Derived, semantic, or model-generated evidence requiring verification",
+                                                       "may_define_kis_facts":  false
+                                                   }
+                                               ],
+                    "requirements":  [
+                                         "R1: The future Documentation Reference Standard MUST define source roles, authority boundaries, permitted uses, provenance requirements, freshness requirements, and conflict behavior for every admitted documentation reference.",
+                                         "R2: KIS-owned behavior and factual generated reference content MUST remain sourced from the current canonical KIS owner or an adopted KIS MRD; a documentation reference MUST NOT become a second fact owner.",
+                                         "R3: MCP 2026-07-28 MUST be treated as normative within its applicable protocol-conformance domain, while remaining non-authoritative for KIS-specific behavior outside that domain.",
+                                         "R4: Google Developer Documentation Style Guide material MUST be treated as prescriptive writing guidance only and MUST NOT define KIS semantics, state, policy, or runtime behavior.",
+                                         "R5: External implementation references MUST be explicitly non-normative and MUST NOT populate canonical KIS facts, generated factual reference tables, or normative requirements without a separate evidence-backed adoption decision.",
+                                         "R6: Each external implementation reference MUST have a bounded role that states which documentation concern it may inform; the repository MUST NOT adopt an external project as a general undocumented template.",
+                                         "R7: The future standard MUST provide a versioned machine-readable reference registry whose semantic role is distinct from acquisition metadata in publication/harvest-sources.json and whose entries can reference existing harvest-source identities instead of duplicating them.",
+                                         "R8: Material used by deterministic builds MUST be pinned to reproducible revisions or content hashes when the source supports them; documentation builds MUST NOT silently depend on live moving web content.",
+                                         "R9: The reference registry MUST support add, update, deprecate, supersede, and remove lifecycle states without erasing historical provenance.",
+                                         "R10: The documentation system MUST distinguish human task/concept documentation, human-readable normative specifications, and exact generated reference material because each output class has different source and presentation rules.",
+                                         "R11: Exact generated reference material for tools, schemas, settings, policies, states, relationships, capabilities, and permissions MUST derive from canonical KIS facts rather than external examples or independently maintained prose.",
+                                         "R12: Human-readable normative specifications MUST preserve the strength and meaning of adopted KIS requirements while explaining concepts in prose before dense reference detail where appropriate.",
+                                         "R13: Human task and concept documentation MAY use workflow and presentation patterns from approved implementation references but MUST preserve KIS terminology, behavior, authority, and provenance.",
+                                         "R14: Contradictions between a reference and a canonical owner MUST surface as diagnostics or review findings; the system MUST NOT silently normalize the canonical fact to match the reference.",
+                                         "R15: Validation MUST prevent implementation_reference, prescriptive_external, and inferred_evidence material from being promoted to canonical KIS fact solely because it appears in generated documentation.",
+                                         "R16: A generated human-review page MUST explain the official reference set, each source role, permitted uses, authority limits, provenance, and lifecycle without becoming write-back authority.",
+                                         "R17: External-source licensing, attribution, and copying constraints MUST be recorded before source material is harvested beyond metadata or small evidence excerpts.",
+                                         "R18: Implementation MUST begin only after a separately approved implementation step. Preparation was preserved at commit 2785a3b7a6f42b22ef48e8b151473717a7af5a1e before that approval was exercised."
+                                     ],
+                    "reference_set":  [
+                                          {
+                                              "id":  "mcp-2026",
+                                              "name":  "Model Context Protocol 2026-07-28",
+                                              "role":  "normative_external",
+                                              "use_for":  [
+                                                              "protocol_conformance",
+                                                              "specification_structure",
+                                                              "normative_presentation",
+                                                              "schema_reference"
+                                                          ]
+                                          },
+                                          {
+                                              "id":  "google-developer-style",
+                                              "name":  "Google Developer Documentation Style Guide",
+                                              "role":  "prescriptive_external",
+                                              "use_for":  [
+                                                              "human_prose",
+                                                              "task_documentation",
+                                                              "headings",
+                                                              "lists",
+                                                              "tables",
+                                                              "cross_references"
+                                                          ]
+                                          },
+                                          {
+                                              "id":  "sentry-mcp",
+                                              "name":  "Sentry MCP",
+                                              "role":  "implementation_reference",
+                                              "use_for":  [
+                                                              "documentation_architecture",
+                                                              "engineering_documentation",
+                                                              "operations",
+                                                              "security"
+                                                          ]
+                                          },
+                                          {
+                                              "id":  "github-mcp",
+                                              "name":  "GitHub MCP Server",
+                                              "role":  "implementation_reference",
+                                              "use_for":  [
+                                                              "tool_reference",
+                                                              "configuration_reference",
+                                                              "generated_documentation",
+                                                              "stale_detection"
+                                                          ]
+                                          },
+                                          {
+                                              "id":  "azure-mcp",
+                                              "name":  "Azure MCP Server",
+                                              "role":  "implementation_reference",
+                                              "use_for":  [
+                                                              "large_scale_reference",
+                                                              "generated_reference",
+                                                              "drift_control"
+                                                          ]
+                                          },
+                                          {
+                                              "id":  "playwright-mcp",
+                                              "name":  "Playwright MCP",
+                                              "role":  "implementation_reference",
+                                              "use_for":  [
+                                                              "task_oriented_documentation",
+                                                              "getting_started",
+                                                              "generated_tool_reference"
+                                                          ]
+                                          },
+                                          {
+                                              "id":  "atlassian-rovo-mcp",
+                                              "name":  "Atlassian Rovo MCP",
+                                              "role":  "implementation_reference",
+                                              "use_for":  [
+                                                              "permissions_presentation",
+                                                              "capability_catalogue",
+                                                              "discover_execute_patterns"
+                                                          ]
+                                          },
+                                          {
+                                              "id":  "figma-mcp",
+                                              "name":  "Figma MCP",
+                                              "role":  "implementation_reference",
+                                              "use_for":  [
+                                                              "workflow_oriented_documentation",
+                                                              "task_grouping"
+                                                          ]
+                                          },
+                                          {
+                                              "id":  "aws-labs-mcp",
+                                              "name":  "AWS Labs MCP",
+                                              "role":  "implementation_reference",
+                                              "use_for":  [
+                                                              "multi_module_consistency",
+                                                              "repeatable_server_documentation"
+                                                          ]
+                                          },
+                                          {
+                                              "id":  "cloudflare-mcp",
+                                              "name":  "Cloudflare MCP",
+                                              "role":  "implementation_reference",
+                                              "use_for":  [
+                                                              "tool_surface_scaling",
+                                                              "context_budget",
+                                                              "dynamic_discovery"
+                                                          ]
+                                          }
+                                      ],
+                    "reference_locators":  [
+                                               {
+                                                   "id":  "sentry-mcp",
+                                                   "locator":  "https://github.com/getsentry/sentry-mcp"
+                                               },
+                                               {
+                                                   "id":  "github-mcp",
+                                                   "locator":  "https://github.com/github/github-mcp-server"
+                                               },
+                                               {
+                                                   "id":  "azure-mcp",
+                                                   "locator":  "https://github.com/microsoft/mcp"
+                                               },
+                                               {
+                                                   "id":  "playwright-mcp",
+                                                   "locator":  "https://github.com/microsoft/playwright-mcp"
+                                               },
+                                               {
+                                                   "id":  "atlassian-rovo-mcp",
+                                                   "locator":  "https://developer.atlassian.com/cloud/rovo-mcp/guides/supported-tools/"
+                                               },
+                                               {
+                                                   "id":  "figma-mcp",
+                                                   "locator":  "https://developers.figma.com/docs/figma-mcp-server/"
+                                               },
+                                               {
+                                                   "id":  "aws-labs-mcp",
+                                                   "locator":  "https://github.com/awslabs/mcp"
+                                               },
+                                               {
+                                                   "id":  "cloudflare-mcp",
+                                                   "locator":  "https://github.com/cloudflare/mcp"
+                                               }
+                                           ],
+                    "decisions":  [
+                                      "D1: Use domain-scoped authority rather than a single total precedence list. KIS owns KIS facts; MCP owns MCP conformance requirements within its domain; writing guidance and implementation references cannot override either owner.",
+                                      "D2: Register external implementation references by bounded documentation concern instead of treating any repository as the KIS documentation template.",
+                                      "D3: Keep documentation-reference semantics distinct from harvest/acquisition semantics. The future reference registry should reference harvest-source identities and provenance rather than duplicate retrieval configuration.",
+                                      "D4: Require pinned or hashed evidence for deterministic generation; live web access may support research and refresh workflows but not silent build-time authority.",
+                                      "D5: Define three human output classes: task/concept documentation, human-readable specification, and generated reference. Their presentation may differ, but each remains downstream of governed sources.",
+                                      "D6: Adopt the initial ten-source reference set in this change as the proposed official baseline for later implementation review, with MCP and Google carrying specialized external roles and the eight implementation sources remaining non-normative.",
+                                      "D7: Do not copy external documentation wholesale. Harvest only the bounded patterns, metadata, or evidence needed for an approved use and preserve source provenance and licensing constraints.",
+                                      "D8: The standard itself must be machine-readable authority first and a generated human-review surface second. No hand-authored durable Markdown is introduced."
+                                  ],
+                    "output_classes":  [
+                                           {
+                                               "class":  "human_documentation",
+                                               "purpose":  "Teach concepts, tasks, workflows, examples, architecture, and operations in reader-oriented prose.",
+                                               "source_rule":  "Canonical KIS facts provide factual content; approved external references may inform organization and presentation only."
+                                           },
+                                           {
+                                               "class":  "human_readable_specification",
+                                               "purpose":  "Explain adopted normative KIS behavior while preserving requirement strength, identifiers, ownership, and traceability.",
+                                               "source_rule":  "Adopted KIS MRDs and applicable normative external standards provide requirements; presentation remains generated and non-authoritative."
+                                           },
+                                           {
+                                               "class":  "generated_reference",
+                                               "purpose":  "Expose exact tools, schemas, settings, policies, states, relationships, capabilities, permissions, and provenance.",
+                                               "source_rule":  "Only canonical KIS facts or explicitly applicable normative protocol facts may populate factual reference data."
+                                           }
+                                       ],
+                    "reference_basis":  [
+                                            "C:/Projects/kis-mcp-doc/AGENTS.md for source classification, authority, harvest posture, generated-view rules, and the MCP 2026 presentation mandate.",
+                                            "C:/Projects/kis-mcp-doc/mrd/governance/** for KIS MRD classification, ownership, provenance, lifecycle, dependencies, applicability, and validation semantics.",
+                                            "C:/Projects/kis-mcp-doc/publication/harvest-sources.json for the existing machine-readable acquisition/source inventory that the future semantic reference registry must complement rather than duplicate.",
+                                            "C:/Projects/kis-mcp-doc/.work/changes/005-mcp-spec-2026-baseline/change.mrd.json for the adopted MCP 2026-07-28 documentation/specification baseline.",
+                                            "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean/markdown/025-specification-specification.md for specification vocabulary and normative-keyword conventions.",
+                                            "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean/markdown/029-specification-overview.md for protocol structure and current MCP request/result conventions.",
+                                            "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean/markdown/030-specification-versioning-and-compatibility.md for date-based protocol versioning and compatibility presentation.",
+                                            "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean/markdown/055-specification-schema-reference.md for the current MCP 2026 schema-reference model.",
+                                            "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean/markdown/056-extensions-extensions-overview.md for bounded optional-extension and explicit-negotiation patterns.",
+                                            "C:/Projects/References/google-developer-style-guide/014-prescriptive-documentation.md for task-focused prescriptive documentation.",
+                                            "C:/Projects/References/google-developer-style-guide/017-tone.md and 019-voice.md for professional tone and active voice.",
+                                            "C:/Projects/References/google-developer-style-guide/030-sentence-structure.md and 052-paragraph-structure.md for focused sentence and paragraph construction.",
+                                            "C:/Projects/References/google-developer-style-guide/046-headings.md, 048-lists.md, 055-tables.md, and 057-cross-references.md for scannable structure and references.",
+                                            "Comparative research completed on 2026-08-26 for Sentry MCP, GitHub MCP Server, Azure MCP Server, Playwright MCP, Atlassian Rovo MCP, Figma MCP, AWS Labs MCP, and Cloudflare MCP."
+                                        ],
+                    "future_implementation_plan":  [
+                                                       "P1: Define the machine-readable Documentation Reference Standard and reference-registry schema using the minimum sufficient existing MRD types and repository contract conventions.",
+                                                       "P2: Bind the reference registry to existing harvest-source identities and add role, bounded-use, provenance, freshness, lifecycle, licensing, and supersession semantics without duplicating acquisition configuration.",
+                                                       "P3: Pin the approved external implementation evidence to exact revisions or content hashes and record refresh policy.",
+                                                       "P4: Add validation that blocks non-normative or inferred reference material from becoming canonical KIS facts without explicit adoption through the owning authority.",
+                                                       "P5: Add deterministic generation of the human-readable Documentation Reference Standard and reference catalogue from validated machine-readable authority.",
+                                                       "P6: Add tests for authority separation, provenance, deterministic generation, stale/tamper detection, reference lifecycle, and conflict diagnostics.",
+                                                       "P7: After the standard is reviewed and implemented, use it as the governed basis for later HRD/documentation refinements rather than changing Work Management HRDs in this change."
+                                                   ],
+                    "tasks":  [
+                                  {
+                                      "id":  "T0",
+                                      "status":  "done",
+                                      "text":  "Raise the governed change and GitHub issue, load the documentation skill, and review the applicable MCP 2026 and Google Developer Documentation references."
+                                  },
+                                  {
+                                      "id":  "T1",
+                                      "status":  "done",
+                                      "text":  "Select the minimum sufficient KIS MRD types and define the prescriptive Documentation Reference Standard authority model."
+                                  },
+                                  {
+                                      "id":  "T2",
+                                      "status":  "done",
+                                      "text":  "Define the versioned reference-registry contract and its relationship to publication/harvest-sources.json."
+                                  },
+                                  {
+                                      "id":  "T3",
+                                      "status":  "done",
+                                      "text":  "Pin and classify the approved external implementation reference evidence, including licensing and refresh metadata."
+                                  },
+                                  {
+                                      "id":  "T4",
+                                      "status":  "done",
+                                      "text":  "Implement validation and deterministic generation for the standard and human review surface."
+                                  },
+                                  {
+                                      "id":  "T5",
+                                      "status":  "done",
+                                      "text":  "Verify authority separation, source coverage, provenance, determinism, drift handling, and generated readability before review."
+                                  }
+                              ],
+                    "risks":  [
+                                  "Authority confusion: readers or generators could mistake an external implementation example for KIS authority unless source roles are explicit and enforced.",
+                                  "Registry duplication: a new semantic reference registry could drift from publication/harvest-sources.json if identities and ownership are not linked cleanly.",
+                                  "Reference churn: external repositories and product documentation change independently and can make unpinned examples stale.",
+                                  "Overfitting: copying one external project\u0027s information architecture could distort KIS concepts or create unnecessary structure.",
+                                  "Licensing and attribution: harvested external content may carry reuse restrictions that differ from metadata-only reference use.",
+                                  "Generated-authority inversion: a polished HRD can appear authoritative unless the publication contract keeps write-back and fact ownership explicit."
+                              ],
+                    "future_acceptance":  [
+                                              "Every admitted documentation source has one explicit role, bounded permitted use, provenance identity, freshness strategy, and lifecycle state.",
+                                              "The official reference set distinguishes MCP normative protocol authority, Google prescriptive writing guidance, and non-normative implementation references.",
+                                              "The semantic reference registry does not duplicate harvest acquisition facts and can resolve its source identities to reproducible evidence.",
+                                              "No implementation reference or inferred evidence can populate canonical KIS factual reference content without an explicit governed adoption path.",
+                                              "Task documentation, human-readable specification, and generated reference have distinct source and presentation contracts.",
+                                              "The human-readable Documentation Reference Standard is generated from validated machine-readable authority and explains the model in plain English.",
+                                              "External-reference conflicts, stale evidence, missing hashes, and unsupported authority promotions fail visibly rather than being silently accepted.",
+                                              "Deterministic generation, provenance, stale/tamper checks, schema validation, and repository verification pass."
+                                          ],
+                    "preparation_acceptance":  [
+                                                   "Change 008 exists in an isolated branch-backed worktree and owns only .work/changes/008-documentation-reference-standard/**.",
+                                                   "GitHub issue 12 records the same preparation-only outcome and reference basis.",
+                                                   "The change records the approved initial reference set and bounded roles for every reference.",
+                                                   "The change records the MCP 2026, Google Developer Documentation, KIS governance, harvest-registry, and external comparative research basis used to prepare it.",
+                                                   "The change defines authority separation, future registry semantics, output classes, validation expectations, implementation plan, risks, and later acceptance criteria without implementing them.",
+                                                   "No tracked file outside the change directory is modified by this preparation."
+                                               ],
+                    "out_of_scope_for_preparation":  [
+                                                         "Creating or adopting prescriptive documentation-reference MRDs outside this change directory.",
+                                                         "Creating the future reference-registry schema or modifying publication/harvest-sources.json.",
+                                                         "Harvesting or vendoring external implementation documentation into the repository.",
+                                                         "Changing the publication contract, generator, renderer, generated HRDs, or generated reference pages.",
+                                                         "Changing Work Management documentation, Work Management behavior, or GitHub Project configuration.",
+                                                         "Changing MCP/FastMCP runtime protocol behavior or adopting new MCP 2026 runtime features.",
+                                                         "Adding validators, tests, CI behavior, or source-code implementation for the future standard."
+                                                     ],
+                    "closeout":  {
+                                     "state":  "implementation_complete_pending_review",
+                                     "verification":  [
+                                                          "Focused Documentation Reference Standard tests pass.",
+                                                          "Full repository pytest suite passes.",
+                                                          "scripts/verify.ps1 passes with locked offline dependency synchronization, all validators, all generated-output checks, and git diff --check."
+                                                      ],
+                                     "reviews":  [
+
+                                                 ],
+                                     "publication":  "generated/documentation-reference-standard/**",
+                                     "merge":  null,
+                                     "unresolved":  [
+                                                        "GitHub issue 12 exists, but governed Work Management Project capture remains blocked because kis-mcp-doc is not bound to the current kis-mcp Project repository configuration. This implementation does not bypass that boundary."
+                                                    ]
+                                 },
+                    "implementation":  {
+                                           "authorization":  "operator approved implementation in conversation:2026-08-26 after preparation commit 2785a3b7a6f42b22ef48e8b151473717a7af5a1e",
+                                           "selected_mrd_types":  [
+                                                                      "CON-POL",
+                                                                      "SEM-REG"
+                                                                  ],
+                                           "canonical_mrds":  [
+                                                                  "KIS-DOC-CON-POL-001",
+                                                                  "KIS-DOC-SEM-REG-001"
+                                                              ],
+                                           "contract":  "contracts/documentation/reference/v1/**",
+                                           "publication":  "publication/documentation-reference-standard.json",
+                                           "generated_review_surface":  "generated/documentation-reference-standard/**",
+                                           "validator":  "src/kis_mcp_doc/documentation_reference.py",
+                                           "canonical_verification":  "scripts/verify.ps1"
+                                       }
+                }
 }

--- a/.work/changes/008-documentation-reference-standard/change.mrd.json
+++ b/.work/changes/008-documentation-reference-standard/change.mrd.json
@@ -1,0 +1,251 @@
+{
+  "_mrd": {
+    "schema_version": 1,
+    "id": "KIS-CHG008-WRK-WFL-001",
+    "title": "Documentation Reference Standard preparation",
+    "module": "change-008",
+    "class": "WRK",
+    "type": "WFL",
+    "layer": "L3",
+    "record_mode": "descriptive",
+    "status": "active",
+    "version": "1.0.0",
+    "dependencies": [
+      {"mrd_id": "KIS-KNOW-WRK-WFL-001", "relationship": "depends_on"},
+      {"mrd_id": "KIS-KNOW-CON-POL-002", "relationship": "depends_on"},
+      {"mrd_id": "KIS-CHG005-WRK-WFL-001", "relationship": "depends_on"},
+      {"mrd_id": "KIS-KNOW-EVL-TST-001", "relationship": "validated_by"}
+    ],
+    "provenance": {
+      "sources": [
+        {
+          "source_id": "KIS-OPERATOR-DIRECTION-2026-08-26-DOCUMENTATION-REFERENCE-STANDARD",
+          "kind": "operator_direction",
+          "role": "approved_change_basis",
+          "locator": "conversation:2026-08-26",
+          "revision": "documentation-reference-standard-approved",
+          "sha256": null
+        },
+        {
+          "source_id": "GH-ISSUE-12",
+          "kind": "operator_approved_work_item",
+          "role": "approved_change_basis",
+          "locator": "github:NielPieterse0/kis-mcp-doc#12",
+          "revision": "2026-08-26",
+          "sha256": null
+        },
+        {
+          "source_id": "MCP-SPEC-2026-07-28",
+          "kind": "external_reference",
+          "role": "normative_protocol_reference",
+          "locator": "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean",
+          "revision": "2026-07-28",
+          "sha256": null
+        },
+        {
+          "source_id": "GOOGLE-DEVELOPER-DOCUMENTATION-STYLE-GUIDE",
+          "kind": "external_reference",
+          "role": "prescriptive_writing_reference",
+          "locator": "C:/Projects/References/google-developer-style-guide",
+          "revision": "captured-corpus",
+          "sha256": null
+        },
+        {
+          "source_id": "KIS-EXTERNAL-MCP-DOC-RESEARCH-2026-08-26",
+          "kind": "research_evidence",
+          "role": "implementation_reference_selection",
+          "locator": "conversation:2026-08-26",
+          "revision": "comparative-mcp-documentation-research",
+          "sha256": null
+        }
+      ],
+      "source_fingerprint": "sha256:d77b758a7d1cd8c8c4372fb66b45e0750a4511219d83c4a47e38370f01df3bfe",
+      "fact_quality": "direct"
+    },
+    "supersedes": [],
+    "superseded_by": null
+  },
+  "content": {
+    "change_id": "008-documentation-reference-standard",
+    "work_item": {
+      "repository": "NielPieterse0/kis-mcp-doc",
+      "issue": 12,
+      "project": "NielPieterse0/1",
+      "record_id": "SPEC-008"
+    },
+    "outcome": "Prepare a governed Documentation Reference Standard so future KIS documentation can use normative protocol sources, writing guidance, and external MCP implementation examples without confusing evidence with authority.",
+    "preparation_boundary": [
+      "This change currently creates planning and change-definition records only.",
+      "No canonical MRD, contract, schema, harvest registry, publication profile, generator, renderer, generated document, runtime behavior, or test behavior is changed during preparation.",
+      "The later implementation MUST enter through a separately approved implementation step within this governed change or a successor change, depending on review outcome."
+    ],
+    "problem": [
+      "KIS has authoritative source and provenance rules, a captured MCP 2026 reference corpus, a captured Google style corpus, and an existing harvest-source registry, but it does not yet prescribe one documentation-specific contract for how those sources and external implementation examples may influence generated documentation.",
+      "Without that contract, useful external patterns can become informal tribal knowledge, reference roles can overlap, and future generators can accidentally duplicate source facts or elevate non-normative evidence into apparent KIS authority.",
+      "The standard must make the source role, permitted use, provenance, freshness, and conflict behavior explicit before the external reference set is used to reshape additional KIS HRDs."
+    ],
+    "authority_model": [
+      "KIS canonical sources and adopted KIS MRDs own KIS-specific facts, behavior, policy, configuration, and lifecycle semantics.",
+      "The pinned MCP 2026-07-28 specification is normative for MCP protocol conformance within the protocol concerns it defines. It is not authority for unrelated KIS product behavior.",
+      "KIS repository and documentation governance controls how KIS-owned documentation is produced and how external evidence is classified.",
+      "The Google Developer Documentation Style Guide is prescriptive presentation guidance for human-facing prose where higher KIS authority does not prescribe a different form. It does not define KIS behavior.",
+      "External MCP implementations are non-normative evidence and design references. They may demonstrate useful documentation structures and engineering patterns, but they cannot create or override KIS facts.",
+      "Model-generated, semantic-provider, DeepWiki/Litho, Graphify, and similar inferred material remains advisory or inferred evidence until verified against an owning source and explicitly adopted through KIS governance."
+    ],
+    "candidate_source_roles": [
+      {"role": "canonical_kis", "meaning": "KIS-owned canonical fact or adopted prescriptive MRD", "may_define_kis_facts": true},
+      {"role": "normative_external", "meaning": "External standard that is normative within a bounded conformance domain such as MCP", "may_define_kis_facts": false},
+      {"role": "prescriptive_external", "meaning": "External guidance that prescribes presentation or practice without owning KIS behavior", "may_define_kis_facts": false},
+      {"role": "implementation_reference", "meaning": "External implementation used to study reusable patterns", "may_define_kis_facts": false},
+      {"role": "inferred_evidence", "meaning": "Derived, semantic, or model-generated evidence requiring verification", "may_define_kis_facts": false}
+    ],
+    "requirements": [
+      "R1: The future Documentation Reference Standard MUST define source roles, authority boundaries, permitted uses, provenance requirements, freshness requirements, and conflict behavior for every admitted documentation reference.",
+      "R2: KIS-owned behavior and factual generated reference content MUST remain sourced from the current canonical KIS owner or an adopted KIS MRD; a documentation reference MUST NOT become a second fact owner.",
+      "R3: MCP 2026-07-28 MUST be treated as normative within its applicable protocol-conformance domain, while remaining non-authoritative for KIS-specific behavior outside that domain.",
+      "R4: Google Developer Documentation Style Guide material MUST be treated as prescriptive writing guidance only and MUST NOT define KIS semantics, state, policy, or runtime behavior.",
+      "R5: External implementation references MUST be explicitly non-normative and MUST NOT populate canonical KIS facts, generated factual reference tables, or normative requirements without a separate evidence-backed adoption decision.",
+      "R6: Each external implementation reference MUST have a bounded role that states which documentation concern it may inform; the repository MUST NOT adopt an external project as a general undocumented template.",
+      "R7: The future standard MUST provide a versioned machine-readable reference registry whose semantic role is distinct from acquisition metadata in publication/harvest-sources.json and whose entries can reference existing harvest-source identities instead of duplicating them.",
+      "R8: Material used by deterministic builds MUST be pinned to reproducible revisions or content hashes when the source supports them; documentation builds MUST NOT silently depend on live moving web content.",
+      "R9: The reference registry MUST support add, update, deprecate, supersede, and remove lifecycle states without erasing historical provenance.",
+      "R10: The documentation system MUST distinguish human task/concept documentation, human-readable normative specifications, and exact generated reference material because each output class has different source and presentation rules.",
+      "R11: Exact generated reference material for tools, schemas, settings, policies, states, relationships, capabilities, and permissions MUST derive from canonical KIS facts rather than external examples or independently maintained prose.",
+      "R12: Human-readable normative specifications MUST preserve the strength and meaning of adopted KIS requirements while explaining concepts in prose before dense reference detail where appropriate.",
+      "R13: Human task and concept documentation MAY use workflow and presentation patterns from approved implementation references but MUST preserve KIS terminology, behavior, authority, and provenance.",
+      "R14: Contradictions between a reference and a canonical owner MUST surface as diagnostics or review findings; the system MUST NOT silently normalize the canonical fact to match the reference.",
+      "R15: Validation MUST prevent implementation_reference, prescriptive_external, and inferred_evidence material from being promoted to canonical KIS fact solely because it appears in generated documentation.",
+      "R16: A generated human-review page MUST explain the official reference set, each source role, permitted uses, authority limits, provenance, and lifecycle without becoming write-back authority.",
+      "R17: External-source licensing, attribution, and copying constraints MUST be recorded before source material is harvested beyond metadata or small evidence excerpts.",
+      "R18: This preparation slice MUST NOT implement any of the future registry, schema, generator, validator, renderer, harvest, or publication behavior described by these requirements."
+    ],
+    "reference_set": [
+      {"id": "mcp-2026", "name": "Model Context Protocol 2026-07-28", "role": "normative_external", "use_for": ["protocol_conformance", "specification_structure", "normative_presentation", "schema_reference"]},
+      {"id": "google-developer-style", "name": "Google Developer Documentation Style Guide", "role": "prescriptive_external", "use_for": ["human_prose", "task_documentation", "headings", "lists", "tables", "cross_references"]},
+      {"id": "sentry-mcp", "name": "Sentry MCP", "role": "implementation_reference", "use_for": ["documentation_architecture", "engineering_documentation", "operations", "security"]},
+      {"id": "github-mcp", "name": "GitHub MCP Server", "role": "implementation_reference", "use_for": ["tool_reference", "configuration_reference", "generated_documentation", "stale_detection"]},
+      {"id": "azure-mcp", "name": "Azure MCP Server", "role": "implementation_reference", "use_for": ["large_scale_reference", "generated_reference", "drift_control"]},
+      {"id": "playwright-mcp", "name": "Playwright MCP", "role": "implementation_reference", "use_for": ["task_oriented_documentation", "getting_started", "generated_tool_reference"]},
+      {"id": "atlassian-rovo-mcp", "name": "Atlassian Rovo MCP", "role": "implementation_reference", "use_for": ["permissions_presentation", "capability_catalogue", "discover_execute_patterns"]},
+      {"id": "figma-mcp", "name": "Figma MCP", "role": "implementation_reference", "use_for": ["workflow_oriented_documentation", "task_grouping"]},
+      {"id": "aws-labs-mcp", "name": "AWS Labs MCP", "role": "implementation_reference", "use_for": ["multi_module_consistency", "repeatable_server_documentation"]},
+      {"id": "cloudflare-mcp", "name": "Cloudflare MCP", "role": "implementation_reference", "use_for": ["tool_surface_scaling", "context_budget", "dynamic_discovery"]}
+    ],
+    "reference_locators": [
+      {"id": "sentry-mcp", "locator": "https://github.com/getsentry/sentry-mcp"},
+      {"id": "github-mcp", "locator": "https://github.com/github/github-mcp-server"},
+      {"id": "azure-mcp", "locator": "https://github.com/microsoft/mcp"},
+      {"id": "playwright-mcp", "locator": "https://github.com/microsoft/playwright-mcp"},
+      {"id": "atlassian-rovo-mcp", "locator": "https://developer.atlassian.com/cloud/rovo-mcp/guides/supported-tools/"},
+      {"id": "figma-mcp", "locator": "https://developers.figma.com/docs/figma-mcp-server/"},
+      {"id": "aws-labs-mcp", "locator": "https://github.com/awslabs/mcp"},
+      {"id": "cloudflare-mcp", "locator": "https://github.com/cloudflare/mcp"}
+    ],
+    "decisions": [
+      "D1: Use domain-scoped authority rather than a single total precedence list. KIS owns KIS facts; MCP owns MCP conformance requirements within its domain; writing guidance and implementation references cannot override either owner.",
+      "D2: Register external implementation references by bounded documentation concern instead of treating any repository as the KIS documentation template.",
+      "D3: Keep documentation-reference semantics distinct from harvest/acquisition semantics. The future reference registry should reference harvest-source identities and provenance rather than duplicate retrieval configuration.",
+      "D4: Require pinned or hashed evidence for deterministic generation; live web access may support research and refresh workflows but not silent build-time authority.",
+      "D5: Define three human output classes: task/concept documentation, human-readable specification, and generated reference. Their presentation may differ, but each remains downstream of governed sources.",
+      "D6: Adopt the initial ten-source reference set in this change as the proposed official baseline for later implementation review, with MCP and Google carrying specialized external roles and the eight implementation sources remaining non-normative.",
+      "D7: Do not copy external documentation wholesale. Harvest only the bounded patterns, metadata, or evidence needed for an approved use and preserve source provenance and licensing constraints.",
+      "D8: The standard itself must be machine-readable authority first and a generated human-review surface second. No hand-authored durable Markdown is introduced."
+    ],
+    "output_classes": [
+      {
+        "class": "human_documentation",
+        "purpose": "Teach concepts, tasks, workflows, examples, architecture, and operations in reader-oriented prose.",
+        "source_rule": "Canonical KIS facts provide factual content; approved external references may inform organization and presentation only."
+      },
+      {
+        "class": "human_readable_specification",
+        "purpose": "Explain adopted normative KIS behavior while preserving requirement strength, identifiers, ownership, and traceability.",
+        "source_rule": "Adopted KIS MRDs and applicable normative external standards provide requirements; presentation remains generated and non-authoritative."
+      },
+      {
+        "class": "generated_reference",
+        "purpose": "Expose exact tools, schemas, settings, policies, states, relationships, capabilities, permissions, and provenance.",
+        "source_rule": "Only canonical KIS facts or explicitly applicable normative protocol facts may populate factual reference data."
+      }
+    ],
+    "reference_basis": [
+      "C:/Projects/kis-mcp-doc/AGENTS.md for source classification, authority, harvest posture, generated-view rules, and the MCP 2026 presentation mandate.",
+      "C:/Projects/kis-mcp-doc/mrd/governance/** for KIS MRD classification, ownership, provenance, lifecycle, dependencies, applicability, and validation semantics.",
+      "C:/Projects/kis-mcp-doc/publication/harvest-sources.json for the existing machine-readable acquisition/source inventory that the future semantic reference registry must complement rather than duplicate.",
+      "C:/Projects/kis-mcp-doc/.work/changes/005-mcp-spec-2026-baseline/change.mrd.json for the adopted MCP 2026-07-28 documentation/specification baseline.",
+      "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean/markdown/025-specification-specification.md for specification vocabulary and normative-keyword conventions.",
+      "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean/markdown/029-specification-overview.md for protocol structure and current MCP request/result conventions.",
+      "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean/markdown/030-specification-versioning-and-compatibility.md for date-based protocol versioning and compatibility presentation.",
+      "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean/markdown/055-specification-schema-reference.md for the current MCP 2026 schema-reference model.",
+      "C:/Projects/References/mcp-specification/mcp-docs-2026-07-28-direct-md-clean/markdown/056-extensions-extensions-overview.md for bounded optional-extension and explicit-negotiation patterns.",
+      "C:/Projects/References/google-developer-style-guide/014-prescriptive-documentation.md for task-focused prescriptive documentation.",
+      "C:/Projects/References/google-developer-style-guide/017-tone.md and 019-voice.md for professional tone and active voice.",
+      "C:/Projects/References/google-developer-style-guide/030-sentence-structure.md and 052-paragraph-structure.md for focused sentence and paragraph construction.",
+      "C:/Projects/References/google-developer-style-guide/046-headings.md, 048-lists.md, 055-tables.md, and 057-cross-references.md for scannable structure and references.",
+      "Comparative research completed on 2026-08-26 for Sentry MCP, GitHub MCP Server, Azure MCP Server, Playwright MCP, Atlassian Rovo MCP, Figma MCP, AWS Labs MCP, and Cloudflare MCP."
+    ],
+    "future_implementation_plan": [
+      "P1: Define the machine-readable Documentation Reference Standard and reference-registry schema using the minimum sufficient existing MRD types and repository contract conventions.",
+      "P2: Bind the reference registry to existing harvest-source identities and add role, bounded-use, provenance, freshness, lifecycle, licensing, and supersession semantics without duplicating acquisition configuration.",
+      "P3: Pin the approved external implementation evidence to exact revisions or content hashes and record refresh policy.",
+      "P4: Add validation that blocks non-normative or inferred reference material from becoming canonical KIS facts without explicit adoption through the owning authority.",
+      "P5: Add deterministic generation of the human-readable Documentation Reference Standard and reference catalogue from validated machine-readable authority.",
+      "P6: Add tests for authority separation, provenance, deterministic generation, stale/tamper detection, reference lifecycle, and conflict diagnostics.",
+      "P7: After the standard is reviewed and implemented, use it as the governed basis for later HRD/documentation refinements rather than changing Work Management HRDs in this change."
+    ],
+    "tasks": [
+      {"id": "T0", "status": "done", "text": "Raise the governed change and GitHub issue, load the documentation skill, and review the applicable MCP 2026 and Google Developer Documentation references."},
+      {"id": "T1", "status": "pending", "text": "Select the minimum sufficient KIS MRD types and define the prescriptive Documentation Reference Standard authority model."},
+      {"id": "T2", "status": "pending", "text": "Define the versioned reference-registry contract and its relationship to publication/harvest-sources.json."},
+      {"id": "T3", "status": "pending", "text": "Pin and classify the approved external implementation reference evidence, including licensing and refresh metadata."},
+      {"id": "T4", "status": "pending", "text": "Implement validation and deterministic generation for the standard and human review surface."},
+      {"id": "T5", "status": "pending", "text": "Verify authority separation, source coverage, provenance, determinism, drift handling, and generated readability before review."}
+    ],
+    "risks": [
+      "Authority confusion: readers or generators could mistake an external implementation example for KIS authority unless source roles are explicit and enforced.",
+      "Registry duplication: a new semantic reference registry could drift from publication/harvest-sources.json if identities and ownership are not linked cleanly.",
+      "Reference churn: external repositories and product documentation change independently and can make unpinned examples stale.",
+      "Overfitting: copying one external project's information architecture could distort KIS concepts or create unnecessary structure.",
+      "Licensing and attribution: harvested external content may carry reuse restrictions that differ from metadata-only reference use.",
+      "Generated-authority inversion: a polished HRD can appear authoritative unless the publication contract keeps write-back and fact ownership explicit."
+    ],
+    "future_acceptance": [
+      "Every admitted documentation source has one explicit role, bounded permitted use, provenance identity, freshness strategy, and lifecycle state.",
+      "The official reference set distinguishes MCP normative protocol authority, Google prescriptive writing guidance, and non-normative implementation references.",
+      "The semantic reference registry does not duplicate harvest acquisition facts and can resolve its source identities to reproducible evidence.",
+      "No implementation reference or inferred evidence can populate canonical KIS factual reference content without an explicit governed adoption path.",
+      "Task documentation, human-readable specification, and generated reference have distinct source and presentation contracts.",
+      "The human-readable Documentation Reference Standard is generated from validated machine-readable authority and explains the model in plain English.",
+      "External-reference conflicts, stale evidence, missing hashes, and unsupported authority promotions fail visibly rather than being silently accepted.",
+      "Deterministic generation, provenance, stale/tamper checks, schema validation, and repository verification pass."
+    ],
+    "preparation_acceptance": [
+      "Change 008 exists in an isolated branch-backed worktree and owns only .work/changes/008-documentation-reference-standard/**.",
+      "GitHub issue 12 records the same preparation-only outcome and reference basis.",
+      "The change records the approved initial reference set and bounded roles for every reference.",
+      "The change records the MCP 2026, Google Developer Documentation, KIS governance, harvest-registry, and external comparative research basis used to prepare it.",
+      "The change defines authority separation, future registry semantics, output classes, validation expectations, implementation plan, risks, and later acceptance criteria without implementing them.",
+      "No tracked file outside the change directory is modified by this preparation."
+    ],
+    "out_of_scope_for_preparation": [
+      "Creating or adopting prescriptive documentation-reference MRDs outside this change directory.",
+      "Creating the future reference-registry schema or modifying publication/harvest-sources.json.",
+      "Harvesting or vendoring external implementation documentation into the repository.",
+      "Changing the publication contract, generator, renderer, generated HRDs, or generated reference pages.",
+      "Changing Work Management documentation, Work Management behavior, or GitHub Project configuration.",
+      "Changing MCP/FastMCP runtime protocol behavior or adopting new MCP 2026 runtime features.",
+      "Adding validators, tests, CI behavior, or source-code implementation for the future standard."
+    ],
+    "closeout": {
+      "state": "prepared_for_review",
+      "verification": [],
+      "reviews": [],
+      "publication": null,
+      "merge": null,
+      "unresolved": [
+        "GitHub issue 12 is created, but governed Work Management Project capture is blocked by GITHUB_PROJECT_MANAGEMENT_INVALID_COMMAND because the source repository NielPieterse0/kis-mcp-doc does not match the current kis-mcp Project repository binding. Do not bypass this boundary; resolve it through Work Management governance before relying on Project state for this change.",
+        "The exact MRD type set and canonical on-disk location for the future semantic reference registry remain implementation-design decisions to resolve in T1-T2 using minimum-sufficient selection and existing ownership rules."
+      ]
+    }
+  }
+}

--- a/.work/changes/008-documentation-reference-standard/scope.json
+++ b/.work/changes/008-documentation-reference-standard/scope.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 4,
+  "change_id": "008-documentation-reference-standard",
+  "status": "active",
+  "branch": "change/008-documentation-reference-standard",
+  "worktree": ".work/worktrees/008-documentation-reference-standard",
+  "base": "main",
+  "outcome": "Prepare the governed Documentation Reference Standard that will define source roles, authority boundaries, provenance, and permitted uses for documentation references without implementing the standard yet.",
+  "owned_paths": [
+    ".work/changes/008-documentation-reference-standard/**"
+  ],
+  "shared_paths": [],
+  "excluded_paths": [
+    "AGENTS.md",
+    "contracts/**",
+    "mrd/**",
+    "publication/**",
+    "generated/**",
+    "src/**",
+    "tests/**",
+    "C:/Projects/kis-mcp/**",
+    "C:/Projects/References/**"
+  ],
+  "dependencies": [
+    "005-mcp-spec-2026-baseline"
+  ],
+  "integration_owner": null,
+  "complexity": "large",
+  "risk_triggers": ["public_contract"],
+  "base_evidence": {
+    "local_sha": "d0105b364056e00b5fab407d8426c60df83429d4",
+    "local_tree": "4214c33ea163002392d7391e31c182853ea4aecf",
+    "upstream_sha": "d0105b364056e00b5fab407d8426c60df83429d4",
+    "upstream_tree": "4214c33ea163002392d7391e31c182853ea4aecf",
+    "upstream_ref": "github:main",
+    "evidence_source": "verified_github_default",
+    "relation": "equal"
+  },
+  "work_management": {
+    "project_id": "kis-mcp",
+    "record_id": "SPEC-008",
+    "source_repository": "NielPieterse0/kis-mcp-doc",
+    "source_number": 12,
+    "source_kind": "issue",
+    "documentation_impact": "planned"
+  }
+}

--- a/.work/changes/008-documentation-reference-standard/scope.json
+++ b/.work/changes/008-documentation-reference-standard/scope.json
@@ -5,25 +5,34 @@
   "branch": "change/008-documentation-reference-standard",
   "worktree": ".work/worktrees/008-documentation-reference-standard",
   "base": "main",
-  "outcome": "Prepare the governed Documentation Reference Standard that will define source roles, authority boundaries, provenance, and permitted uses for documentation references without implementing the standard yet.",
+  "outcome": "Implement the governed Documentation Reference Standard, semantic reference registry, validation, deterministic human-review publication, and verification for the approved ten-source baseline.",
   "owned_paths": [
-    ".work/changes/008-documentation-reference-standard/**"
+    ".work/changes/008-documentation-reference-standard/**",
+    "contracts/documentation/reference/**",
+    "mrd/documentation/**",
+    "publication/documentation-reference-standard.json",
+    "generated/documentation-reference-standard/**",
+    "src/kis_mcp_doc/documentation_reference.py",
+    "src/kis_mcp_doc/cli.py",
+    "scripts/verify.ps1",
+    "tests/test_documentation_reference_standard.py"
   ],
   "shared_paths": [],
   "excluded_paths": [
     "AGENTS.md",
-    "contracts/**",
-    "mrd/**",
-    "publication/**",
-    "generated/**",
-    "src/**",
-    "tests/**",
-    "C:/Projects/kis-mcp/**",
+    "mrd/governance/**",
+    "mrd/work-management/**",
+    "publication/harvest-sources.json",
+    "generated/governance-spec/**",
+    "generated/work-management-spec/**",
+    "src/kis_mcp_doc/governance.py",
+    "src/kis_mcp_doc/harvest.py",
+    "src/kis_mcp_doc/litho.py",
+    "src/kis_mcp_doc/render.py",
+    "src/kis_mcp_doc/work_management.py",    "C:/Projects/kis-mcp/**",
     "C:/Projects/References/**"
   ],
-  "dependencies": [
-    "005-mcp-spec-2026-baseline"
-  ],
+  "dependencies": ["005-mcp-spec-2026-baseline"],
   "integration_owner": null,
   "complexity": "large",
   "risk_triggers": ["public_contract"],
@@ -42,6 +51,6 @@
     "source_repository": "NielPieterse0/kis-mcp-doc",
     "source_number": 12,
     "source_kind": "issue",
-    "documentation_impact": "planned"
+    "documentation_impact": "implementation"
   }
 }

--- a/contracts/documentation/reference/v1/manifest.schema.json
+++ b/contracts/documentation/reference/v1/manifest.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://kis.local/contracts/documentation/reference/v1/manifest.schema.json",
+  "title":"KIS Documentation Reference Standard Build Manifest",
+  "type":"object","additionalProperties":false,
+  "required":["contract","specification","inputs","input_set_sha256","validation","files","bundle_sha256"],
+  "properties":{
+    "contract":{"type":"object","additionalProperties":false,"required":["name","version"],"properties":{"name":{"const":"documentation-reference-standard-build"},"version":{"const":1}}},
+    "specification":{"type":"object","additionalProperties":false,"required":["title","version","status","layout_profile"],"properties":{"title":{"const":"Documentation Reference Standard"},"version":{"type":"string","pattern":"^[0-9]+\\.[0-9]+\\.[0-9]+$"},"status":{"type":"string","minLength":1},"layout_profile":{"const":"mcp-spec"}}},
+    "inputs":{"type":"array","minItems":8,"uniqueItems":true,"items":{"$ref":"#/$defs/file"}},
+    "input_set_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},
+    "validation":{"type":"object","required":["status","checks","diagnostics"]},
+    "files":{"type":"array","minItems":4,"uniqueItems":true,"items":{"$ref":"#/$defs/file"}},
+    "bundle_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"}
+  },
+  "$defs":{"file":{"type":"object","additionalProperties":false,"required":["path","sha256","bytes"],"properties":{"path":{"type":"string","minLength":1},"sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},"bytes":{"type":"integer","minimum":0}}}}
+}

--- a/contracts/documentation/reference/v1/publication.schema.json
+++ b/contracts/documentation/reference/v1/publication.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://kis.local/contracts/documentation/reference/v1/publication.schema.json",
+  "title":"KIS Documentation Reference Standard Publication",
+  "type":"object","additionalProperties":false,
+  "required":["schema_version","layout_profile","title","subtitle","version","status","generator"],
+  "properties":{
+    "schema_version":{"const":1},
+    "layout_profile":{"const":"mcp-spec"},
+    "title":{"const":"Documentation Reference Standard"},
+    "subtitle":{"type":"string","minLength":1},
+    "version":{"type":"string","pattern":"^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "status":{"type":"string","minLength":1},
+    "generator":{"type":"object","additionalProperties":false,"required":["name","version","algorithm"],"properties":{"name":{"const":"kis-mcp-doc"},"version":{"type":"string","pattern":"^[0-9]+\\.[0-9]+\\.[0-9]+$"},"algorithm":{"const":"documentation-reference-standard-v1"}}}
+  }
+}

--- a/contracts/documentation/reference/v1/registry.schema.json
+++ b/contracts/documentation/reference/v1/registry.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kis.local/contracts/documentation/reference/v1/registry.schema.json",
+  "title": "KIS Documentation Reference Registry Content",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["registry_version", "refresh_policy", "licensing_policy", "evidence_records", "references"],
+  "properties": {
+    "registry_version": {"type":"string","pattern":"^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "refresh_policy": {"type":"string","minLength":1},
+    "licensing_policy": {"type":"string","minLength":1},
+    "evidence_records": {"type":"array","minItems":1,"uniqueItems":true,"items":{"type":"object","additionalProperties":false,"required":["id","kind","source_path","git_commit","sha256"],"properties":{"id":{"type":"string","minLength":1},"kind":{"const":"governed_research_record"},"source_path":{"type":"string","minLength":1},"git_commit":{"type":"string","pattern":"^[a-f0-9]{40}$"},"sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"}}}},
+    "references": {"type":"array","minItems":10,"maxItems":10,"items":{"$ref":"#/$defs/reference"}}
+  },
+  "$defs": {
+    "reference": {
+      "type":"object","additionalProperties":false,
+      "required":["id","name","role","locator","harvest_source_id","permitted_uses","may_define_kis_facts","pin","freshness","lifecycle","license"],
+      "properties": {
+        "id":{"type":"string","pattern":"^[a-z0-9][a-z0-9-]*$"},
+        "name":{"type":"string","minLength":1},
+        "role":{"enum":["canonical_kis","normative_external","prescriptive_external","implementation_reference","inferred_evidence"]},
+        "locator":{"type":"string","minLength":1},
+        "harvest_source_id":{"type":["string","null"]},
+        "permitted_uses":{"type":"array","minItems":1,"uniqueItems":true,"items":{"type":"string","minLength":1}},
+        "may_define_kis_facts":{"type":"boolean"},        "pin":{"oneOf":[{"type":"null"},{"type":"object","additionalProperties":false,"required":["kind","value","revision"],"properties":{"kind":{"enum":["content_sha256","captured_corpus_sha256","research_evidence_sha256"]},"value":{"type":"string","pattern":"^[a-f0-9]{64}$"},"revision":{"type":"string","minLength":1}}}]},
+        "freshness":{"type":"object","additionalProperties":false,"required":["strategy","checked_on"],"properties":{"strategy":{"type":"string","minLength":1},"checked_on":{"type":"string","pattern":"^[0-9]{4}-[0-9]{2}-[0-9]{2}$"}}},
+        "lifecycle":{"type":"object","additionalProperties":false,"required":["state","supersedes","superseded_by"],"properties":{"state":{"enum":["active","deprecated","superseded","removed"]},"supersedes":{"type":"array","uniqueItems":true,"items":{"type":"string"}},"superseded_by":{"type":["string","null"]}}},
+        "license":{"type":"object","additionalProperties":false,"required":["reuse_boundary","status"],"properties":{"reuse_boundary":{"type":"string","minLength":1},"status":{"type":"string","minLength":1}}}
+      }
+    }
+  }
+}

--- a/contracts/documentation/reference/v1/standard.schema.json
+++ b/contracts/documentation/reference/v1/standard.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kis.local/contracts/documentation/reference/v1/standard.schema.json",
+  "title": "KIS Documentation Reference Standard Content",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["concern","heading","purpose","authority_model","output_classes","registry_contract","conflict_behavior","requirements"],
+  "properties": {
+    "concern":{"const":"documentation_reference_authority"},
+    "heading":{"const":"Documentation Reference Standard"},
+    "purpose":{"type":"string","minLength":1},
+    "authority_model":{"type":"array","minItems":5,"items":{"type":"object","required":["role","domain","may_define_kis_facts"],"properties":{"role":{"type":"string"},"domain":{"type":"string"},"may_define_kis_facts":{"type":"boolean"}}}},
+    "output_classes":{"type":"array","minItems":3,"maxItems":3,"items":{"type":"object","required":["class","purpose","source_rule"],"properties":{"class":{"enum":["human_documentation","human_readable_specification","generated_reference"]},"purpose":{"type":"string"},"source_rule":{"type":"string"}}}},
+    "registry_contract":{"type":"object","required":["owner","harvest_registry","relationship","required_lifecycle_states"]},
+    "conflict_behavior":{"type":"object","required":["canonical_conflict","unsupported_promotion","stale_or_unpinned_reference"]},
+    "requirements":{"type":"array","minItems":9,"items":{"type":"object","required":["rule_id","statement","enforcement"],"properties":{"rule_id":{"type":"string","pattern":"^KIS-DOC-REF-[0-9]{3}$"},"statement":{"type":"string","minLength":1},"enforcement":{"type":"string","minLength":1}}}}
+  }
+}

--- a/generated/documentation-reference-standard/000-index.md
+++ b/generated/documentation-reference-standard/000-index.md
@@ -1,0 +1,9 @@
+<!-- GENERATED -- DO NOT EDIT -->
+# Documentation Reference Standard — documentation index
+
+This generated collection is a review projection. The documentation MRDs and referenced canonical sources remain authoritative.
+
+- [Specification](001-specification.md)
+- [Reference catalogue](002-reference-catalogue.md)
+- [Machine-readable reference registry](data/reference-registry.json)
+- [Build manifest](manifest.json)

--- a/generated/documentation-reference-standard/001-specification.md
+++ b/generated/documentation-reference-standard/001-specification.md
@@ -1,0 +1,88 @@
+<!-- GENERATED -- DO NOT EDIT -->
+# Documentation Reference Standard
+
+<div id="enable-section-numbers" />
+
+Source roles, authority boundaries, provenance, lifecycle, and permitted use for KIS documentation references
+
+This specification governs how documentation references can influence KIS documentation. It keeps source authority separate from presentation guidance and implementation evidence.
+
+## Authority model
+
+- **`canonical_kis`:** KIS-specific facts, behavior, policy, configuration, lifecycle, and adopted requirements; may define KIS facts.
+- **`normative_external`:** The bounded conformance domain owned by the external standard; MUST NOT define KIS facts.
+- **`prescriptive_external`:** Presentation or practice guidance where KIS authority is silent; MUST NOT define KIS facts.
+- **`implementation_reference`:** Bounded reusable documentation or engineering patterns; MUST NOT define KIS facts.
+- **`inferred_evidence`:** Derived evidence requiring verification against an owning source; MUST NOT define KIS facts.
+
+## Documentation output classes
+
+### Human documentation
+
+Teach concepts, tasks, workflows, examples, architecture, and operations in reader-oriented prose.
+
+Canonical KIS facts supply factual content; approved references may inform organization and presentation only.
+
+### Human-readable specification
+
+Explain adopted normative behavior while preserving requirement strength, identifiers, ownership, and traceability.
+
+Adopted KIS MRDs and applicable normative external standards supply requirements; generated prose remains non-authoritative.
+
+### Generated reference
+
+Expose exact tools, schemas, settings, policies, states, relationships, capabilities, permissions, and provenance.
+
+Only canonical KIS facts or explicitly applicable normative protocol facts may populate factual reference data.
+
+## Reference registry
+
+Refresh references only through a governed registry change. Deterministic builds use the pinned registry state and never fetch live sources.
+
+Metadata and bounded pattern summaries are permitted. Harvesting reusable source content requires source-specific license and attribution review first.
+
+## Conflict behavior
+
+When a reference conflicts with a canonical owner, KIS surfaces the conflict and keeps the canonical owner unchanged. Unsupported authority promotion and active unpinned references fail validation.
+
+## Requirements
+
+### KIS-DOC-REF-001
+
+Every admitted documentation reference MUST declare one source role, bounded permitted uses, provenance, freshness strategy, lifecycle state, and authority limit.
+
+### KIS-DOC-REF-002
+
+KIS-owned factual content MUST remain sourced from its current canonical owner; a documentation reference MUST NOT become a second owner.
+
+### KIS-DOC-REF-003
+
+MCP 2026-07-28 MUST be treated as normative only within its applicable MCP protocol-conformance domain.
+
+### KIS-DOC-REF-004
+
+Google Developer Documentation guidance MUST remain presentation guidance and MUST NOT define KIS runtime or governance semantics.
+
+### KIS-DOC-REF-005
+
+Implementation references and inferred evidence MUST NOT populate canonical KIS facts without a separately governed adoption decision.
+
+### KIS-DOC-REF-006
+
+Material used by deterministic generation MUST resolve to a reproducible revision or content hash; live moving web content MUST NOT be a silent build input.
+
+### KIS-DOC-REF-007
+
+Contradictions with a canonical owner MUST surface as diagnostics and MUST NOT silently change the canonical value.
+
+### KIS-DOC-REF-008
+
+Generated documentation MUST remain a deterministic review projection with no write-back authority.
+
+### KIS-DOC-REF-009
+
+External content MUST NOT be harvested beyond metadata or bounded evidence until licensing, attribution, and reuse constraints are recorded.
+
+## Source and authority
+
+This page is generated from `KIS-DOC-CON-POL-001` and `KIS-DOC-SEM-REG-001`. It has no write-back authority.

--- a/generated/documentation-reference-standard/002-reference-catalogue.md
+++ b/generated/documentation-reference-standard/002-reference-catalogue.md
@@ -1,0 +1,23 @@
+<!-- GENERATED -- DO NOT EDIT -->
+# Documentation reference catalogue
+
+Each entry has a bounded role. Only the applicable canonical owner can define a KIS fact.
+
+| Reference | Role | Permitted use | Pin | Lifecycle |
+|---|---|---|---|---|
+| Model Context Protocol 2026-07-28 | `normative_external` | `protocol_conformance`, `specification_structure`, `normative_presentation`, `schema_reference` | `content_sha256` at `2026-07-28` | `active` |
+| Google Developer Documentation Style Guide | `prescriptive_external` | `human_prose`, `task_documentation`, `headings`, `lists`, `tables`, `cross_references` | `captured_corpus_sha256` at `captured-corpus-2026-08-26` | `active` |
+| Sentry MCP | `implementation_reference` | `documentation_architecture`, `engineering_documentation`, `operations`, `security` | `research_evidence_sha256` at `change-008-preparation@2785a3b` | `active` |
+| GitHub MCP Server | `implementation_reference` | `tool_reference`, `configuration_reference`, `generated_documentation`, `stale_detection` | `research_evidence_sha256` at `change-008-preparation@2785a3b` | `active` |
+| Azure MCP Server | `implementation_reference` | `large_scale_reference`, `generated_reference`, `drift_control` | `research_evidence_sha256` at `change-008-preparation@2785a3b` | `active` |
+| Playwright MCP | `implementation_reference` | `task_oriented_documentation`, `getting_started`, `generated_tool_reference` | `research_evidence_sha256` at `change-008-preparation@2785a3b` | `active` |
+| Atlassian Rovo MCP | `implementation_reference` | `permissions_presentation`, `capability_catalogue`, `discover_execute_patterns` | `research_evidence_sha256` at `change-008-preparation@2785a3b` | `active` |
+| Figma MCP | `implementation_reference` | `workflow_oriented_documentation`, `task_grouping` | `research_evidence_sha256` at `change-008-preparation@2785a3b` | `active` |
+| AWS Labs MCP | `implementation_reference` | `multi_module_consistency`, `repeatable_server_documentation` | `research_evidence_sha256` at `change-008-preparation@2785a3b` | `active` |
+| Cloudflare MCP | `implementation_reference` | `tool_surface_scaling`, `context_budget`, `dynamic_discovery` | `research_evidence_sha256` at `change-008-preparation@2785a3b` | `active` |
+
+## Licensing and refresh
+
+Metadata and bounded pattern summaries are permitted. Harvesting reusable source content requires source-specific license and attribution review first.
+
+Refresh references only through a governed registry change. Deterministic builds use the pinned registry state and never fetch live sources.

--- a/generated/documentation-reference-standard/data/reference-registry.json
+++ b/generated/documentation-reference-standard/data/reference-registry.json
@@ -1,0 +1,330 @@
+{
+  "evidence_records": [
+    {
+      "git_commit": "2785a3b7a6f42b22ef48e8b151473717a7af5a1e",
+      "id": "change-008-preparation@2785a3b",
+      "kind": "governed_research_record",
+      "sha256": "007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07",
+      "source_path": ".work/changes/008-documentation-reference-standard/change.mrd.json"
+    }
+  ],
+  "licensing_policy": "Metadata and bounded pattern summaries are permitted. Harvesting reusable source content requires source-specific license and attribution review first.",
+  "references": [
+    {
+      "freshness": {
+        "checked_on": "2026-08-26",
+        "strategy": "governed_version_refresh"
+      },
+      "harvest_source_id": "mcp-spec-2026-07-28",
+      "id": "mcp-2026",
+      "license": {
+        "reuse_boundary": "normative_reference_and_bounded_excerpt_only",
+        "status": "source_terms_apply"
+      },
+      "lifecycle": {
+        "state": "active",
+        "superseded_by": null,
+        "supersedes": []
+      },
+      "locator": "https://modelcontextprotocol.io/specification/2026-07-28/",
+      "may_define_kis_facts": false,
+      "name": "Model Context Protocol 2026-07-28",
+      "permitted_uses": [
+        "protocol_conformance",
+        "specification_structure",
+        "normative_presentation",
+        "schema_reference"
+      ],
+      "pin": {
+        "kind": "content_sha256",
+        "revision": "2026-07-28",
+        "value": "8d5af577abff93b6c3a62419f146345f3387550e22255cf81004080e87a761e2"
+      },
+      "role": "normative_external"
+    },
+    {
+      "freshness": {
+        "checked_on": "2026-08-26",
+        "strategy": "governed_corpus_refresh"
+      },
+      "harvest_source_id": null,
+      "id": "google-developer-style",
+      "license": {
+        "reuse_boundary": "prescriptive_guidance_and_bounded_excerpt_only",
+        "status": "source_terms_apply"
+      },
+      "lifecycle": {
+        "state": "active",
+        "superseded_by": null,
+        "supersedes": []
+      },
+      "locator": "https://developers.google.com/style",
+      "may_define_kis_facts": false,
+      "name": "Google Developer Documentation Style Guide",
+      "permitted_uses": [
+        "human_prose",
+        "task_documentation",
+        "headings",
+        "lists",
+        "tables",
+        "cross_references"
+      ],
+      "pin": {
+        "kind": "captured_corpus_sha256",
+        "revision": "captured-corpus-2026-08-26",
+        "value": "d9081dff4aad18561f3c4d492a2623b181f7a5f347436eb2519d6ca4c3fdc7c9"
+      },
+      "role": "prescriptive_external"
+    },
+    {
+      "freshness": {
+        "checked_on": "2026-08-26",
+        "strategy": "governed_research_refresh"
+      },
+      "harvest_source_id": null,
+      "id": "sentry-mcp",
+      "license": {
+        "reuse_boundary": "metadata_and_bounded_pattern_summary_only",
+        "status": "content_not_harvested"
+      },
+      "lifecycle": {
+        "state": "active",
+        "superseded_by": null,
+        "supersedes": []
+      },
+      "locator": "https://github.com/getsentry/sentry-mcp",
+      "may_define_kis_facts": false,
+      "name": "Sentry MCP",
+      "permitted_uses": [
+        "documentation_architecture",
+        "engineering_documentation",
+        "operations",
+        "security"
+      ],
+      "pin": {
+        "kind": "research_evidence_sha256",
+        "revision": "change-008-preparation@2785a3b",
+        "value": "007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07"
+      },
+      "role": "implementation_reference"
+    },
+    {
+      "freshness": {
+        "checked_on": "2026-08-26",
+        "strategy": "governed_research_refresh"
+      },
+      "harvest_source_id": null,
+      "id": "github-mcp",
+      "license": {
+        "reuse_boundary": "metadata_and_bounded_pattern_summary_only",
+        "status": "content_not_harvested"
+      },
+      "lifecycle": {
+        "state": "active",
+        "superseded_by": null,
+        "supersedes": []
+      },
+      "locator": "https://github.com/github/github-mcp-server",
+      "may_define_kis_facts": false,
+      "name": "GitHub MCP Server",
+      "permitted_uses": [
+        "tool_reference",
+        "configuration_reference",
+        "generated_documentation",
+        "stale_detection"
+      ],
+      "pin": {
+        "kind": "research_evidence_sha256",
+        "revision": "change-008-preparation@2785a3b",
+        "value": "007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07"
+      },
+      "role": "implementation_reference"
+    },
+    {
+      "freshness": {
+        "checked_on": "2026-08-26",
+        "strategy": "governed_research_refresh"
+      },
+      "harvest_source_id": null,
+      "id": "azure-mcp",
+      "license": {
+        "reuse_boundary": "metadata_and_bounded_pattern_summary_only",
+        "status": "content_not_harvested"
+      },
+      "lifecycle": {
+        "state": "active",
+        "superseded_by": null,
+        "supersedes": []
+      },
+      "locator": "https://github.com/microsoft/mcp",
+      "may_define_kis_facts": false,
+      "name": "Azure MCP Server",
+      "permitted_uses": [
+        "large_scale_reference",
+        "generated_reference",
+        "drift_control"
+      ],
+      "pin": {
+        "kind": "research_evidence_sha256",
+        "revision": "change-008-preparation@2785a3b",
+        "value": "007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07"
+      },
+      "role": "implementation_reference"
+    },
+    {
+      "freshness": {
+        "checked_on": "2026-08-26",
+        "strategy": "governed_research_refresh"
+      },
+      "harvest_source_id": null,
+      "id": "playwright-mcp",
+      "license": {
+        "reuse_boundary": "metadata_and_bounded_pattern_summary_only",
+        "status": "content_not_harvested"
+      },
+      "lifecycle": {
+        "state": "active",
+        "superseded_by": null,
+        "supersedes": []
+      },
+      "locator": "https://github.com/microsoft/playwright-mcp",
+      "may_define_kis_facts": false,
+      "name": "Playwright MCP",
+      "permitted_uses": [
+        "task_oriented_documentation",
+        "getting_started",
+        "generated_tool_reference"
+      ],
+      "pin": {
+        "kind": "research_evidence_sha256",
+        "revision": "change-008-preparation@2785a3b",
+        "value": "007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07"
+      },
+      "role": "implementation_reference"
+    },
+    {
+      "freshness": {
+        "checked_on": "2026-08-26",
+        "strategy": "governed_research_refresh"
+      },
+      "harvest_source_id": null,
+      "id": "atlassian-rovo-mcp",
+      "license": {
+        "reuse_boundary": "metadata_and_bounded_pattern_summary_only",
+        "status": "content_not_harvested"
+      },
+      "lifecycle": {
+        "state": "active",
+        "superseded_by": null,
+        "supersedes": []
+      },
+      "locator": "https://developer.atlassian.com/cloud/rovo-mcp/guides/supported-tools/",
+      "may_define_kis_facts": false,
+      "name": "Atlassian Rovo MCP",
+      "permitted_uses": [
+        "permissions_presentation",
+        "capability_catalogue",
+        "discover_execute_patterns"
+      ],
+      "pin": {
+        "kind": "research_evidence_sha256",
+        "revision": "change-008-preparation@2785a3b",
+        "value": "007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07"
+      },
+      "role": "implementation_reference"
+    },
+    {
+      "freshness": {
+        "checked_on": "2026-08-26",
+        "strategy": "governed_research_refresh"
+      },
+      "harvest_source_id": null,
+      "id": "figma-mcp",
+      "license": {
+        "reuse_boundary": "metadata_and_bounded_pattern_summary_only",
+        "status": "content_not_harvested"
+      },
+      "lifecycle": {
+        "state": "active",
+        "superseded_by": null,
+        "supersedes": []
+      },
+      "locator": "https://developers.figma.com/docs/figma-mcp-server/",
+      "may_define_kis_facts": false,
+      "name": "Figma MCP",
+      "permitted_uses": [
+        "workflow_oriented_documentation",
+        "task_grouping"
+      ],
+      "pin": {
+        "kind": "research_evidence_sha256",
+        "revision": "change-008-preparation@2785a3b",
+        "value": "007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07"
+      },
+      "role": "implementation_reference"
+    },
+    {
+      "freshness": {
+        "checked_on": "2026-08-26",
+        "strategy": "governed_research_refresh"
+      },
+      "harvest_source_id": null,
+      "id": "aws-labs-mcp",
+      "license": {
+        "reuse_boundary": "metadata_and_bounded_pattern_summary_only",
+        "status": "content_not_harvested"
+      },
+      "lifecycle": {
+        "state": "active",
+        "superseded_by": null,
+        "supersedes": []
+      },
+      "locator": "https://github.com/awslabs/mcp",
+      "may_define_kis_facts": false,
+      "name": "AWS Labs MCP",
+      "permitted_uses": [
+        "multi_module_consistency",
+        "repeatable_server_documentation"
+      ],
+      "pin": {
+        "kind": "research_evidence_sha256",
+        "revision": "change-008-preparation@2785a3b",
+        "value": "007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07"
+      },
+      "role": "implementation_reference"
+    },
+    {
+      "freshness": {
+        "checked_on": "2026-08-26",
+        "strategy": "governed_research_refresh"
+      },
+      "harvest_source_id": null,
+      "id": "cloudflare-mcp",
+      "license": {
+        "reuse_boundary": "metadata_and_bounded_pattern_summary_only",
+        "status": "content_not_harvested"
+      },
+      "lifecycle": {
+        "state": "active",
+        "superseded_by": null,
+        "supersedes": []
+      },
+      "locator": "https://github.com/cloudflare/mcp",
+      "may_define_kis_facts": false,
+      "name": "Cloudflare MCP",
+      "permitted_uses": [
+        "tool_surface_scaling",
+        "context_budget",
+        "dynamic_discovery"
+      ],
+      "pin": {
+        "kind": "research_evidence_sha256",
+        "revision": "change-008-preparation@2785a3b",
+        "value": "007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07"
+      },
+      "role": "implementation_reference"
+    }
+  ],
+  "refresh_policy": "Refresh references only through a governed registry change. Deterministic builds use the pinned registry state and never fetch live sources.",
+  "registry_version": "1.0.0"
+}

--- a/generated/documentation-reference-standard/manifest.json
+++ b/generated/documentation-reference-standard/manifest.json
@@ -1,0 +1,100 @@
+{
+  "bundle_sha256": "6add3c2ee2137cecd272eedc83151bd747490030b22274b1692a47873ccac7a2",
+  "contract": {
+    "name": "documentation-reference-standard-build",
+    "version": 1
+  },
+  "files": [
+    {
+      "bytes": 419,
+      "path": "000-index.md",
+      "sha256": "73c7320926d381dd89a99a55eaeb9b92617a49da32e406359c2db468fbdd28ee"
+    },
+    {
+      "bytes": 3907,
+      "path": "001-specification.md",
+      "sha256": "51bcb9eb34c848d2ef4c0229fe10c8f61b33584d105201dbae874045e39e2934"
+    },
+    {
+      "bytes": 2573,
+      "path": "002-reference-catalogue.md",
+      "sha256": "4a3049eb7b772ef586ba9df7c70bf07884d84c1e07ee41bea39770489481be55"
+    },
+    {
+      "bytes": 10384,
+      "path": "data/reference-registry.json",
+      "sha256": "0daffac7e07d744a752affde559c65708568fd2ce6fc95d7672185717145d3cc"
+    }
+  ],
+  "input_set_sha256": "b96d60b414c18921aa43fb76a1b2a820a97d09fce00ddb0e084ba42c300a0b09",
+  "inputs": [
+    {
+      "bytes": 5712,
+      "path": "mrd/documentation/01-reference-standard.mrd.json",
+      "sha256": "da30a9f44828194a6b0b1e382c39936ae3d07705521dd6c07af60286b5133dc1"
+    },
+    {
+      "bytes": 8944,
+      "path": "mrd/documentation/02-reference-registry.mrd.json",
+      "sha256": "5a1f98e9fb937df209e303abc6fa3af3fd73c922a868e76519939d6dd42ec24c"
+    },
+    {
+      "bytes": 403,
+      "path": "publication/documentation-reference-standard.json",
+      "sha256": "35f4170ba7e70cabc664b6f880f41af40a897909c982c4cdc30cb03d5f412fdd"
+    },
+    {
+      "bytes": 5511,
+      "path": "contracts/mrd/v1/mrd.schema.json",
+      "sha256": "fb9f3210b022d8def12a92bfccc1cb45e5ccf1146fa9d59168baf3f630ded153"
+    },
+    {
+      "bytes": 1686,
+      "path": "contracts/documentation/reference/v1/standard.schema.json",
+      "sha256": "5169879bbf6f2438d805e79daf89288be7e06174136109ad195f189efea27995"
+    },
+    {
+      "bytes": 3013,
+      "path": "contracts/documentation/reference/v1/registry.schema.json",
+      "sha256": "5463214ffde7a87354bd4760a2f91af72258c5c8114cd9d01545874c33c578ec"
+    },
+    {
+      "bytes": 964,
+      "path": "contracts/documentation/reference/v1/publication.schema.json",
+      "sha256": "3c00d080610c02816a0d13e8b2677f7af3fefb777b0bd1d9f493ae4b1d7507b7"
+    },
+    {
+      "bytes": 1575,
+      "path": "contracts/documentation/reference/v1/manifest.schema.json",
+      "sha256": "c319f7a303e859787a59c0ff1a0299820977bcfd8a9542135ff67546e42d2e8e"
+    },
+    {
+      "bytes": 4012,
+      "path": "publication/harvest-sources.json",
+      "sha256": "c95235389e40f4761f345225db13a4465d16d4024f029858206571b6bd6ab4a7"
+    },
+    {
+      "bytes": 20315,
+      "path": "src/kis_mcp_doc/documentation_reference.py",
+      "sha256": "a4587ece5b73b39b0f3060001ba1879452f0dc3c43405b682329c1b16dc78578"
+    }
+  ],
+  "specification": {
+    "layout_profile": "mcp-spec",
+    "status": "draft",
+    "title": "Documentation Reference Standard",
+    "version": "1.0.0"
+  },
+  "validation": {
+    "checks": {
+      "authority": "pass",
+      "harvest_binding": "pass",
+      "lifecycle": "pass",
+      "pinning": "pass",
+      "provenance": "pass",
+      "schema": "pass"
+    },
+    "diagnostics": [],
+    "status": "valid"
+  }
+}

--- a/mrd/documentation/01-reference-standard.mrd.json
+++ b/mrd/documentation/01-reference-standard.mrd.json
@@ -1,0 +1,66 @@
+{
+  "_mrd": {
+    "schema_version": 1,
+    "id": "KIS-DOC-CON-POL-001",
+    "title": "Documentation Reference Standard",
+    "module": "documentation",
+    "class": "CON",
+    "type": "POL",
+    "layer": "L1",
+    "record_mode": "prescriptive",
+    "status": "active",
+    "version": "1.0.0",
+    "dependencies": [
+      {"mrd_id": "KIS-KNOW-CON-POL-002", "relationship": "depends_on"},
+      {"mrd_id": "KIS-KNOW-SEM-REG-001", "relationship": "depends_on"},
+      {"mrd_id": "KIS-DOC-SEM-REG-001", "relationship": "governs"},
+      {"source": "repo:publication/harvest-sources.json", "relationship": "references"}
+    ],
+    "provenance": {
+      "sources": [
+        {"source_id": "KIS-OPERATOR-DIRECTION-2026-08-26-DOCUMENTATION-REFERENCE-STANDARD", "kind": "operator_direction", "role": "normative_adoption_basis", "locator": "conversation:2026-08-26", "revision": "implementation-approved", "sha256": null}
+      ],
+      "source_fingerprint": "sha256:d3bbcb111a0cdb3c83a2bcbad87ff21b886b07ba8454a4756ff3332b03396a16",
+      "fact_quality": "direct"
+    },
+    "supersedes": [],
+    "superseded_by": null
+  },  "content": {
+    "concern": "documentation_reference_authority",
+    "heading": "Documentation Reference Standard",
+    "purpose": "Govern how KIS documentation uses canonical KIS authority, normative protocol sources, prescriptive writing guidance, implementation references, and inferred evidence without creating duplicate fact ownership.",
+    "authority_model": [
+      {"role": "canonical_kis", "domain": "KIS-specific facts, behavior, policy, configuration, lifecycle, and adopted requirements", "may_define_kis_facts": true},
+      {"role": "normative_external", "domain": "The bounded conformance domain owned by the external standard", "may_define_kis_facts": false},
+      {"role": "prescriptive_external", "domain": "Presentation or practice guidance where KIS authority is silent", "may_define_kis_facts": false},
+      {"role": "implementation_reference", "domain": "Bounded reusable documentation or engineering patterns", "may_define_kis_facts": false},
+      {"role": "inferred_evidence", "domain": "Derived evidence requiring verification against an owning source", "may_define_kis_facts": false}
+    ],
+    "output_classes": [
+      {"class": "human_documentation", "purpose": "Teach concepts, tasks, workflows, examples, architecture, and operations in reader-oriented prose.", "source_rule": "Canonical KIS facts supply factual content; approved references may inform organization and presentation only."},
+      {"class": "human_readable_specification", "purpose": "Explain adopted normative behavior while preserving requirement strength, identifiers, ownership, and traceability.", "source_rule": "Adopted KIS MRDs and applicable normative external standards supply requirements; generated prose remains non-authoritative."},
+      {"class": "generated_reference", "purpose": "Expose exact tools, schemas, settings, policies, states, relationships, capabilities, permissions, and provenance.", "source_rule": "Only canonical KIS facts or explicitly applicable normative protocol facts may populate factual reference data."}
+    ],
+    "registry_contract": {
+      "owner": "KIS-DOC-SEM-REG-001",
+      "harvest_registry": "publication/harvest-sources.json",
+      "relationship": "semantic registry references acquisition identities; it does not duplicate acquisition configuration",
+      "required_lifecycle_states": ["active", "deprecated", "superseded", "removed"]
+    },    "conflict_behavior": {
+      "canonical_conflict": "surface_diagnostic_and_keep_canonical_owner",
+      "unsupported_promotion": "block",
+      "stale_or_unpinned_reference": "block_when_active_or_used_by_deterministic_generation"
+    },
+    "requirements": [
+      {"rule_id": "KIS-DOC-REF-001", "statement": "Every admitted documentation reference MUST declare one source role, bounded permitted uses, provenance, freshness strategy, lifecycle state, and authority limit.", "enforcement": "validator"},
+      {"rule_id": "KIS-DOC-REF-002", "statement": "KIS-owned factual content MUST remain sourced from its current canonical owner; a documentation reference MUST NOT become a second owner.", "enforcement": "validator"},
+      {"rule_id": "KIS-DOC-REF-003", "statement": "MCP 2026-07-28 MUST be treated as normative only within its applicable MCP protocol-conformance domain.", "enforcement": "validator"},
+      {"rule_id": "KIS-DOC-REF-004", "statement": "Google Developer Documentation guidance MUST remain presentation guidance and MUST NOT define KIS runtime or governance semantics.", "enforcement": "validator"},
+      {"rule_id": "KIS-DOC-REF-005", "statement": "Implementation references and inferred evidence MUST NOT populate canonical KIS facts without a separately governed adoption decision.", "enforcement": "validator"},
+      {"rule_id": "KIS-DOC-REF-006", "statement": "Material used by deterministic generation MUST resolve to a reproducible revision or content hash; live moving web content MUST NOT be a silent build input.", "enforcement": "validator"},
+      {"rule_id": "KIS-DOC-REF-007", "statement": "Contradictions with a canonical owner MUST surface as diagnostics and MUST NOT silently change the canonical value.", "enforcement": "validator"},
+      {"rule_id": "KIS-DOC-REF-008", "statement": "Generated documentation MUST remain a deterministic review projection with no write-back authority.", "enforcement": "generator"},
+      {"rule_id": "KIS-DOC-REF-009", "statement": "External content MUST NOT be harvested beyond metadata or bounded evidence until licensing, attribution, and reuse constraints are recorded.", "enforcement": "workflow"}
+    ]
+  }
+}

--- a/mrd/documentation/02-reference-registry.mrd.json
+++ b/mrd/documentation/02-reference-registry.mrd.json
@@ -1,0 +1,56 @@
+{
+  "_mrd": {
+    "schema_version": 1,
+    "id": "KIS-DOC-SEM-REG-001",
+    "title": "Documentation Reference Registry",
+    "module": "documentation",
+    "class": "SEM",
+    "type": "REG",
+    "layer": "L1",
+    "record_mode": "prescriptive",
+    "status": "active",
+    "version": "1.0.0",
+    "dependencies": [
+      {"mrd_id": "KIS-DOC-CON-POL-001", "relationship": "depends_on"},
+      {"source": "repo:publication/harvest-sources.json", "relationship": "references"}
+    ],
+    "provenance": {
+      "sources": [
+        {"source_id": "KIS-EXTERNAL-MCP-DOC-RESEARCH-2026-08-26", "kind": "research_evidence", "role": "reference_selection_basis", "locator": "conversation:2026-08-26", "revision": "comparative-mcp-documentation-research", "sha256": null}
+      ],
+      "source_fingerprint": "sha256:02eed97bc1cb864bcdec59eefd5bb0fd4fe70a7b3c7991f87e2ea47e8b0587e2",
+      "fact_quality": "direct"
+    },
+    "supersedes": [],
+    "superseded_by": null
+  },
+  "content": {
+    "registry_version": "1.0.0",
+    "refresh_policy": "Refresh references only through a governed registry change. Deterministic builds use the pinned registry state and never fetch live sources.",
+    "licensing_policy": "Metadata and bounded pattern summaries are permitted. Harvesting reusable source content requires source-specific license and attribution review first.",
+    "evidence_records": [
+      {"id":"change-008-preparation@2785a3b","kind":"governed_research_record","source_path":".work/changes/008-documentation-reference-standard/change.mrd.json","git_commit":"2785a3b7a6f42b22ef48e8b151473717a7af5a1e","sha256":"007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07"}
+    ],
+    "references": [      {
+        "id": "mcp-2026", "name": "Model Context Protocol 2026-07-28", "role": "normative_external", "locator": "https://modelcontextprotocol.io/specification/2026-07-28/", "harvest_source_id": "mcp-spec-2026-07-28",
+        "permitted_uses": ["protocol_conformance", "specification_structure", "normative_presentation", "schema_reference"], "may_define_kis_facts": false,
+        "pin": {"kind": "content_sha256", "value": "8d5af577abff93b6c3a62419f146345f3387550e22255cf81004080e87a761e2", "revision": "2026-07-28"},
+        "freshness": {"strategy": "governed_version_refresh", "checked_on": "2026-08-26"}, "lifecycle": {"state": "active", "supersedes": [], "superseded_by": null},
+        "license": {"reuse_boundary": "normative_reference_and_bounded_excerpt_only", "status": "source_terms_apply"}
+      },
+      {
+        "id": "google-developer-style", "name": "Google Developer Documentation Style Guide", "role": "prescriptive_external", "locator": "https://developers.google.com/style", "harvest_source_id": null,
+        "permitted_uses": ["human_prose", "task_documentation", "headings", "lists", "tables", "cross_references"], "may_define_kis_facts": false,
+        "pin": {"kind": "captured_corpus_sha256", "value": "d9081dff4aad18561f3c4d492a2623b181f7a5f347436eb2519d6ca4c3fdc7c9", "revision": "captured-corpus-2026-08-26"},
+        "freshness": {"strategy": "governed_corpus_refresh", "checked_on": "2026-08-26"}, "lifecycle": {"state": "active", "supersedes": [], "superseded_by": null},
+        "license": {"reuse_boundary": "prescriptive_guidance_and_bounded_excerpt_only", "status": "source_terms_apply"}
+      },      {"id":"sentry-mcp","name":"Sentry MCP","role":"implementation_reference","locator":"https://github.com/getsentry/sentry-mcp","harvest_source_id":null,"permitted_uses":["documentation_architecture","engineering_documentation","operations","security"],"may_define_kis_facts":false,"pin":{"kind":"research_evidence_sha256","value":"007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07","revision":"change-008-preparation@2785a3b"},"freshness":{"strategy":"governed_research_refresh","checked_on":"2026-08-26"},"lifecycle":{"state":"active","supersedes":[],"superseded_by":null},"license":{"reuse_boundary":"metadata_and_bounded_pattern_summary_only","status":"content_not_harvested"}},
+      {"id":"github-mcp","name":"GitHub MCP Server","role":"implementation_reference","locator":"https://github.com/github/github-mcp-server","harvest_source_id":null,"permitted_uses":["tool_reference","configuration_reference","generated_documentation","stale_detection"],"may_define_kis_facts":false,"pin":{"kind":"research_evidence_sha256","value":"007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07","revision":"change-008-preparation@2785a3b"},"freshness":{"strategy":"governed_research_refresh","checked_on":"2026-08-26"},"lifecycle":{"state":"active","supersedes":[],"superseded_by":null},"license":{"reuse_boundary":"metadata_and_bounded_pattern_summary_only","status":"content_not_harvested"}},
+      {"id":"azure-mcp","name":"Azure MCP Server","role":"implementation_reference","locator":"https://github.com/microsoft/mcp","harvest_source_id":null,"permitted_uses":["large_scale_reference","generated_reference","drift_control"],"may_define_kis_facts":false,"pin":{"kind":"research_evidence_sha256","value":"007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07","revision":"change-008-preparation@2785a3b"},"freshness":{"strategy":"governed_research_refresh","checked_on":"2026-08-26"},"lifecycle":{"state":"active","supersedes":[],"superseded_by":null},"license":{"reuse_boundary":"metadata_and_bounded_pattern_summary_only","status":"content_not_harvested"}},
+      {"id":"playwright-mcp","name":"Playwright MCP","role":"implementation_reference","locator":"https://github.com/microsoft/playwright-mcp","harvest_source_id":null,"permitted_uses":["task_oriented_documentation","getting_started","generated_tool_reference"],"may_define_kis_facts":false,"pin":{"kind":"research_evidence_sha256","value":"007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07","revision":"change-008-preparation@2785a3b"},"freshness":{"strategy":"governed_research_refresh","checked_on":"2026-08-26"},"lifecycle":{"state":"active","supersedes":[],"superseded_by":null},"license":{"reuse_boundary":"metadata_and_bounded_pattern_summary_only","status":"content_not_harvested"}},      {"id":"atlassian-rovo-mcp","name":"Atlassian Rovo MCP","role":"implementation_reference","locator":"https://developer.atlassian.com/cloud/rovo-mcp/guides/supported-tools/","harvest_source_id":null,"permitted_uses":["permissions_presentation","capability_catalogue","discover_execute_patterns"],"may_define_kis_facts":false,"pin":{"kind":"research_evidence_sha256","value":"007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07","revision":"change-008-preparation@2785a3b"},"freshness":{"strategy":"governed_research_refresh","checked_on":"2026-08-26"},"lifecycle":{"state":"active","supersedes":[],"superseded_by":null},"license":{"reuse_boundary":"metadata_and_bounded_pattern_summary_only","status":"content_not_harvested"}},
+      {"id":"figma-mcp","name":"Figma MCP","role":"implementation_reference","locator":"https://developers.figma.com/docs/figma-mcp-server/","harvest_source_id":null,"permitted_uses":["workflow_oriented_documentation","task_grouping"],"may_define_kis_facts":false,"pin":{"kind":"research_evidence_sha256","value":"007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07","revision":"change-008-preparation@2785a3b"},"freshness":{"strategy":"governed_research_refresh","checked_on":"2026-08-26"},"lifecycle":{"state":"active","supersedes":[],"superseded_by":null},"license":{"reuse_boundary":"metadata_and_bounded_pattern_summary_only","status":"content_not_harvested"}},
+      {"id":"aws-labs-mcp","name":"AWS Labs MCP","role":"implementation_reference","locator":"https://github.com/awslabs/mcp","harvest_source_id":null,"permitted_uses":["multi_module_consistency","repeatable_server_documentation"],"may_define_kis_facts":false,"pin":{"kind":"research_evidence_sha256","value":"007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07","revision":"change-008-preparation@2785a3b"},"freshness":{"strategy":"governed_research_refresh","checked_on":"2026-08-26"},"lifecycle":{"state":"active","supersedes":[],"superseded_by":null},"license":{"reuse_boundary":"metadata_and_bounded_pattern_summary_only","status":"content_not_harvested"}},
+      {"id":"cloudflare-mcp","name":"Cloudflare MCP","role":"implementation_reference","locator":"https://github.com/cloudflare/mcp","harvest_source_id":null,"permitted_uses":["tool_surface_scaling","context_budget","dynamic_discovery"],"may_define_kis_facts":false,"pin":{"kind":"research_evidence_sha256","value":"007662c0d3527c5d22b7963901d495c68db89483d8087ec03fbb628546399a07","revision":"change-008-preparation@2785a3b"},"freshness":{"strategy":"governed_research_refresh","checked_on":"2026-08-26"},"lifecycle":{"state":"active","supersedes":[],"superseded_by":null},"license":{"reuse_boundary":"metadata_and_bounded_pattern_summary_only","status":"content_not_harvested"}}
+    ]
+  }
+}

--- a/publication/documentation-reference-standard.json
+++ b/publication/documentation-reference-standard.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "layout_profile": "mcp-spec",
+  "title": "Documentation Reference Standard",
+  "subtitle": "Source roles, authority boundaries, provenance, lifecycle, and permitted use for KIS documentation references",
+  "version": "1.0.0",
+  "status": "draft",
+  "generator": {
+    "name": "kis-mcp-doc",
+    "version": "0.1.0",
+    "algorithm": "documentation-reference-standard-v1"
+  }
+}

--- a/scripts/verify.ps1
+++ b/scripts/verify.ps1
@@ -22,7 +22,8 @@ if ($env:KIS_EXACT_SHA) {
 
 $AllowedGeneratedMarkdownPrefixes = @(
     'generated/governance-spec/',
-    'generated/work-management-spec/'
+    'generated/work-management-spec/',
+    'generated/documentation-reference-standard/'
 )
 $TrackedMarkdown = @(& git -C $RepositoryRoot ls-files '*.md')
 $UnexpectedMarkdown = @(
@@ -65,6 +66,16 @@ try {
     & $PythonCommand -m kis_mcp_doc --root . check-generated
     if ($LASTEXITCODE -ne 0) {
         throw "Generated-output verification failed with exit code $LASTEXITCODE"
+    }
+
+    & $PythonCommand -m kis_mcp_doc --root . references-validate
+    if ($LASTEXITCODE -ne 0) {
+        throw "Documentation Reference Standard validation failed with exit code $LASTEXITCODE"
+    }
+
+    & $PythonCommand -m kis_mcp_doc --root . references-check-generated
+    if ($LASTEXITCODE -ne 0) {
+        throw "Documentation Reference Standard generated-output verification failed with exit code $LASTEXITCODE"
     }
 
     & $PythonCommand -m kis_mcp_doc --root . work-validate

--- a/src/kis_mcp_doc/cli.py
+++ b/src/kis_mcp_doc/cli.py
@@ -4,9 +4,18 @@ import argparse
 import json
 from pathlib import Path
 
+from .documentation_reference import (
+    DocumentationReferenceRepository,
+    build_documentation_reference_standard,
+    verify_documentation_reference_standard,
+)
 from .governance import GovernanceRepository
 from .render import build_governance_spec, verify_governance_spec
-from .work_management import WorkManagementRepository, build_work_management_spec, verify_work_management_spec
+from .work_management import (
+    WorkManagementRepository,
+    build_work_management_spec,
+    verify_work_management_spec,
+)
 
 
 def _repository(root: Path) -> GovernanceRepository:
@@ -18,6 +27,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--root", type=Path, default=Path.cwd())
     sub = parser.add_subparsers(dest="command", required=True)
     sub.add_parser("validate")
+    sub.add_parser("references-validate")
+    references_build = sub.add_parser("references-build")
+    references_build.add_argument("--output", type=Path)
+    references_build.add_argument("--replace", action="store_true")
+    references_check = sub.add_parser("references-check-generated")
+    references_check.add_argument("--output", type=Path)
     sub.add_parser("work-validate")
     work_build = sub.add_parser("work-build")
     work_build.add_argument("--output", type=Path)
@@ -40,6 +55,24 @@ def main(argv: list[str] | None = None) -> int:
         result = repo.validate()
         print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
         return 0 if result["status"] == "valid" else 1
+    if args.command == "references-validate":
+        result = DocumentationReferenceRepository(root).validate()
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0 if result["status"] == "valid" else 1
+    if args.command == "references-build":
+        output = args.output or (root / "generated" / "documentation-reference-standard")
+        manifest = build_documentation_reference_standard(
+            DocumentationReferenceRepository(root), output, replace=args.replace
+        )
+        print(json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+    if args.command == "references-check-generated":
+        output = args.output or (root / "generated" / "documentation-reference-standard")
+        result = verify_documentation_reference_standard(
+            DocumentationReferenceRepository(root), output
+        )
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0 if result["status"] == "valid" else 1
 
     if args.command == "work-validate":
         result = WorkManagementRepository(root).validate()
@@ -47,7 +80,9 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if result["status"] == "valid" else 1
     if args.command == "work-build":
         output = args.output or (root / "generated" / "work-management-spec")
-        manifest = build_work_management_spec(WorkManagementRepository(root), output, replace=args.replace)
+        manifest = build_work_management_spec(
+            WorkManagementRepository(root), output, replace=args.replace
+        )
         print(json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True))
         return 0
     if args.command == "work-check-generated":
@@ -67,14 +102,12 @@ def main(argv: list[str] | None = None) -> int:
         )
         print(json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True))
         return 0
-
     if args.command == "check-generated":
         result = verify_governance_spec(
             repo, publication, output, litho_package=args.litho_package
         )
         print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
         return 0 if result["status"] == "valid" else 1
-
     return 2
 
 

--- a/src/kis_mcp_doc/documentation_reference.py
+++ b/src/kis_mcp_doc/documentation_reference.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from .governance import canonical_hash, canonical_source_bytes
+from .harvest import load_harvest_registry
+
+
+_POLICY_PATH = "mrd/documentation/01-reference-standard.mrd.json"
+_REGISTRY_PATH = "mrd/documentation/02-reference-registry.mrd.json"
+_CORE_SCHEMA = "contracts/mrd/v1/mrd.schema.json"
+_POLICY_SCHEMA = "contracts/documentation/reference/v1/standard.schema.json"
+_REGISTRY_SCHEMA = "contracts/documentation/reference/v1/registry.schema.json"
+_PUBLICATION_SCHEMA = "contracts/documentation/reference/v1/publication.schema.json"
+_MANIFEST_SCHEMA = "contracts/documentation/reference/v1/manifest.schema.json"
+_PUBLICATION = "publication/documentation-reference-standard.json"
+
+_EXPECTED_REFERENCES = {
+    "mcp-2026": "normative_external",
+    "google-developer-style": "prescriptive_external",
+    "sentry-mcp": "implementation_reference",
+    "github-mcp": "implementation_reference",
+    "azure-mcp": "implementation_reference",
+    "playwright-mcp": "implementation_reference",
+    "atlassian-rovo-mcp": "implementation_reference",
+    "figma-mcp": "implementation_reference",
+    "aws-labs-mcp": "implementation_reference",
+    "cloudflare-mcp": "implementation_reference",
+}
+
+
+class DocumentationReferenceRepository:
+    def __init__(self, root: Path) -> None:
+        self.root = Path(root).resolve()
+
+    def load(self) -> dict[str, dict[str, Any]]:
+        documents: dict[str, dict[str, Any]] = {}
+        for relative in (_POLICY_PATH, _REGISTRY_PATH):
+            path = self.root / relative
+            try:
+                document = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, json.JSONDecodeError) as error:
+                raise ValueError(f"unable to load documentation reference MRD {relative}: {error}") from error
+            doc_id = document.get("_mrd", {}).get("id")
+            if not isinstance(doc_id, str):
+                raise ValueError(f"documentation reference MRD has no id: {relative}")
+            if doc_id in documents:
+                raise ValueError(f"duplicate documentation reference MRD id: {doc_id}")
+            documents[doc_id] = document
+        return documents
+
+    def validate(self) -> dict[str, Any]:
+        try:
+            documents = self.load()
+        except ValueError as error:
+            return _result([_diag("REFERENCE_SOURCE_INVALID", str(error))])
+        return self.validate_documents(documents)
+
+    def validate_documents(self, documents: dict[str, dict[str, Any]]) -> dict[str, Any]:
+        diagnostics: list[dict[str, str]] = []
+        checks = {key: "pass" for key in ("schema", "authority", "harvest_binding", "pinning", "lifecycle", "provenance")}
+        policy = documents.get("KIS-DOC-CON-POL-001")
+        registry = documents.get("KIS-DOC-SEM-REG-001")
+        if policy is None or registry is None:
+            return _result([_diag("REFERENCE_MRD_SET_INVALID", "documentation reference policy and registry MRDs are required")], checks)
+
+        for document, schema_relative, label in (
+            (policy, _POLICY_SCHEMA, "documentation reference policy"),
+            (registry, _REGISTRY_SCHEMA, "documentation reference registry"),
+        ):
+            diagnostics.extend(_schema_diagnostics(self.root, _CORE_SCHEMA, document, f"{label} envelope"))
+            diagnostics.extend(_schema_diagnostics(self.root, schema_relative, document.get("content"), label))
+        if diagnostics:
+            checks["schema"] = "fail"
+
+        registry_content = registry.get("content", {})
+        known_mrd_ids = set(documents)
+        for path in self.root.glob("mrd/**/*.mrd.json"):
+            try:
+                candidate = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, json.JSONDecodeError):
+                continue
+            candidate_id = candidate.get("_mrd", {}).get("id")
+            if isinstance(candidate_id, str):
+                known_mrd_ids.add(candidate_id)
+        for doc_id, document in documents.items():
+            provenance = document.get("_mrd", {}).get("provenance", {})
+            expected_fingerprint = "sha256:" + canonical_hash(provenance.get("sources", []))
+            if provenance.get("source_fingerprint") != expected_fingerprint:
+                diagnostics.append(_diag("REFERENCE_PROVENANCE_FINGERPRINT_MISMATCH", f"provenance fingerprint mismatch: {doc_id}"))
+                checks["provenance"] = "fail"
+            for dependency in document.get("_mrd", {}).get("dependencies", []):
+                target_id = dependency.get("mrd_id")
+                if target_id and target_id not in known_mrd_ids:
+                    diagnostics.append(_diag("REFERENCE_DEPENDENCY_UNRESOLVED", f"unresolved MRD dependency: {doc_id} -> {target_id}"))
+                    checks["provenance"] = "fail"
+                source = dependency.get("source")
+                if source and source.startswith("repo:") and not (self.root / source[5:]).is_file():
+                    diagnostics.append(_diag("REFERENCE_SOURCE_UNRESOLVED", f"unresolved repository source: {doc_id} -> {source}"))
+                    checks["provenance"] = "fail"
+
+        references = registry_content.get("references", [])
+        evidence_records = {item.get("id"): item for item in registry_content.get("evidence_records", []) if isinstance(item, dict)}
+        by_id = {item.get("id"): item for item in references if isinstance(item, dict)}
+        if set(by_id) != set(_EXPECTED_REFERENCES):
+            diagnostics.append(_diag("REFERENCE_BASELINE_MISMATCH", "reference registry must contain the approved ten-source baseline"))
+            checks["authority"] = "fail"
+        for source_id, expected_role in _EXPECTED_REFERENCES.items():
+            source = by_id.get(source_id)
+            if source is None:
+                continue
+            if source.get("role") != expected_role:
+                diagnostics.append(_diag("REFERENCE_ROLE_MISMATCH", f"reference {source_id} must use role {expected_role}"))
+                checks["authority"] = "fail"
+            if source.get("role") != "canonical_kis" and source.get("may_define_kis_facts") is not False:
+                diagnostics.append(_diag("REFERENCE_AUTHORITY_PROMOTION_FORBIDDEN", f"non-canonical reference cannot define KIS facts: {source_id}"))
+                checks["authority"] = "fail"
+            lifecycle = source.get("lifecycle", {})
+            if lifecycle.get("state") == "active" and source.get("pin") is None:
+                diagnostics.append(_diag("REFERENCE_PIN_REQUIRED", f"active reference must be pinned: {source_id}"))
+                checks["pinning"] = "fail"
+            pin = source.get("pin") or {}
+            if pin.get("kind") == "research_evidence_sha256":
+                evidence = evidence_records.get(pin.get("revision"))
+                if evidence is None or evidence.get("sha256") != pin.get("value"):
+                    diagnostics.append(_diag("REFERENCE_EVIDENCE_PIN_MISMATCH", f"research evidence pin is not bound to a registered evidence record: {source_id}"))
+                    checks["pinning"] = "fail"
+            if lifecycle.get("state") == "superseded" and not lifecycle.get("superseded_by"):
+                diagnostics.append(_diag("REFERENCE_SUPERSESSION_INVALID", f"superseded reference must identify its replacement: {source_id}"))
+                checks["lifecycle"] = "fail"
+
+        harvest_sources: dict[str, dict[str, Any]] = {}
+        try:
+            harvest = load_harvest_registry(self.root)
+            harvest_sources = {item["id"]: item for item in harvest["sources"]}
+        except ValueError as error:
+            diagnostics.append(_diag("HARVEST_REGISTRY_INVALID", str(error)))
+            checks["harvest_binding"] = "fail"
+        for source in references:
+            harvest_id = source.get("harvest_source_id")
+            if not harvest_id:
+                continue
+            harvest_source = harvest_sources.get(harvest_id)
+            if harvest_source is None:
+                diagnostics.append(_diag("REFERENCE_HARVEST_BINDING_MISSING", f"unknown harvest source id: {harvest_id}"))
+                checks["harvest_binding"] = "fail"
+                continue
+            pin = source.get("pin") or {}
+            expected_hash = harvest_source.get("content_sha256")
+            if expected_hash and pin.get("kind") == "content_sha256" and pin.get("value") != expected_hash:
+                diagnostics.append(_diag("REFERENCE_HARVEST_PIN_MISMATCH", f"reference pin differs from harvest source: {source.get('id')}"))
+                checks["harvest_binding"] = "fail"
+        return _result(diagnostics, checks)
+
+
+def build_documentation_reference_standard(
+    repository: DocumentationReferenceRepository,
+    output: Path,
+    *,
+    replace: bool = False,
+) -> dict[str, Any]:
+    validation = repository.validate()
+    if validation["status"] != "valid":
+        raise ValueError(f"documentation reference standard is invalid: {validation['diagnostics']}")
+    documents = repository.load()
+    config = _load_json(repository.root / _PUBLICATION, "documentation reference publication")
+    publication_diagnostics = _schema_diagnostics(repository.root, _PUBLICATION_SCHEMA, config, "documentation reference publication")
+    if publication_diagnostics:
+        raise ValueError(f"documentation reference publication is invalid: {publication_diagnostics}")
+    files = _build_files(documents, config)
+    manifest = _build_manifest(repository, documents, config, files, validation)
+    manifest_diagnostics = _schema_diagnostics(repository.root, _MANIFEST_SCHEMA, manifest, "documentation reference build manifest")
+    if manifest_diagnostics:
+        raise ValueError(f"documentation reference build manifest is invalid: {manifest_diagnostics}")
+    output = Path(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f".{output.name}.", suffix=".tmp", dir=output.parent))
+    try:
+        for relative, payload in files.items():
+            target = staging / Path(*relative.split("/"))
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(payload)
+        (staging / "manifest.json").write_bytes(_json_bytes(manifest))
+        if output.exists():
+            if not replace:
+                raise FileExistsError(f"output already exists: {output}")
+            shutil.rmtree(output)
+        os.replace(staging, output)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return manifest
+
+
+def verify_documentation_reference_standard(
+    repository: DocumentationReferenceRepository,
+    output: Path,
+) -> dict[str, Any]:
+    diagnostics: list[dict[str, str]] = []
+    validation = repository.validate()
+    if validation["status"] != "valid":
+        diagnostics.extend(validation["diagnostics"])
+        return _verification(diagnostics)
+    output = Path(output)
+    manifest_path = output / "manifest.json"
+    if not manifest_path.is_file():
+        return _verification([_diag("GENERATED_MANIFEST_MISSING", "manifest.json is missing")])
+    try:
+        actual_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        return _verification([_diag("GENERATED_MANIFEST_INVALID", str(error))])
+    manifest_schema_diagnostics = _schema_diagnostics(repository.root, _MANIFEST_SCHEMA, actual_manifest, "documentation reference build manifest")
+    if manifest_schema_diagnostics:
+        diagnostics.extend(manifest_schema_diagnostics)
+    documents = repository.load()
+    config = _load_json(repository.root / _PUBLICATION, "documentation reference publication")
+    publication_schema_diagnostics = _schema_diagnostics(repository.root, _PUBLICATION_SCHEMA, config, "documentation reference publication")
+    if publication_schema_diagnostics:
+        diagnostics.extend(publication_schema_diagnostics)
+    expected_files = _build_files(documents, config)
+    expected_manifest = _build_manifest(repository, documents, config, expected_files, validation)
+    if actual_manifest != expected_manifest:
+        diagnostics.append(_diag("GENERATED_MANIFEST_MISMATCH", "manifest differs from deterministic current inputs"))
+    expected_paths = set(expected_files) | {"manifest.json"}
+    actual_paths = {path.relative_to(output).as_posix() for path in output.rglob("*") if path.is_file()}
+    if actual_paths != expected_paths:
+        diagnostics.append(_diag("GENERATED_FILE_SET_MISMATCH", "generated file inventory differs from deterministic output"))
+    for relative, payload in expected_files.items():
+        path = output / Path(*relative.split("/"))
+        if not path.is_file():
+            diagnostics.append(_diag("GENERATED_FILE_MISSING", f"generated file missing: {relative}"))
+            continue
+        if path.read_bytes() != payload:
+            diagnostics.append(_diag("GENERATED_FILE_CONTENT_MISMATCH", f"generated file differs from deterministic output: {relative}"))
+    return _verification(diagnostics)
+
+
+def _build_files(documents: dict[str, dict[str, Any]], config: dict[str, Any]) -> dict[str, bytes]:
+    policy = documents["KIS-DOC-CON-POL-001"]["content"]
+    registry = documents["KIS-DOC-SEM-REG-001"]["content"]
+    return {
+        "000-index.md": _render_index(config).encode("utf-8"),
+        "001-specification.md": _render_specification(config, policy, registry).encode("utf-8"),
+        "002-reference-catalogue.md": _render_catalogue(registry).encode("utf-8"),
+        "data/reference-registry.json": _json_bytes(registry),
+    }
+
+
+def _build_manifest(
+    repository: DocumentationReferenceRepository,
+    documents: dict[str, dict[str, Any]],
+    config: dict[str, Any],
+    files: dict[str, bytes],
+    validation: dict[str, Any],
+) -> dict[str, Any]:
+    inputs = []
+    for relative in (_POLICY_PATH, _REGISTRY_PATH, _PUBLICATION, _CORE_SCHEMA, _POLICY_SCHEMA, _REGISTRY_SCHEMA, _PUBLICATION_SCHEMA, _MANIFEST_SCHEMA, "publication/harvest-sources.json", "src/kis_mcp_doc/documentation_reference.py"):
+        payload = canonical_source_bytes(repository.root / relative)
+        inputs.append({"path": relative, "sha256": hashlib.sha256(payload).hexdigest(), "bytes": len(payload)})
+    declarations = [
+        {"path": path, "sha256": hashlib.sha256(payload).hexdigest(), "bytes": len(payload)}
+        for path, payload in sorted(files.items())
+    ]
+    return {
+        "contract": {"name": "documentation-reference-standard-build", "version": 1},
+        "specification": {key: config[key] for key in ("title", "version", "status", "layout_profile")},
+        "inputs": inputs,
+        "input_set_sha256": canonical_hash(inputs),
+        "validation": validation,
+        "files": declarations,
+        "bundle_sha256": canonical_hash(declarations),
+    }
+
+
+def _render_index(config: dict[str, Any]) -> str:
+    return "\n".join([
+        "<!-- GENERATED -- DO NOT EDIT -->",
+        f"# {config['title']} — documentation index",
+        "",
+        "This generated collection is a review projection. The documentation MRDs and referenced canonical sources remain authoritative.",
+        "",
+        "- [Specification](001-specification.md)",
+        "- [Reference catalogue](002-reference-catalogue.md)",
+        "- [Machine-readable reference registry](data/reference-registry.json)",
+        "- [Build manifest](manifest.json)",
+        "",
+    ])
+
+
+def _render_specification(config: dict[str, Any], policy: dict[str, Any], registry: dict[str, Any]) -> str:
+    lines = [
+        "<!-- GENERATED -- DO NOT EDIT -->",
+        f"# {config['title']}",
+        "",
+        '<div id="enable-section-numbers" />',
+        "",
+        config["subtitle"],
+        "",
+        "This specification governs how documentation references can influence KIS documentation. It keeps source authority separate from presentation guidance and implementation evidence.",
+        "",
+        "## Authority model",
+        "",
+    ]
+    for item in policy["authority_model"]:
+        permission = "may define KIS facts" if item["may_define_kis_facts"] else "MUST NOT define KIS facts"
+        lines.append(f"- **`{item['role']}`:** {item['domain']}; {permission}.")
+    lines.extend(["", "## Documentation output classes", ""])
+    for item in policy["output_classes"]:
+        label = item["class"].replace("human_readable", "human-readable").replace("_", " ")
+        lines.extend([f"### {label.capitalize()}", "", item["purpose"], "", item["source_rule"], ""])
+    lines.extend(["## Reference registry", "", registry["refresh_policy"], "", registry["licensing_policy"], "", "## Conflict behavior", ""])
+    lines.append("When a reference conflicts with a canonical owner, KIS surfaces the conflict and keeps the canonical owner unchanged. Unsupported authority promotion and active unpinned references fail validation.")
+    lines.extend(["", "## Requirements", ""])
+    for rule in policy["requirements"]:
+        lines.extend([f"### {rule['rule_id']}", "", rule["statement"], ""])
+    lines.extend(["## Source and authority", "", "This page is generated from `KIS-DOC-CON-POL-001` and `KIS-DOC-SEM-REG-001`. It has no write-back authority.", ""])
+    return "\n".join(lines)
+
+
+def _render_catalogue(registry: dict[str, Any]) -> str:
+    lines = [
+        "<!-- GENERATED -- DO NOT EDIT -->",
+        "# Documentation reference catalogue",
+        "",
+        "Each entry has a bounded role. Only the applicable canonical owner can define a KIS fact.",
+        "",
+        "| Reference | Role | Permitted use | Pin | Lifecycle |",
+        "|---|---|---|---|---|",
+    ]
+    for source in registry["references"]:
+        uses = ", ".join(f"`{item}`" for item in source["permitted_uses"])
+        pin = source["pin"]
+        pin_text = "none" if pin is None else f"`{pin['kind']}` at `{pin['revision']}`"
+        lines.append(f"| {source['name']} | `{source['role']}` | {uses} | {pin_text} | `{source['lifecycle']['state']}` |")
+    lines.extend(["", "## Licensing and refresh", "", registry["licensing_policy"], "", registry["refresh_policy"], ""])
+    return "\n".join(lines)
+
+
+def _schema_diagnostics(root: Path, schema_relative: str, instance: object, label: str) -> list[dict[str, str]]:
+    try:
+        schema = _load_json(root / schema_relative, f"{label} schema")
+        Draft202012Validator.check_schema(schema)
+        errors = sorted(Draft202012Validator(schema).iter_errors(instance), key=lambda error: tuple(str(part) for part in error.absolute_path))
+    except (ValueError, Exception) as error:
+        return [_diag("REFERENCE_SCHEMA_INVALID", str(error))]
+    diagnostics = []
+    for error in errors:
+        location = "/".join(str(part) for part in error.absolute_path) or "$"
+        diagnostics.append(_diag("REFERENCE_SCHEMA_VALIDATION_FAILED", f"{label} invalid at {location}: {error.message}"))
+    return diagnostics
+
+
+def _load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"unable to load {label}: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
+
+
+def _json_bytes(value: object) -> bytes:
+    return (json.dumps(value, indent=2, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _diag(code: str, message: str) -> dict[str, str]:
+    return {"code": code, "message": message}
+
+
+def _result(diagnostics: list[dict[str, str]], checks: dict[str, str] | None = None) -> dict[str, Any]:
+    if checks is None:
+        checks = {key: "fail" for key in ("schema", "authority", "harvest_binding", "pinning", "lifecycle", "provenance")}
+    return {"status": "invalid" if diagnostics else "valid", "checks": checks, "diagnostics": diagnostics}
+
+
+def _verification(diagnostics: list[dict[str, str]]) -> dict[str, Any]:
+    return {"status": "invalid" if diagnostics else "valid", "diagnostics": diagnostics}

--- a/tests/test_documentation_reference_standard.py
+++ b/tests/test_documentation_reference_standard.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kis_mcp_doc.cli import main
+from kis_mcp_doc.documentation_reference import (
+    DocumentationReferenceRepository,
+    build_documentation_reference_standard,
+    verify_documentation_reference_standard,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _repo() -> DocumentationReferenceRepository:
+    return DocumentationReferenceRepository(ROOT)
+
+
+def test_reference_standard_validates_official_baseline() -> None:
+    result = _repo().validate()
+
+    assert result["status"] == "valid"
+    assert result["checks"] == {
+        "schema": "pass",
+        "authority": "pass",
+        "harvest_binding": "pass",
+        "pinning": "pass",
+        "lifecycle": "pass",
+        "provenance": "pass",
+    }
+
+
+def test_reference_registry_has_ten_bounded_sources() -> None:
+    documents = _repo().load()
+    registry = documents["KIS-DOC-SEM-REG-001"]["content"]
+    sources = {item["id"]: item for item in registry["references"]}
+
+    assert len(sources) == 10
+    assert sources["mcp-2026"]["role"] == "normative_external"
+    assert sources["google-developer-style"]["role"] == "prescriptive_external"
+    for source_id in (
+        "sentry-mcp", "github-mcp", "azure-mcp", "playwright-mcp",
+        "atlassian-rovo-mcp", "figma-mcp", "aws-labs-mcp", "cloudflare-mcp",
+    ):
+        assert sources[source_id]["role"] == "implementation_reference"
+        assert sources[source_id]["may_define_kis_facts"] is False
+        assert source_id not in sources[source_id]["permitted_uses"]
+
+
+def test_reference_registry_resolves_mcp_harvest_identity() -> None:
+    registry = _repo().load()["KIS-DOC-SEM-REG-001"]["content"]
+    mcp = next(item for item in registry["references"] if item["id"] == "mcp-2026")
+
+    assert mcp["harvest_source_id"] == "mcp-spec-2026-07-28"
+    assert mcp["pin"]["kind"] == "content_sha256"
+    assert len(mcp["pin"]["value"]) == 64
+
+
+def test_non_normative_source_cannot_claim_canonical_authority(tmp_path: Path) -> None:
+    repo = _repo()
+    documents = repo.load()
+    registry = documents["KIS-DOC-SEM-REG-001"]
+    github = next(item for item in registry["content"]["references"] if item["id"] == "github-mcp")
+    github["may_define_kis_facts"] = True
+
+    result = repo.validate_documents(documents)
+
+    assert result["status"] == "invalid"
+    assert any(item["code"] == "REFERENCE_AUTHORITY_PROMOTION_FORBIDDEN" for item in result["diagnostics"])
+
+
+def test_unpinned_active_reference_fails_closed() -> None:
+    repo = _repo()
+    documents = repo.load()
+    registry = documents["KIS-DOC-SEM-REG-001"]
+    sentry = next(item for item in registry["content"]["references"] if item["id"] == "sentry-mcp")
+    sentry["pin"] = None
+
+    result = repo.validate_documents(documents)
+
+    assert result["status"] == "invalid"
+    assert any(item["code"] == "REFERENCE_PIN_REQUIRED" for item in result["diagnostics"])
+
+
+def test_reference_standard_build_is_deterministic_and_verifiable(tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+
+    manifest_a = build_documentation_reference_standard(_repo(), first)
+    manifest_b = build_documentation_reference_standard(_repo(), second)
+
+    assert manifest_a == manifest_b
+    assert (first / "001-specification.md").read_bytes() == (second / "001-specification.md").read_bytes()
+    assert (first / "002-reference-catalogue.md").read_bytes() == (second / "002-reference-catalogue.md").read_bytes()
+    assert verify_documentation_reference_standard(_repo(), first)["status"] == "valid"
+
+
+def test_reference_standard_generated_page_explains_authority_and_output_classes(tmp_path: Path) -> None:
+    output = tmp_path / "build"
+    build_documentation_reference_standard(_repo(), output)
+    page = (output / "001-specification.md").read_text(encoding="utf-8")
+
+    assert "# Documentation Reference Standard" in page
+    assert "## Authority model" in page
+    assert "## Documentation output classes" in page
+    assert "human documentation" in page.lower()
+    assert "human-readable specification" in page.lower()
+    assert "generated reference" in page.lower()
+    assert "MUST NOT" in page
+
+
+def test_generated_tamper_is_detected(tmp_path: Path) -> None:
+    output = tmp_path / "build"
+    build_documentation_reference_standard(_repo(), output)
+    (output / "002-reference-catalogue.md").write_text("tampered\n", encoding="utf-8")
+
+    result = verify_documentation_reference_standard(_repo(), output)
+
+    assert result["status"] == "invalid"
+    assert any(item["code"] == "GENERATED_FILE_CONTENT_MISMATCH" for item in result["diagnostics"])
+
+
+def test_cli_reference_commands(tmp_path: Path) -> None:
+    output = tmp_path / "build"
+
+    assert main(["--root", str(ROOT), "references-validate"]) == 0
+    assert main(["--root", str(ROOT), "references-build", "--output", str(output)]) == 0
+    assert main(["--root", str(ROOT), "references-check-generated", "--output", str(output)]) == 0
+
+
+def test_registry_projection_is_machine_readable(tmp_path: Path) -> None:
+    output = tmp_path / "build"
+    build_documentation_reference_standard(_repo(), output)
+    registry = json.loads((output / "data" / "reference-registry.json").read_text(encoding="utf-8"))
+
+    assert registry["registry_version"] == "1.0.0"
+    assert len(registry["references"]) == 10
+
+
+def test_research_reference_pin_must_bind_registered_evidence() -> None:
+    repo = _repo()
+    documents = repo.load()
+    registry = documents["KIS-DOC-SEM-REG-001"]
+    source = next(item for item in registry["content"]["references"] if item["id"] == "sentry-mcp")
+    source["pin"]["value"] = "0" * 64
+
+    result = repo.validate_documents(documents)
+
+    assert result["status"] == "invalid"
+    assert any(item["code"] == "REFERENCE_EVIDENCE_PIN_MISMATCH" for item in result["diagnostics"])
+
+
+def test_mrd_provenance_fingerprint_mismatch_fails() -> None:
+    repo = _repo()
+    documents = repo.load()
+    documents["KIS-DOC-CON-POL-001"]["_mrd"]["provenance"]["source_fingerprint"] = "sha256:" + ("0" * 64)
+
+    result = repo.validate_documents(documents)
+
+    assert result["status"] == "invalid"
+    assert any(item["code"] == "REFERENCE_PROVENANCE_FINGERPRINT_MISMATCH" for item in result["diagnostics"])


### PR DESCRIPTION
Implements Change 008 end-to-end.

- adds prescriptive Documentation Reference Standard and semantic reference registry MRDs
- defines schemas for policy, registry, publication, and build manifest
- enforces authority separation, provenance, pinning, lifecycle, and harvest bindings
- adds deterministic MCP-spec-style human review output and reference catalogue
- wires CLI and canonical repository verification
- adds tests for authority promotion, provenance, stale/tamper detection, lifecycle, and deterministic generation

Verification: canonical scripts/verify.ps1 passed on exact head 5e7f64f0983c685b1403b85977c095cfcce34ebb. Documentation specialist review returned no findings.