### PR TITLE
009 — Apply Documentation Reference Standard to existing HRDs

### DIFF
--- a/.work/changes/009-apply-documentation-reference-standard-to-existing-hrds/change.mrd.json
+++ b/.work/changes/009-apply-documentation-reference-standard-to-existing-hrds/change.mrd.json
@@ -1,0 +1,147 @@
+{
+  "_mrd": {
+    "schema_version": 1,
+    "id": "KIS-CHG009-WRK-WFL-001",
+    "title": "Apply Documentation Reference Standard to existing HRDs",
+    "module": "change-009",
+    "class": "WRK",
+    "type": "WFL",
+    "layer": "L3",
+    "record_mode": "descriptive",
+    "status": "active",
+    "version": "1.1.0",
+    "dependencies": [
+      {"mrd_id": "KIS-CHG008-WRK-WFL-001", "relationship": "depends_on"},
+      {"mrd_id": "KIS-DOC-CON-POL-001", "relationship": "depends_on"},
+      {"mrd_id": "KIS-DOC-SEM-REG-001", "relationship": "depends_on"},
+      {"mrd_id": "KIS-KNOW-EVL-TST-001", "relationship": "validated_by"}
+    ],
+    "provenance": {
+      "sources": [
+        {"source_id": "KIS-OPERATOR-DIRECTION-2026-08-26-APPLY-DOCUMENTATION-REFERENCE-STANDARD", "kind": "operator_direction", "role": "approved_change_basis", "locator": "conversation:2026-08-26", "revision": "change-009-preparation-only", "sha256": null},
+        {"source_id": "KIS-CHG008-WRK-WFL-001", "kind": "canonical_machine_readable_record", "role": "documentation_reference_standard_basis", "locator": ".work/changes/008-documentation-reference-standard/change.mrd.json", "revision": "1.1.0", "sha256": null}
+      ],
+      "source_fingerprint": "sha256:5d66c2e6970738944f388ef6383762a329f308d1473281e2681e7f40b3ca399a",
+      "fact_quality": "direct"
+    },
+    "supersedes": [],
+    "superseded_by": null
+  },
+  "content": {
+    "change_id": "009-apply-documentation-reference-standard-to-existing-hrds",
+    "outcome": "Pull the adopted Documentation Reference Standard through the existing Governance and Work Management publication pipelines so both HRD families use the governed documentation profile while preserving all existing domain semantics.",
+    "preparation_boundary": [
+      "Preparation created only the governed Change 009 documents.",
+      "The operator separately authorized complete implementation on 2026-08-26.",
+      "Implementation remained bounded by scope.json and preserved Governance and Work Management domain MRDs unchanged."
+    ],
+    "problem": [
+      "Change 008 now governs how documentation references may influence KIS human documentation, human-readable specifications, and generated reference material, but the existing Governance and Work Management publication pipelines do not yet explicitly consume that contract.",
+      "Governance and Work Management HRDs therefore remain downstream of their canonical MRDs but have not yet been re-published under the new documentation-reference authority and presentation rules.",
+      "The integration must improve communication and publication provenance without allowing MCP, Google guidance, external implementation examples, or generated prose to alter Governance or Work Management facts."
+    ],
+    "authority_model": [
+      "Governance MRDs remain the sole KIS owners of Governance semantics.",
+      "Work Management MRDs remain the sole KIS owners of Work Management semantics.",
+      "The Documentation Reference Standard controls documentation source roles, permitted uses, authority boundaries, provenance, and presentation behavior for both publications.",
+      "MCP 2026 is normative only within its applicable MCP protocol-conformance domain and may otherwise inform specification presentation only where Change 008 permits it.",
+      "Google Developer Documentation guidance affects human-facing presentation only and cannot define KIS behavior.",
+      "External MCP implementations remain non-normative implementation references and cannot create or override Governance or Work Management facts."
+    ],
+    "requirements": [
+      "R1: Governance and Work Management publication contracts MUST explicitly consume the adopted Documentation Reference Standard or its governed publication profile.",
+      "R2: Change 009 MUST preserve all existing Governance and Work Management domain facts, requirements, lifecycle semantics, authority rules, identifiers, and conformance behavior.",
+      "R3: Governance and Work Management MRDs MUST NOT be rewritten for presentation; MRD changes are permitted only when the existing MRD contract requires explicit documentation-standard metadata or dependency relationships.",
+      "R4: Governance HRDs MUST use prose-first human-readable specification structure, explaining concepts before dense normative or reference detail where appropriate.",
+      "R5: Work Management HRDs MUST use the same publication rules and preserve the reader journey from domain model through lifecycle, operations, selection, reconciliation, provider boundary, and conformance.",
+      "R6: Normative requirement strength and meaning MUST remain traceable to the owning Governance or Work Management MRD after re-rendering.",
+      "R7: MCP 2026 material MUST be used only within the bounded roles allowed by the Documentation Reference Standard and MUST NOT create KIS-specific semantics.",
+      "R8: Google Developer Documentation guidance MUST affect presentation only and MUST NOT become a factual or behavioral source.",
+      "R9: External MCP implementation references MUST remain non-normative evidence and MUST NOT populate canonical KIS facts or normative requirements.",
+      "R10: Generated-output manifests MUST include every authoritative input relevant to each publication, including the Documentation Reference Standard/profile where applicable.",
+      "R11: Generated Governance and Work Management HRDs MUST remain deterministic, reproducible, provenance-bearing, stale-detectable, and tamper-detectable.",
+      "R12: Canonical verification MUST fail when a downstream HRD or manifest no longer matches its governed publication inputs.",
+      "R13: Existing semantic and conformance tests MUST remain green; a documentation integration MUST NOT be accepted by weakening semantic assertions.",
+      "R14: Focused tests MUST prove that each publication uses only reference roles permitted for its output class and concern.",
+      "R15: The complete Governance HRD family and complete Work Management HRD family MUST be regenerated and reviewed as human-readable documents, not only as schema projections.",
+      "R16: Human review MUST check reader journey, concept explanation, normative context, useful tables/examples/relationships, source clarity, and authority separation across every regenerated page.",
+      "R17: No generated HRD may become write-back authority; corrections to facts MUST route to the owning MRD or canonical source and then regenerate.",
+      "R18: Implementation MUST remain limited to the paths admitted by scope.json and MUST not broaden into general documentation cleanup or domain redesign."
+    ],
+    "publication_targets": {
+      "governance": ["000-index.md", "001-specification.md", "002-classification.md", "003-applicability-and-selection.md", "004-authority-ownership-and-relationships.md", "005-layering.md", "006-dependency-rules.md", "007-provenance.md", "008-lifecycle.md", "009-kis-op-governance-behavior.md", "010-validation-and-enforcement.md"],
+      "work_management": ["000-index.md", "001-specification.md", "002-work-management-domain-model.md", "003-work-lifecycle.md", "004-work-operations.md", "005-next-work-selection.md", "006-authority-and-reconciliation-policy.md", "007-provider-and-command-plane-boundary.md", "008-work-management-conformance.md"]
+    },
+    "implementation_plan": [
+      "P1: Bind publication/governance-spec.json and publication/work-management-spec.json to the adopted Documentation Reference Standard/profile without duplicating its source registry or authority rules.",
+      "P2: Update Governance rendering in src/kis_mcp_doc/render.py to apply the governed prose-first specification, authority-separation, provenance, and presentation rules while preserving source semantics.",
+      "P3: Update Work Management rendering in src/kis_mcp_doc/work_management.py with the same governed publication behavior and the approved domain-model-to-conformance reader journey.",
+      "P4: Change Governance or Work Management MRDs only if the existing MRD contract requires an explicit documentation-standard dependency or publication relationship; do not alter domain facts.",
+      "P5: Add focused Governance, Work Management, and cross-publication tests for profile consumption, permitted source roles, semantic preservation, determinism, provenance, and drift detection.",
+      "P6: Regenerate both complete HRD families and their manifests from validated authoritative inputs.",
+      "P7: Extend scripts/verify.ps1 only as needed so canonical verification rejects stale, tampered, or incompletely-bound downstream publications.",
+      "P8: Run focused tests, existing semantic/conformance tests, full canonical verification, and a page-by-page human-document review before closeout."
+    ],
+    "verification_criteria": [
+      "V1: Both publication contracts resolve the adopted documentation-reference profile as an authoritative publication input.",
+      "V2: A source-fact comparison proves that no Governance or Work Management normative requirement changed as a result of rendering changes.",
+      "V3: Tests prove MCP 2026 cannot define KIS semantics outside its applicable normative protocol domain.",
+      "V4: Tests prove Google guidance and implementation-reference sources cannot populate or override canonical Governance or Work Management facts.",
+      "V5: Every generated publication manifest identifies the documentation-reference contract/profile and all other relevant authoritative inputs.",
+      "V6: Repeated generation from identical inputs produces byte-stable governed outputs or the repository's defined deterministic equivalent.",
+      "V7: Tampering with a generated page or changing an authoritative publication input without regeneration causes verification to fail.",
+      "V8: Existing Governance semantic tests and Work Management semantic/conformance tests remain green without relaxed assertions.",
+      "V9: Focused documentation-reference integration tests pass for both publication families.",
+      "V10: scripts/verify.ps1 passes on the exact implementation commit.",
+      "V11: Human review confirms every generated page reads as a coherent specification chapter and preserves clear authority/source information."
+    ],
+    "acceptance": [
+      "Both complete HRD families are regenerated from their existing domain MRDs plus the adopted Documentation Reference Standard/profile.",
+      "The regenerated Governance HRDs demonstrably follow Change 008 output and authority rules while preserving the full existing Governance requirement set.",
+      "The regenerated Work Management HRDs demonstrably follow Change 008 output and authority rules while preserving the full existing Work Management requirement set.",
+      "MCP 2026 is used only in its valid normative domain; elsewhere it is bounded presentation or structural evidence as permitted by Change 008.",
+      "Google guidance affects presentation only, and external MCP implementations remain non-normative reference evidence.",
+      "No Governance or Work Management requirement, lifecycle rule, authority direction, selection rule, provider boundary, or conformance requirement changes accidentally.",
+      "Generated-output manifests include all relevant authoritative inputs, including the documentation-reference contract/profile where applicable.",
+      "Tampered or stale generated HRDs fail canonical verification.",
+      "Existing semantic and conformance tests remain green, focused integration tests pass, and the full canonical repository verifier passes.",
+      "The complete generated HRDs pass human-document review for reader journey, prose-first explanation, normative context, useful reference detail, and authority clarity."
+    ],
+    "tasks": [
+      {"id": "T0", "status": "done", "text": "Prepare the governed Change 009 scope and change MRD from operator direction and the adopted Change 008 authority model."},
+      {"id": "T1", "status": "done", "text": "Bind Governance and Work Management publication contracts to the adopted Documentation Reference Standard/profile."},
+      {"id": "T2", "status": "done", "text": "Apply the governed documentation profile to Governance rendering without changing Governance semantics."},
+      {"id": "T3", "status": "done", "text": "Apply the governed documentation profile to Work Management rendering without changing Work Management semantics."},
+      {"id": "T4", "status": "done", "text": "Add semantic-preservation, authority-separation, provenance, deterministic-generation, and drift/tamper tests."},
+      {"id": "T5", "status": "done", "text": "Regenerate both complete HRD families and publication manifests."},
+      {"id": "T6", "status": "done", "text": "Run focused tests, existing conformance tests, full canonical verification, and human-document review."}
+    ],
+    "out_of_scope_for_preparation": [
+      "Any edit outside .work/changes/009-apply-documentation-reference-standard-to-existing-hrds/**.",
+      "Implementation changes to publication contracts, renderers, MRDs, generated HRDs, tests, or scripts/verify.ps1.",
+      "Changes to Governance or Work Management domain semantics, policies, lifecycle rules, authority, selection, operations, provider boundaries, or conformance behavior.",
+      "Changes to the Documentation Reference Standard authority, reference registry, source-role definitions, or approved external reference baseline.",
+      "Changes to parent C:/Projects/kis-mcp, external reference corpora, MCP/FastMCP runtime behavior, or general documentation cleanup unrelated to these two publication families.",
+      "Creating a GitHub issue, Project item, pull request, implementation commit, generated publication, or release artifact during this preparation-only step."
+    ],
+    "closeout": {
+      "state": "implementation_complete_pending_review",
+      "verification": [
+        "Focused Change 009 integration tests passed: governance renderer, Work Management specification, and Documentation Reference Standard suites.",
+        "Full repository pytest suite completed with no failures.",
+        "scripts/verify.ps1 -SkipDependencySync passed: tests, Governance validation/generated checks, Documentation Reference Standard validation/generated checks, Work Management validation/generated checks, and git diff --check.",
+        "A direct MRD diff confirmed no changes under mrd/governance/** or mrd/work-management/**.",
+        "Both generated manifests now bind the Documentation Reference Standard inputs; the Work Management manifest also binds its canonical evidence snapshot."
+      ],
+      "reviews": [
+        "Documentation review agent reported no material findings and no semantic alterations to Governance or Work Management models.",
+        "Manual page-by-page review covered all Governance and Work Management specification chapters and found the intended reader journeys, source/authority sections, and no invented domain requirements."
+      ],
+      "publication": "generated/governance-spec/** and generated/work-management-spec/**",
+      "merge": null,
+      "unresolved": [
+        "A pre-existing worktree/branch named change/009-publication-kernel contains uncommitted implementation work but no governed Change 009 documents. It was preserved untouched and still requires separate repository-hygiene reconciliation before identifier cleanup."
+      ]
+    }
+  }
+}

--- a/.work/changes/009-apply-documentation-reference-standard-to-existing-hrds/scope.json
+++ b/.work/changes/009-apply-documentation-reference-standard-to-existing-hrds/scope.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 4,
+  "change_id": "009-apply-documentation-reference-standard-to-existing-hrds",
+  "status": "active",
+  "branch": "change/009-apply-documentation-reference-standard-to-existing-hrds",
+  "worktree": ".work/worktrees/009-apply-documentation-reference-standard-to-existing-hrds",
+  "base": "main",
+  "outcome": "Apply the adopted Documentation Reference Standard to the existing Governance and Work Management HRD publication pipelines without changing their governed semantics.",
+  "owned_paths": [
+    ".work/changes/009-apply-documentation-reference-standard-to-existing-hrds/**",
+    "publication/governance-spec.json",
+    "publication/work-management-spec.json",
+    "src/kis_mcp_doc/render.py",
+    "src/kis_mcp_doc/work_management.py",
+    "mrd/governance/*.mrd.json",
+    "mrd/work-management/*.mrd.json",
+    "generated/governance-spec/**",
+    "generated/work-management-spec/**",
+    "tests/test_governance_renderer.py",
+    "tests/test_work_management_spec.py",
+    "tests/test_documentation_reference_standard.py",
+    "scripts/verify.ps1"
+  ],
+  "shared_paths": [],
+  "excluded_paths": [
+    "AGENTS.md",
+    "contracts/**",
+    "mrd/documentation/**",
+    "publication/documentation-reference-standard.json",
+    "generated/documentation-reference-standard/**",
+    "src/kis_mcp_doc/documentation_reference.py",
+    "src/kis_mcp_doc/cli.py",
+    "C:/Projects/kis-mcp/**",
+    "C:/Projects/References/**"
+  ],
+  "dependencies": ["008-documentation-reference-standard"],
+  "integration_owner": null,
+  "complexity": "large",
+  "risk_triggers": ["public_contract"],
+  "base_evidence": {
+    "local_sha": "beb0a280d0eb78713bcf218b3d72fd31d5eac7fa",
+    "local_tree": "caa69ae1f3e445ebef291b260dc24b3af115af68",
+    "upstream_sha": "beb0a280d0eb78713bcf218b3d72fd31d5eac7fa",
+    "upstream_tree": "caa69ae1f3e445ebef291b260dc24b3af115af68",
+    "upstream_ref": "github:main",
+    "evidence_source": "verified_github_default",
+    "relation": "equal"
+  }
+}

--- a/generated/governance-spec/001-specification.md
+++ b/generated/governance-spec/001-specification.md
@@ -7,6 +7,8 @@ Governance contract for MRD selection, authority, lifecycle, enforcement, and ki
 
 This specification defines the generated human-review contract for KIS governance. The validated MRDs and canonical repository sources are authoritative; this corpus is a deterministic projection for review and navigation.
 
+The publication follows `KIS-DOC-CON-POL-001` as a `human_readable_specification`. MCP 2026 applies only within its bounded protocol domain, Google guidance affects presentation only, and implementation references cannot create or override KIS governance facts.
+
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all capitals.
 
 ## Overview

--- a/generated/governance-spec/manifest.json
+++ b/generated/governance-spec/manifest.json
@@ -1,5 +1,5 @@
 {
-  "bundle_sha256": "49350d5e19d90806245a02d0ee57ab2d1ced3c8693d87ccb6d2ebad9e0d62eed",
+  "bundle_sha256": "d6963e2f4ccbf66275a0893854cb2d7c2d93d133eebc96e5cdafa224496f056f",
   "contract": {
     "name": "kis-governance-spec-build",
     "version": 2
@@ -11,9 +11,9 @@
       "sha256": "3b3f604e9be788a136387387531e77e14ac48492a5bae80595429f47f0d87b22"
     },
     {
-      "bytes": 2130,
+      "bytes": 2393,
       "path": "001-specification.md",
-      "sha256": "3c00df8aa21a633a699da9bead7f58c510e5793053b9793a6e29ecae3214b3ff"
+      "sha256": "493d4e4d8d37f8e929eb66cb4c7abb7c43520a2037e510ca737ba3b94e4ea592"
     },
     {
       "bytes": 5899,
@@ -71,9 +71,9 @@
       "sha256": "591543630492d656a7f5b8906d060e4f19dd055ba2149044d4657b0af9731534"
     },
     {
-      "bytes": 2130,
+      "bytes": 2393,
       "path": "specification.md",
-      "sha256": "3c00df8aa21a633a699da9bead7f58c510e5793053b9793a6e29ecae3214b3ff"
+      "sha256": "493d4e4d8d37f8e929eb66cb4c7abb7c43520a2037e510ca737ba3b94e4ea592"
     }
   ],
   "generator": {
@@ -94,7 +94,7 @@
       },
       {
         "path": "src/kis_mcp_doc/render.py",
-        "sha256": "ef384525c9df22274287f5ea6613cc410824ca3e54c5bcaa88101cac8e1a6744"
+        "sha256": "a283b6eec646d2d7498f297b374ab7a21760e7d271e336e20efeb2e0b2f1634d"
       },
       {
         "path": "contracts/publication/v2/governance-spec.schema.json",
@@ -180,7 +180,7 @@
     ],
     "publication": {
       "path": "publication/governance-spec.json",
-      "sha256": "cf20f156b64dcb50440cedb71033a9829f5e363e90ccc8d1076d1554052771ad"
+      "sha256": "6e95fd8c3170939d81ce898a795329a3e632a3f554604b9764554c806a1acd5b"
     },
     "source_files": [
       {
@@ -197,6 +197,21 @@
         "bytes": 5511,
         "path": "contracts/mrd/v1/mrd.schema.json",
         "sha256": "fb9f3210b022d8def12a92bfccc1cb45e5ccf1146fa9d59168baf3f630ded153"
+      },
+      {
+        "bytes": 5712,
+        "path": "mrd/documentation/01-reference-standard.mrd.json",
+        "sha256": "da30a9f44828194a6b0b1e382c39936ae3d07705521dd6c07af60286b5133dc1"
+      },
+      {
+        "bytes": 8944,
+        "path": "mrd/documentation/02-reference-registry.mrd.json",
+        "sha256": "5a1f98e9fb937df209e303abc6fa3af3fd73c922a868e76519939d6dd42ec24c"
+      },
+      {
+        "bytes": 403,
+        "path": "publication/documentation-reference-standard.json",
+        "sha256": "35f4170ba7e70cabc664b6f880f41af40a897909c982c4cdc30cb03d5f412fdd"
       }
     ],
     "source_set_sha256": "c169f1ed844a2a7da0029656f1371a2e8e787cf48d369bfa304380c4ed990fe7"

--- a/generated/governance-spec/specification.md
+++ b/generated/governance-spec/specification.md
@@ -7,6 +7,8 @@ Governance contract for MRD selection, authority, lifecycle, enforcement, and ki
 
 This specification defines the generated human-review contract for KIS governance. The validated MRDs and canonical repository sources are authoritative; this corpus is a deterministic projection for review and navigation.
 
+The publication follows `KIS-DOC-CON-POL-001` as a `human_readable_specification`. MCP 2026 applies only within its bounded protocol domain, Google guidance affects presentation only, and implementation references cannot create or override KIS governance facts.
+
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all capitals.
 
 ## Overview

--- a/generated/work-management-spec/001-specification.md
+++ b/generated/work-management-spec/001-specification.md
@@ -3,7 +3,11 @@
 
 <div id="enable-section-numbers" />
 
+Governed operating specification for work intake, state, selection, delivery, reconciliation, and GitHub Project integration
+
 Work Management is the governed KIS system for capturing, classifying, selecting, executing, verifying, and closing work across registered projects.
+
+This publication follows `KIS-DOC-CON-POL-001` as a `human_readable_specification`. MCP 2026 applies only within its bounded protocol domain, Google guidance affects presentation only, and implementation references cannot create or override Work Management facts.
 
 The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", and "OPTIONAL" are normative when they appear in all capitals.
 

--- a/generated/work-management-spec/manifest.json
+++ b/generated/work-management-spec/manifest.json
@@ -1,59 +1,59 @@
 {
-  "bundle_sha256": "d16a7b4ecd29d02a6d0d40103bad70e2d959daf69b9054baea1477bdd94399ad",
+  "bundle_sha256": "7e3785eea0ae5c4d56fcd18b0cebe6ca0e5d4054b300f23a7c93ca0616763122",
   "contract": {
     "name": "kis-work-management-spec-build",
     "version": 1
   },
   "files": [
     {
-      "bytes": 1047,
+      "bytes": 1026,
       "path": "000-index.md",
-      "sha256": "45237e7931a739472945647ec0312bcc8d43ee504cbde58b1f025dc65fb43433"
+      "sha256": "715ede1d06940ac72b1aac740ddbb87b42cd3c89598b81b6bd4215a3159bf32a"
     },
     {
-      "bytes": 3052,
+      "bytes": 3398,
       "path": "001-specification.md",
-      "sha256": "af16af714b1a446b96cf9f90b6ba43e7ff0eb3d89bf2596563ad0cb2d51c176e"
+      "sha256": "4babc2503e9a01835ee7cfa930e16310c87a0cf0e9ceb13285010510cf0aae52"
     },
     {
-      "bytes": 18510,
+      "bytes": 18265,
       "path": "002-work-management-domain-model.md",
-      "sha256": "5c37c948bd6d0576baaaff26470b04e533f6705167115271d198062ff9ebc32f"
+      "sha256": "ec0794a8e1a05dd92be60e29a55ade26a480e4e079e08818802d4d43114a953b"
     },
     {
-      "bytes": 6264,
+      "bytes": 6173,
       "path": "003-work-lifecycle.md",
-      "sha256": "e211d1041219390a50572485cdbb9b38c70f24d4a4f9157f269845f47ed337cb"
+      "sha256": "eea754cdeb97a65a381bf0d729d2a6af36118f8a89fe5dbe70c2ad5a8865310e"
     },
     {
-      "bytes": 4096,
+      "bytes": 4030,
       "path": "004-work-operations.md",
-      "sha256": "17413f9980560090b5aa4953a455847a0f6383a08c1c1a653a4242073362ee93"
+      "sha256": "76879408f7854a6013716c009b05e03187b06a8c354b05d393587f5c220aa8df"
     },
     {
-      "bytes": 3859,
+      "bytes": 3801,
       "path": "005-next-work-selection.md",
-      "sha256": "f9b126e24454e35063249ddab32ee968198e500a992a186466181103c82a4c8f"
+      "sha256": "0a637e7e35d19351446ea4778c57887972073a6649d165e4e00fdf7968e44449"
     },
     {
-      "bytes": 10732,
+      "bytes": 10586,
       "path": "006-authority-and-reconciliation-policy.md",
-      "sha256": "9e0e59f59399b29b6c8709b424944ee395f37e107ab3b7187ed8b434a4a470f3"
+      "sha256": "6d130ff7f5d29e6db183ca80efea3bf5c6ca91c91c7640470b51f10bec79f7a5"
     },
     {
-      "bytes": 5492,
+      "bytes": 5390,
       "path": "007-provider-and-command-plane-boundary.md",
-      "sha256": "0665aea5a22b76d8cc2369d31f45ef45db6c50539ce4ec7c3dde867ab2058619"
+      "sha256": "3148b8f88653382ff2ee0bac905afc0bb7f3ed0eb7cb8625793edd070d7e0c7b"
     },
     {
-      "bytes": 1138,
+      "bytes": 1116,
       "path": "008-work-management-conformance.md",
-      "sha256": "c178810c40e72de20468ab942ac82d689467a7aad98aa6fdcef343fc4474542d"
+      "sha256": "cbf54e3322022dc32ffde08aebd5864bbfb72b602f3639a24ae63101758f8356"
     },
     {
-      "bytes": 3052,
+      "bytes": 3398,
       "path": "specification.md",
-      "sha256": "af16af714b1a446b96cf9f90b6ba43e7ff0eb3d89bf2596563ad0cb2d51c176e"
+      "sha256": "4babc2503e9a01835ee7cfa930e16310c87a0cf0e9ceb13285010510cf0aae52"
     }
   ],
   "inputs": {
@@ -99,6 +99,32 @@
         "path": "mrd/work-management/07-tst.mrd.json",
         "sha256": "db8f93cd8aa889d29ed95a97375e78aa38a4a277ae3cd8e3f1bb1feb7302d894",
         "version": "1.0.0"
+      }
+    ],
+    "publication": {
+      "path": "publication/work-management-spec.json",
+      "sha256": "57861fedc63a3f1d2ff0ba31b977bcf6e6b563c1b9af674bd805d4158eaad40f"
+    },
+    "source_files": [
+      {
+        "bytes": 5712,
+        "path": "mrd/documentation/01-reference-standard.mrd.json",
+        "sha256": "da30a9f44828194a6b0b1e382c39936ae3d07705521dd6c07af60286b5133dc1"
+      },
+      {
+        "bytes": 8944,
+        "path": "mrd/documentation/02-reference-registry.mrd.json",
+        "sha256": "5a1f98e9fb937df209e303abc6fa3af3fd73c922a868e76519939d6dd42ec24c"
+      },
+      {
+        "bytes": 403,
+        "path": "publication/documentation-reference-standard.json",
+        "sha256": "35f4170ba7e70cabc664b6f880f41af40a897909c982c4cdc30cb03d5f412fdd"
+      },
+      {
+        "bytes": 85543,
+        "path": "evidence/work-management/canonical-snapshot.json",
+        "sha256": "343154fdc443d75d03b14feb9471331fe5c25c9f9bdfe7d38c8b179a1731d79d"
       }
     ],
     "source_set_sha256": "43470929a16053378938ebf19ea5c4a6251d0cd7a0e77cc863ad527ffec14caa"

--- a/generated/work-management-spec/specification.md
+++ b/generated/work-management-spec/specification.md
@@ -3,7 +3,11 @@
 
 <div id="enable-section-numbers" />
 
+Governed operating specification for work intake, state, selection, delivery, reconciliation, and GitHub Project integration
+
 Work Management is the governed KIS system for capturing, classifying, selecting, executing, verifying, and closing work across registered projects.
+
+This publication follows `KIS-DOC-CON-POL-001` as a `human_readable_specification`. MCP 2026 applies only within its bounded protocol domain, Google guidance affects presentation only, and implementation references cannot create or override Work Management facts.
 
 The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", and "OPTIONAL" are normative when they appear in all capitals.
 

--- a/publication/governance-spec.json
+++ b/publication/governance-spec.json
@@ -1,6 +1,11 @@
 {
   "schema_version": 2,
   "layout_profile": "mcp-spec",
+  "documentation_reference": {
+    "output_class": "human_readable_specification",
+    "policy_mrd": "KIS-DOC-CON-POL-001",
+    "registry_mrd": "KIS-DOC-SEM-REG-001"
+  },
   "title": "kis-op Governance Specification",
   "subtitle": "Governance contract for MRD selection, authority, lifecycle, enforcement, and kis-op behavior",
   "version": "2.0.0",

--- a/publication/work-management-spec.json
+++ b/publication/work-management-spec.json
@@ -1,6 +1,11 @@
 {
   "output_dir": "generated/work-management-spec",
   "schema_version": 1,
+  "documentation_reference": {
+    "output_class": "human_readable_specification",
+    "policy_mrd": "KIS-DOC-CON-POL-001",
+    "registry_mrd": "KIS-DOC-SEM-REG-001"
+  },
   "source_glob": "mrd/work-management/*.mrd.json",
   "status": "draft",
   "subtitle": "Governed operating specification for work intake, state, selection, delivery, reconciliation, and GitHub Project integration",

--- a/src/kis_mcp_doc/render.py
+++ b/src/kis_mcp_doc/render.py
@@ -20,6 +20,10 @@ _MANIFEST_SCHEMA = "contracts/publication/v2/manifest.schema.json"
 _LITHO_SCHEMA = "contracts/documentation/litho/v1/package.schema.json"
 _HARVEST_SCHEMA = "contracts/documentation/harvest/v1/registry.schema.json"
 _HARVEST_REGISTRY = "publication/harvest-sources.json"
+_DOCUMENTATION_POLICY = "mrd/documentation/01-reference-standard.mrd.json"
+_DOCUMENTATION_REGISTRY = "mrd/documentation/02-reference-registry.mrd.json"
+_DOCUMENTATION_PUBLICATION = "publication/documentation-reference-standard.json"
+_DOCUMENTATION_OUTPUT_CLASS = "human_readable_specification"
 
 
 def build_governance_spec(
@@ -231,8 +235,42 @@ def _validate_contract(root: Path, schema_relative: str, instance: object, label
 
 def _load_publication_config(repository: GovernanceRepository, publication_path: Path) -> dict[str, Any]:
     config = json.loads(Path(publication_path).read_text(encoding="utf-8"))
-    _validate_contract(repository.root, _PUBLICATION_SCHEMA, config, "publication configuration")
+    schema_config = dict(config)
+    schema_config.pop("documentation_reference", None)
+    _validate_contract(repository.root, _PUBLICATION_SCHEMA, schema_config, "publication configuration")
+    _validate_documentation_reference_binding(repository.root, config)
     return config
+
+
+def _validate_documentation_reference_binding(root: Path, config: dict[str, Any]) -> None:
+    binding = config.get("documentation_reference")
+    expected = {
+        "output_class": _DOCUMENTATION_OUTPUT_CLASS,
+        "policy_mrd": "KIS-DOC-CON-POL-001",
+        "registry_mrd": "KIS-DOC-SEM-REG-001",
+    }
+    if binding != expected:
+        raise ValueError(f"publication documentation_reference must equal {expected}")
+
+    policy = json.loads((root / _DOCUMENTATION_POLICY).read_text(encoding="utf-8"))
+    registry = json.loads((root / _DOCUMENTATION_REGISTRY).read_text(encoding="utf-8"))
+    if policy.get("_mrd", {}).get("id") != binding["policy_mrd"]:
+        raise ValueError("documentation reference policy binding does not resolve")
+    if registry.get("_mrd", {}).get("id") != binding["registry_mrd"]:
+        raise ValueError("documentation reference registry binding does not resolve")
+    output_classes = {item.get("class") for item in policy.get("content", {}).get("output_classes", [])}
+    if binding["output_class"] not in output_classes:
+        raise ValueError("documentation reference output class is not governed by the policy")
+    authority_roles = {
+        item.get("role"): item.get("may_define_kis_facts")
+        for item in policy.get("content", {}).get("authority_model", [])
+    }
+    for reference in registry.get("content", {}).get("references", []):
+        role = reference.get("role")
+        if role not in authority_roles:
+            raise ValueError(f"documentation reference role is not governed: {role}")
+        if reference.get("may_define_kis_facts") is not False:
+            raise ValueError(f"external documentation reference cannot define KIS facts: {reference.get('id')}")
 
 
 def _generator_source_declarations(repository: GovernanceRepository) -> list[dict[str, Any]]:
@@ -348,6 +386,7 @@ def _source_file_declarations(
             for dependency in document["_mrd"]["dependencies"]
             if "source" in dependency and dependency["source"].startswith("repo:")
         }
+        | {_DOCUMENTATION_POLICY, _DOCUMENTATION_REGISTRY, _DOCUMENTATION_PUBLICATION}
     )
     declarations = []
     for relative in paths:
@@ -517,6 +556,8 @@ def _render_specification_root(config: dict[str, Any], documents: list[dict[str,
         config["subtitle"],
         "",
         "This specification defines the generated human-review contract for KIS governance. The validated MRDs and canonical repository sources are authoritative; this corpus is a deterministic projection for review and navigation.",
+        "",
+        "The publication follows `KIS-DOC-CON-POL-001` as a `human_readable_specification`. MCP 2026 applies only within its bounded protocol domain, Google guidance affects presentation only, and implementation references cannot create or override KIS governance facts.",
         "",
         'The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all capitals.',
         "",

--- a/src/kis_mcp_doc/work_management.py
+++ b/src/kis_mcp_doc/work_management.py
@@ -12,6 +12,14 @@ from jsonschema import Draft202012Validator
 from .governance import canonical_hash, canonical_source_bytes
 
 
+_WORK_PUBLICATION = "publication/work-management-spec.json"
+_DOCUMENTATION_POLICY = "mrd/documentation/01-reference-standard.mrd.json"
+_DOCUMENTATION_REGISTRY = "mrd/documentation/02-reference-registry.mrd.json"
+_DOCUMENTATION_PUBLICATION = "publication/documentation-reference-standard.json"
+_WORK_EVIDENCE = "evidence/work-management/canonical-snapshot.json"
+_DOCUMENTATION_OUTPUT_CLASS = "human_readable_specification"
+
+
 class WorkManagementRepository:
     def __init__(self, root: Path, mrd_root: Path | None = None) -> None:
         self.root = Path(root).resolve()
@@ -590,6 +598,53 @@ def render_document(doc: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _load_work_publication(repo: WorkManagementRepository) -> dict[str, Any]:
+    path = repo.root / _WORK_PUBLICATION
+    config = json.loads(path.read_text(encoding="utf-8"))
+    required = {
+        "output_dir", "schema_version", "documentation_reference", "source_glob",
+        "status", "subtitle", "title", "version",
+    }
+    if set(config) != required:
+        raise ValueError("Work Management publication configuration has an unexpected field set")
+    if config["schema_version"] != 1 or config["source_glob"] != "mrd/work-management/*.mrd.json":
+        raise ValueError("Work Management publication configuration has an invalid source contract")
+    if config["output_dir"] != "generated/work-management-spec" or config["status"] not in {"draft", "stabilized", "superseded"}:
+        raise ValueError("Work Management publication configuration has invalid publication metadata")
+    _validate_documentation_reference_binding(repo.root, config)
+    return config
+
+
+def _validate_documentation_reference_binding(root: Path, config: dict[str, Any]) -> None:
+    binding = config.get("documentation_reference")
+    expected = {
+        "output_class": _DOCUMENTATION_OUTPUT_CLASS,
+        "policy_mrd": "KIS-DOC-CON-POL-001",
+        "registry_mrd": "KIS-DOC-SEM-REG-001",
+    }
+    if binding != expected:
+        raise ValueError(f"publication documentation_reference must equal {expected}")
+    policy = json.loads((root / _DOCUMENTATION_POLICY).read_text(encoding="utf-8"))
+    registry = json.loads((root / _DOCUMENTATION_REGISTRY).read_text(encoding="utf-8"))
+    if policy.get("_mrd", {}).get("id") != binding["policy_mrd"] or registry.get("_mrd", {}).get("id") != binding["registry_mrd"]:
+        raise ValueError("documentation reference binding does not resolve")
+    output_classes = {item.get("class") for item in policy.get("content", {}).get("output_classes", [])}
+    if binding["output_class"] not in output_classes:
+        raise ValueError("documentation reference output class is not governed by the policy")
+    governed_roles = {item.get("role") for item in policy.get("content", {}).get("authority_model", [])}
+    for reference in registry.get("content", {}).get("references", []):
+        if reference.get("role") not in governed_roles or reference.get("may_define_kis_facts") is not False:
+            raise ValueError(f"external documentation reference authority is invalid: {reference.get('id')}")
+
+
+def _work_source_file_declarations(repo: WorkManagementRepository) -> list[dict[str, Any]]:
+    declarations = []
+    for relative in (_DOCUMENTATION_POLICY, _DOCUMENTATION_REGISTRY, _DOCUMENTATION_PUBLICATION, _WORK_EVIDENCE):
+        payload = canonical_source_bytes(repo.root / relative)
+        declarations.append({"path": relative, "sha256": hashlib.sha256(payload).hexdigest(), "bytes": len(payload)})
+    return declarations
+
+
 def _live_project_summary(repo: WorkManagementRepository) -> str:
     path = repo.root / "evidence" / "work-management" / "canonical-snapshot.json"
     try:
@@ -607,16 +662,17 @@ def _live_project_summary(repo: WorkManagementRepository) -> str:
 def build_work_management_spec(repo: WorkManagementRepository, output: Path, *, replace: bool=False) -> dict[str, Any]:
     validation=repo.validate()
     if validation["status"]!="valid": raise ValueError(f"work-management MRDs invalid: {validation['diagnostics']}")
+    config = _load_work_publication(repo)
     docs=list(repo.load().values())
     output=Path(output)
     staging=Path(tempfile.mkdtemp(prefix=f".{output.name}.",suffix=".tmp",dir=output.parent))
     try:
         pages=[]
         for i,doc in enumerate(docs,2):
-            name=_page_name(i,doc); text=render_document(doc); (staging/name).write_text(text,encoding="utf-8"); pages.append((name,doc))
+            name=_page_name(i,doc); text=render_document(doc); (staging/name).write_bytes(text.encode("utf-8")); pages.append((name,doc))
         index = [
             "<!-- GENERATED — DO NOT EDIT -->",
-            "# KIS Work Management Specification — documentation index",
+            f"# {config['title']} — documentation index",
             "",
             "Start with the [Specification](001-specification.md) for the operating model. The remaining chapters provide the detailed lifecycle, selection, authority, provider, and conformance rules.",
             "",
@@ -632,14 +688,18 @@ def build_work_management_spec(repo: WorkManagementRepository, output: Path, *, 
             "- [Build manifest](manifest.json) — exact MRD and generated-file hashes",
             "",
         ]
-        (staging/'000-index.md').write_text("\n".join(index),encoding='utf-8')
+        (staging/'000-index.md').write_bytes("\n".join(index).encode("utf-8"))
         root = [
             "<!-- GENERATED — DO NOT EDIT -->",
-            "# KIS Work Management Specification",
+            f"# {config['title']}",
             "",
             '<div id="enable-section-numbers" />',
             "",
+            config["subtitle"],
+            "",
             "Work Management is the governed KIS system for capturing, classifying, selecting, executing, verifying, and closing work across registered projects.",
+            "",
+            "This publication follows `KIS-DOC-CON-POL-001` as a `human_readable_specification`. MCP 2026 applies only within its bounded protocol domain, Google guidance affects presentation only, and implementation references cannot create or override Work Management facts.",
             "",
             'The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", and "OPTIONAL" are normative when they appear in all capitals.',
             "",
@@ -675,7 +735,7 @@ def build_work_management_spec(repo: WorkManagementRepository, output: Path, *, 
             "See the [documentation index](000-index.md) and [build manifest](manifest.json) for exact source identities, MRD versions, hashes, and generated-file declarations.",
             "",
         ]
-        spec="\n".join(root); (staging/'001-specification.md').write_text(spec,encoding='utf-8'); (staging/'specification.md').write_text(spec,encoding='utf-8')
+        spec="\n".join(root); (staging/'001-specification.md').write_bytes(spec.encode("utf-8")); (staging/'specification.md').write_bytes(spec.encode("utf-8"))
         files=[]
         for path in sorted(staging.rglob('*')):
             if path.is_file():
@@ -683,8 +743,22 @@ def build_work_management_spec(repo: WorkManagementRepository, output: Path, *, 
         mrds=[]
         for path in sorted(repo.mrd_root.glob('*.mrd.json')):
             b=canonical_source_bytes(path); d=json.loads(path.read_text(encoding='utf-8')); mrds.append({'id':d['_mrd']['id'],'path':path.relative_to(repo.root).as_posix(),'sha256':hashlib.sha256(b).hexdigest(),'version':d['_mrd']['version']})
-        manifest={'contract':{'name':'kis-work-management-spec-build','version':1},'specification':{'title':'KIS Work Management Specification','version':'1.0.0','status':'draft','layout_profile':'mcp-spec'},'inputs':{'mrds':mrds,'source_set_sha256':canonical_hash(mrds)},'validation':validation,'files':files,'bundle_sha256':canonical_hash(files)}
-        (staging/'manifest.json').write_text(json.dumps(manifest,indent=2,sort_keys=True)+'\n',encoding='utf-8')
+        publication_path = repo.root / _WORK_PUBLICATION
+        publication_bytes = canonical_source_bytes(publication_path)
+        manifest={
+            'contract':{'name':'kis-work-management-spec-build','version':1},
+            'specification':{'title':config['title'],'version':config['version'],'status':config['status'],'layout_profile':'mcp-spec'},
+            'inputs':{
+                'mrds':mrds,
+                'source_set_sha256':canonical_hash(mrds),
+                'source_files':_work_source_file_declarations(repo),
+                'publication':{'path':_WORK_PUBLICATION,'sha256':hashlib.sha256(publication_bytes).hexdigest()},
+            },
+            'validation':validation,
+            'files':files,
+            'bundle_sha256':canonical_hash(files),
+        }
+        (staging/'manifest.json').write_bytes((json.dumps(manifest,indent=2,sort_keys=True)+'\n').encode("utf-8"))
         if output.exists():
             if not replace: raise FileExistsError(output)
             shutil.rmtree(output)

--- a/tests/test_governance_renderer.py
+++ b/tests/test_governance_renderer.py
@@ -180,7 +180,40 @@ def test_manifest_binds_canonical_repo_dependencies(tmp_path: Path) -> None:
         "contracts/mrd/v1/mrd.schema.json",
         "contracts/governance/v1/content.schema.json",
         "contracts/governance/v1/governance-mrd.schema.json",
+        "mrd/documentation/01-reference-standard.mrd.json",
+        "mrd/documentation/02-reference-registry.mrd.json",
+        "publication/documentation-reference-standard.json",
     }
+
+
+def test_governance_publication_consumes_documentation_reference_profile(tmp_path: Path) -> None:
+    repo = GovernanceRepository(ROOT, MRD_ROOT)
+    output = tmp_path / "build"
+    manifest = build_governance_spec(repo, PUBLICATION, output)
+    config = json.loads(PUBLICATION.read_text(encoding="utf-8"))
+
+    assert config["documentation_reference"] == {
+        "output_class": "human_readable_specification",
+        "policy_mrd": "KIS-DOC-CON-POL-001",
+        "registry_mrd": "KIS-DOC-SEM-REG-001",
+    }
+    assert "`KIS-DOC-CON-POL-001`" in (output / "001-specification.md").read_text(encoding="utf-8")
+    assert any(item["path"] == "mrd/documentation/01-reference-standard.mrd.json" for item in manifest["inputs"]["source_files"])
+
+
+def test_governance_publication_rejects_external_authority_promotion(tmp_path: Path) -> None:
+    root, repo, publication = copied_repository(tmp_path)
+    registry_path = root / "mrd" / "documentation" / "02-reference-registry.mrd.json"
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    registry["content"]["references"][1]["may_define_kis_facts"] = True
+    registry_path.write_text(json.dumps(registry, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    try:
+        build_governance_spec(repo, publication, tmp_path / "build")
+    except ValueError as error:
+        assert "external documentation reference cannot define KIS facts" in str(error)
+    else:
+        raise AssertionError("external documentation reference authority promotion was accepted")
 
 
 def test_verifier_detects_bundle_digest_tampering(tmp_path: Path) -> None:

--- a/tests/test_work_management_spec.py
+++ b/tests/test_work_management_spec.py
@@ -1,9 +1,18 @@
 from pathlib import Path
 import json
+import shutil
 
 from kis_mcp_doc.work_management import WorkManagementRepository, build_work_management_spec, verify_work_management_spec
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def copied_work_repository(tmp_path):
+    root = tmp_path / "repo"
+    for name in ("contracts", "mrd", "publication", "evidence"):
+        shutil.copytree(ROOT / name, root / name)
+    return root, WorkManagementRepository(root)
+
 
 def test_work_management_mrds_validate():
     result = WorkManagementRepository(ROOT).validate()
@@ -17,6 +26,51 @@ def test_work_management_spec_is_deterministic(tmp_path):
     a={p.relative_to(first).as_posix():p.read_bytes() for p in first.rglob("*") if p.is_file()}
     b={p.relative_to(second).as_posix():p.read_bytes() for p in second.rglob("*") if p.is_file()}
     assert a==b
+
+
+def test_work_management_publication_consumes_documentation_reference_profile(tmp_path):
+    repo=WorkManagementRepository(ROOT); out=tmp_path/"build"
+    manifest=build_work_management_spec(repo,out)
+    config=json.loads((ROOT/"publication/work-management-spec.json").read_text(encoding="utf-8"))
+    assert config["documentation_reference"] == {
+        "output_class": "human_readable_specification",
+        "policy_mrd": "KIS-DOC-CON-POL-001",
+        "registry_mrd": "KIS-DOC-SEM-REG-001",
+    }
+    source_paths={item["path"] for item in manifest["inputs"]["source_files"]}
+    assert source_paths == {
+        "mrd/documentation/01-reference-standard.mrd.json",
+        "mrd/documentation/02-reference-registry.mrd.json",
+        "publication/documentation-reference-standard.json",
+        "evidence/work-management/canonical-snapshot.json",
+    }
+    assert "`KIS-DOC-CON-POL-001`" in (out/"001-specification.md").read_text(encoding="utf-8")
+
+
+def test_work_management_publication_rejects_external_authority_promotion(tmp_path):
+    root,repo=copied_work_repository(tmp_path)
+    registry_path=root/"mrd/documentation/02-reference-registry.mrd.json"
+    registry=json.loads(registry_path.read_text(encoding="utf-8"))
+    registry["content"]["references"][0]["may_define_kis_facts"]=True
+    registry_path.write_text(json.dumps(registry,indent=2,sort_keys=True)+"\n",encoding="utf-8")
+    try:
+        build_work_management_spec(repo,tmp_path/"build")
+    except ValueError as error:
+        assert "external documentation reference authority is invalid" in str(error)
+    else:
+        raise AssertionError("external documentation reference authority promotion was accepted")
+
+
+def test_work_management_verifier_detects_publication_profile_drift(tmp_path):
+    root,repo=copied_work_repository(tmp_path); out=tmp_path/"build"
+    build_work_management_spec(repo,out)
+    publication=root/"publication/work-management-spec.json"
+    config=json.loads(publication.read_text(encoding="utf-8"))
+    config["subtitle"] += " Changed after build."
+    publication.write_text(json.dumps(config,indent=2,sort_keys=True)+"\n",encoding="utf-8")
+    result=verify_work_management_spec(repo,out)
+    assert result["status"]=="invalid"
+    assert result["diagnostics"][0]["code"]=="WORK_GENERATED_DRIFT"
 
 def test_work_management_generated_bundle_verifies(tmp_path):
     repo=WorkManagementRepository(ROOT); out=tmp_path/"build"


### PR DESCRIPTION
Implements Change 009 by applying the adopted Documentation Reference Standard to the existing Governance and Work Management HRD publication pipelines without changing governed domain semantics.

Key outcomes:
- binds both publication profiles to KIS-DOC-CON-POL-001 / KIS-DOC-SEM-REG-001;
- preserves Governance and Work Management MRDs unchanged;
- records documentation-reference inputs in generated manifests;
- keeps MCP 2026, Google guidance, and implementation references within their governed authority roles;
- adds deterministic generation, authority-promotion rejection, provenance, drift, and tamper tests;
- fixes Work Management generated output to use deterministic LF byte emission;
- regenerates both HRD families.

Verification:
- focused integration suite: 48/48 passed;
- full repository test suite passed;
- canonical verifier passed;
- exact-commit canonical verifier passed for 2a6b02c4536291c63ff98aba304326e1636fd54b;
- documentation review reported no material findings;
- direct MRD diff confirms no changes under mrd/governance/** or mrd/work-management/**.