### PR TITLE
011 — Publication Kernel and Publication Family Registry

### DIFF
--- a/.work/changes/011-publication-kernel-and-family-registry/change.mrd.json
+++ b/.work/changes/011-publication-kernel-and-family-registry/change.mrd.json
@@ -160,27 +160,27 @@
       },
       {
         "id": "T2",
-        "status": "planned",
+        "status": "done",
         "text": "Add publication architecture/registry authority and registry schema."
       },
       {
         "id": "T3",
-        "status": "planned",
+        "status": "done",
         "text": "Implement and test the common publication kernel and family adapters."
       },
       {
         "id": "T4",
-        "status": "planned",
+        "status": "done",
         "text": "Refactor current family builders/verifiers and add registry-driven CLI/verifier integration."
       },
       {
         "id": "T5",
-        "status": "planned",
+        "status": "done",
         "text": "Regenerate and verify current publication bundles with semantic/reader-facing preservation."
       },
       {
         "id": "T6",
-        "status": "planned",
+        "status": "in_progress",
         "text": "Complete focused/full/exact verification and architecture/code review, then publish through the governed GitHub path."
       }
     ],
@@ -199,12 +199,28 @@
       "Any general HRD prose rewrite unrelated to publication mechanics."
     ],
     "closeout": {
-      "state": "implementation_planned",
-      "verification": [],
-      "reviews": [],
-      "publication": null,
+      "state": "implementation_verified_awaiting_publication",
+      "verification": [
+        "Focused publication and HRD suite passed after final contract fixes.",
+        "Full repository pytest passed.",
+        "scripts/verify.ps1 passed with locked offline dependencies and all legacy plus registry-driven publication checks.",
+        "Generated reader-facing files are unchanged from Change 010; only manifests changed.",
+        "Protected Governance, Work Management, KIS-DOC-CON-POL-001, and KIS-DOC-SEM-REG-001 diffs are empty."
+      ],
+      "reviews": [
+        "Architecture review initially found two high boundary findings and one medium dependency-direction finding; all were corrected.",
+        "Final architecture review completed with no findings.",
+        "API-contract review findings for path containment, structured build failures, adapter protocol, Work manifest versioning, and compatibility coverage were corrected and covered by tests.",
+        "Follow-up broad API/code-quality review projectors were incomplete because of evidence-size omission; they are not treated as approvals."
+      ],
+      "publication": {
+        "status": "pending_exact_commit_and_github_checks",
+        "issue": 18
+      },
       "merge": null,
-      "unresolved": []
+      "unresolved": [
+        "Broad code-quality/API review projectors could not ingest the complete final evidence set; deterministic tests, exact-diff inspection, and the completed architecture review cover the implemented boundaries."
+      ]
     }
   }
 }

--- a/.work/changes/011-publication-kernel-and-family-registry/change.mrd.json
+++ b/.work/changes/011-publication-kernel-and-family-registry/change.mrd.json
@@ -1,0 +1,210 @@
+{
+  "_mrd": {
+    "schema_version": 1,
+    "id": "KIS-CHG011-WRK-WFL-001",
+    "title": "Publication Kernel and Publication Family Registry",
+    "module": "change-011",
+    "class": "WRK",
+    "type": "WFL",
+    "layer": "L3",
+    "record_mode": "descriptive",
+    "status": "active",
+    "version": "1.0.0",
+    "dependencies": [
+      {
+        "mrd_id": "KIS-DOC-CON-POL-001",
+        "relationship": "depends_on"
+      },
+      {
+        "mrd_id": "KIS-DOC-SEM-REG-001",
+        "relationship": "depends_on"
+      }
+    ],
+    "provenance": {
+      "sources": [
+        {
+          "source_id": "KIS-OPERATOR-DIRECTION-2026-08-26-PUBLICATION-KERNEL",
+          "kind": "operator_direction",
+          "role": "approved_change_basis",
+          "locator": "conversation:2026-08-26",
+          "revision": "implementation-approved",
+          "sha256": null
+        },
+        {
+          "source_id": "GH-ISSUE-18",
+          "kind": "operator_approved_work_item",
+          "role": "approved_change_basis",
+          "locator": "github:NielPieterse0/kis-mcp-doc#18",
+          "revision": "2026-08-26",
+          "sha256": null
+        },
+        {
+          "source_id": "KIS-DOC-CON-POL-001",
+          "kind": "canonical_machine_readable_record",
+          "role": "documentation_output_class_authority",
+          "locator": "mrd/documentation/01-reference-standard.mrd.json",
+          "revision": "1.0.0",
+          "sha256": null
+        },
+        {
+          "source_id": "KIS-DOC-SEM-REG-001",
+          "kind": "canonical_machine_readable_record",
+          "role": "documentation_reference_authority",
+          "locator": "mrd/documentation/02-reference-registry.mrd.json",
+          "revision": "1.0.0",
+          "sha256": null
+        },
+        {
+          "source_id": "KIS-CHG010-WRK-WFL-001",
+          "kind": "canonical_machine_readable_record",
+          "role": "current_hrd_architecture_basis",
+          "locator": ".work/changes/010-hrd-reader-experience-and-reference-separation/change.mrd.json",
+          "revision": "1.1.0",
+          "sha256": null
+        },
+        {
+          "source_id": "ORPHAN-009-PUBLICATION-KERNEL",
+          "kind": "implementation_evidence",
+          "role": "non_authoritative_design_evidence",
+          "locator": ".work/worktrees/009-publication-kernel",
+          "revision": "preserved-uncommitted-worktree",
+          "sha256": null
+        }
+      ],
+      "source_fingerprint": "sha256:613b5131686cb813c58de96736d1c45965e7ba551aa665981b9e8451844c3425",
+      "fact_quality": "direct"
+    },
+    "supersedes": [],
+    "superseded_by": null
+  },
+  "content": {
+    "change_id": "011-publication-kernel-and-family-registry",
+    "work_item": {
+      "repository": "NielPieterse0/kis-mcp-doc",
+      "issue": 18,
+      "project": "NielPieterse0/1",
+      "record_id": "SPEC-011"
+    },
+    "outcome": "Create one small governed publication kernel and one publication-family registry that remove duplicated publication mechanics across current documentation families while preserving family semantic ownership and post-010 reader-facing behavior.",
+    "classification": {
+      "complexity": "large",
+      "risk_triggers": [
+        "public_contract"
+      ],
+      "reason": "The change adds L1 publication authority, a versioned registry contract, and shared mechanics used by every current generated documentation family."
+    },
+    "authority_model": [
+      "KIS-DOC-CON-POL-001 continues to own documentation output classes and source-authority boundaries.",
+      "Governance MRDs continue to own Governance facts and requirements.",
+      "Work Management MRDs continue to own Work Management facts and requirements.",
+      "The Documentation Reference Standard MRDs continue to own documentation reference semantics.",
+      "The publication kernel may own only deterministic publication mechanics; it must not interpret canonical domain facts.",
+      "Each family must retain a named semantic owner and adapter for validation, rendering, canonical fact interpretation, and family-specific manifest semantics.",
+      "The preserved change/009-publication-kernel worktree is non-authoritative implementation evidence and remains untouched."
+    ],
+    "design_decisions": [
+      "D1: Introduce KIS-DOC-CON-POL-002 as the publication-architecture owner and KIS-DOC-SEM-REG-002 as the publication-family discovery owner.",
+      "D2: A publication family is a generated bundle, not a single output class. The registry must therefore admit one or more output classes per family so the post-010 Governance and Work Management bundles can contain both human_readable_specification and generated_reference surfaces.",
+      "D3: Kernel responsibilities are limited to sorted file declarations, deterministic bundle hashes, staged bundle replacement, exact generated-file/manifest drift checks, registry validation/discovery, and registered-family orchestration.",
+      "D4: Domain adapters own semantic validation, rendering, domain-specific diagnostics, family-specific manifest/source semantics, and optional family-specific build parameters.",
+      "D5: Existing family-specific CLI commands remain supported. Registry-driven commands may be added for cross-family validation and verification but must not remove legacy entry points.",
+      "D6: Repository verification should use the family registry as the discovery source for cross-family publication checking instead of duplicating a hard-coded family inventory.",
+      "D7: Refactoring must preserve the post-010 generated Markdown byte-for-byte where feasible; mechanically necessary manifest changes must be deterministic and explicitly tested.",
+      "D8: No live external reference, inferred evidence, or generated output may become a canonical input through publication-family discovery."
+    ],
+    "requirements": [
+      "R1: Shared publication mechanics MUST be implemented once in the common kernel rather than duplicated across family renderers.",
+      "R2: Every registered family MUST declare a stable family ID, title, semantic owner, source root, publication config, output bundle, one or more admitted output classes, and validate/build/verify adapter entrypoints.",
+      "R3: Family IDs and output bundle paths MUST be unique.",
+      "R4: Every registered output class MUST be defined by KIS-DOC-CON-POL-001.",
+      "R5: Every registered adapter entrypoint MUST resolve to a callable before registry validation succeeds.",
+      "R6: The kernel MUST NOT interpret, normalize, or rewrite canonical domain facts.",
+      "R7: Generated publication output MUST remain downstream and MUST NOT gain write-back authority.",
+      "R8: External references MUST NOT become live deterministic build inputs through the kernel or registry.",
+      "R9: Existing family-specific validate/build/check CLI commands MUST remain compatible.",
+      "R10: Registry-driven validation and verification MUST cover every registered family and fail if any family is invalid or stale.",
+      "R11: Bundle writes MUST stage complete output before replacement so a failed build does not leave a partially generated family.",
+      "R12: Exact verification MUST detect missing, extra, changed, stale, or tampered generated files and manifest drift.",
+      "R13: Governance and Work Management post-010 human-readable specification and generated-reference separation MUST remain intact.",
+      "R14: Governance, Work Management, and existing Documentation Reference Standard canonical MRDs MUST remain unchanged by this implementation."
+    ],
+    "implementation_plan": [
+      "P1: Inspect current family builders/verifiers and the preserved orphan prototype; extract only mechanics that remain valid after Change 010.",
+      "P2: Add the publication architecture MRD, family registry MRD, and strict registry schema with multi-output-class support.",
+      "P3: Implement the common kernel and thin family adapters with tests first for registry validity, bundle mechanics, and failure cases.",
+      "P4: Refactor Governance, Work Management, and Documentation Reference Standard builders/verifiers to use common bundle mechanics without moving semantic logic into the kernel.",
+      "P5: Add registry-driven CLI validation/check operations and update canonical verification to consume the registry while retaining legacy commands.",
+      "P6: Regenerate affected bundles, compare reader-facing content with the 010 baseline, and add compatibility/semantic-boundary tests.",
+      "P7: Run focused tests, full pytest, canonical verification, exact-commit verification, architecture/code review, and protected-MRD diffs before publication."
+    ],
+    "verification_criteria": [
+      "V1: Registry schema and semantic validation pass for all current families and reject duplicate IDs/outputs, unsupported output classes, and unresolved adapters.",
+      "V2: Kernel unit tests prove deterministic declarations/hashes, staged replacement, and exact drift/tamper diagnostics.",
+      "V3: Existing Governance, Work Management, and Documentation Reference Standard tests remain green without weakened semantic assertions.",
+      "V4: Generated Markdown content remains semantically identical to Change 010; any changed manifests are deterministic and provenance-complete.",
+      "V5: Direct diffs under mrd/governance/**, mrd/work-management/**, mrd/documentation/01-reference-standard.mrd.json, and mrd/documentation/02-reference-registry.mrd.json are empty.",
+      "V6: Legacy CLI validation/build/check paths and new registry-driven validation/check paths agree.",
+      "V7: scripts/verify.ps1 passes on the final exact commit.",
+      "V8: Architecture and code review find no semantic leakage into the kernel and no material regression."
+    ],
+    "tasks": [
+      {
+        "id": "T0",
+        "status": "done",
+        "text": "Create GitHub issue 18 and isolated Change 011 worktree from verified main 40c32f7b6dd61915d240d7ae40846cce7dc98d44."
+      },
+      {
+        "id": "T1",
+        "status": "done",
+        "text": "Prepare the governed Change 011 scope and implementation MRD."
+      },
+      {
+        "id": "T2",
+        "status": "planned",
+        "text": "Add publication architecture/registry authority and registry schema."
+      },
+      {
+        "id": "T3",
+        "status": "planned",
+        "text": "Implement and test the common publication kernel and family adapters."
+      },
+      {
+        "id": "T4",
+        "status": "planned",
+        "text": "Refactor current family builders/verifiers and add registry-driven CLI/verifier integration."
+      },
+      {
+        "id": "T5",
+        "status": "planned",
+        "text": "Regenerate and verify current publication bundles with semantic/reader-facing preservation."
+      },
+      {
+        "id": "T6",
+        "status": "planned",
+        "text": "Complete focused/full/exact verification and architecture/code review, then publish through the governed GitHub path."
+      }
+    ],
+    "risks": [
+      "Semantic leakage: a generic kernel could accidentally become a second interpreter of domain facts.",
+      "Registry underspecification: treating a family as one output class would lose Change 010's specification/reference separation.",
+      "Manifest churn: refactoring generator mechanics can cause unnecessary generated diffs unless byte stability is actively preserved.",
+      "Partial replacement: a shared write path can amplify failures if it replaces output before a bundle is complete.",
+      "Prototype drift: blindly copying the pre-010 orphan implementation would regress current publication behavior."
+    ],
+    "explicit_exclusions": [
+      "Any change to Governance or Work Management domain MRDs or semantics.",
+      "Any change to KIS-DOC-CON-POL-001 or KIS-DOC-SEM-REG-001 semantics.",
+      "Any edit, reset, cleanup, or deletion of the preserved change/009-publication-kernel worktree.",
+      "Any new task-oriented human documentation, diagrams, site/portal design, parent KIS change, or external reference refresh.",
+      "Any general HRD prose rewrite unrelated to publication mechanics."
+    ],
+    "closeout": {
+      "state": "implementation_planned",
+      "verification": [],
+      "reviews": [],
+      "publication": null,
+      "merge": null,
+      "unresolved": []
+    }
+  }
+}

--- a/.work/changes/011-publication-kernel-and-family-registry/scope.json
+++ b/.work/changes/011-publication-kernel-and-family-registry/scope.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 4,
+  "change_id": "011-publication-kernel-and-family-registry",
+  "status": "active",
+  "branch": "change/011-publication-kernel-and-family-registry",
+  "worktree": ".work/worktrees/011-publication-kernel-and-family-registry",
+  "base": "main",
+  "outcome": "Create a governed shared publication kernel and publication-family registry for all current documentation publication families without changing Governance or Work Management domain semantics.",
+  "owned_paths": [
+    ".work/changes/011-publication-kernel-and-family-registry/**",
+    "contracts/publication/family/v1/registry.schema.json",
+    "mrd/documentation/03-publication-architecture.mrd.json",
+    "mrd/documentation/04-publication-family-registry.mrd.json",
+    "src/kis_mcp_doc/publication_kernel.py",
+    "src/kis_mcp_doc/publication_adapters.py",
+    "src/kis_mcp_doc/render.py",
+    "src/kis_mcp_doc/work_management.py",
+    "src/kis_mcp_doc/documentation_reference.py",
+    "src/kis_mcp_doc/cli.py",
+    "generated/governance-spec/**",
+    "generated/work-management-spec/**",
+    "generated/documentation-reference-standard/**",
+    "tests/test_publication_kernel.py",
+    "tests/test_governance_renderer.py",
+    "tests/test_work_management_spec.py",
+    "tests/test_documentation_reference_standard.py",
+    "tests/test_docs_backend.py",
+    "scripts/verify.ps1"
+  ],
+  "shared_paths": [],
+  "excluded_paths": [
+    "AGENTS.md",
+    "mrd/governance/**",
+    "mrd/work-management/**",
+    "mrd/documentation/01-reference-standard.mrd.json",
+    "mrd/documentation/02-reference-registry.mrd.json",
+    "publication/**",
+    "evidence/**",
+    "C:/Projects/kis-mcp/**",
+    "C:/Projects/References/**",
+    ".work/worktrees/009-publication-kernel/**"
+  ],
+  "dependencies": [
+    "008-documentation-reference-standard",
+    "009-apply-documentation-reference-standard-to-existing-hrds",
+    "010-hrd-reader-experience-and-reference-separation"
+  ],
+  "integration_owner": null,
+  "complexity": "large",
+  "risk_triggers": [
+    "public_contract"
+  ],
+  "base_evidence": {
+    "local_sha": "40c32f7b6dd61915d240d7ae40846cce7dc98d44",
+    "local_tree": "048c7891437bdf80d3e45d86123aaf00d508427a",
+    "upstream_sha": "40c32f7b6dd61915d240d7ae40846cce7dc98d44",
+    "upstream_tree": "048c7891437bdf80d3e45d86123aaf00d508427a",
+    "upstream_ref": "github:main",
+    "evidence_source": "verified_github_default",
+    "relation": "equal"
+  },
+  "work_management": {
+    "project_id": "kis-mcp",
+    "record_id": "SPEC-011",
+    "source_repository": "NielPieterse0/kis-mcp-doc",
+    "source_number": 18,
+    "source_kind": "issue",
+    "documentation_impact": "planned"
+  }
+}

--- a/.work/changes/011-publication-kernel-and-family-registry/scope.json
+++ b/.work/changes/011-publication-kernel-and-family-registry/scope.json
@@ -11,6 +11,8 @@
     "contracts/publication/family/v1/registry.schema.json",
     "mrd/documentation/03-publication-architecture.mrd.json",
     "mrd/documentation/04-publication-family-registry.mrd.json",
+    "src/kis_mcp_doc/canonical.py",
+    "src/kis_mcp_doc/governance.py",
     "src/kis_mcp_doc/publication_kernel.py",
     "src/kis_mcp_doc/publication_adapters.py",
     "src/kis_mcp_doc/render.py",

--- a/contracts/publication/family/v1/registry.schema.json
+++ b/contracts/publication/family/v1/registry.schema.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "KIS publication family registry",
+  "type": "object",
+  "required": [
+    "_mrd",
+    "content"
+  ],
+  "properties": {
+    "_mrd": {
+      "type": "object"
+    },
+    "content": {
+      "type": "object",
+      "required": [
+        "registry_version",
+        "adapter_protocol_version",
+        "families"
+      ],
+      "properties": {
+        "registry_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "adapter_protocol_version": {
+          "const": 1
+        },
+        "families": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "title",
+              "semantic_owner",
+              "mrd_root",
+              "publication_config",
+              "output",
+              "output_classes",
+              "adapter",
+              "legacy_commands"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+              },
+              "title": {
+                "type": "string",
+                "minLength": 1
+              },
+              "semantic_owner": {
+                "type": "string",
+                "minLength": 1
+              },
+              "mrd_root": {
+                "type": "string",
+                "pattern": "^mrd/(?:[A-Za-z0-9][A-Za-z0-9._-]*/)*[A-Za-z0-9][A-Za-z0-9._-]*$"
+              },
+              "publication_config": {
+                "type": "string",
+                "pattern": "^publication/(?:[A-Za-z0-9][A-Za-z0-9._-]*/)*[A-Za-z0-9][A-Za-z0-9._-]*\\.json$"
+              },
+              "output": {
+                "type": "string",
+                "pattern": "^generated/(?:[A-Za-z0-9][A-Za-z0-9._-]*/)*[A-Za-z0-9][A-Za-z0-9._-]*$"
+              },
+              "output_classes": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {
+                  "enum": [
+                    "human_documentation",
+                    "human_readable_specification",
+                    "generated_reference"
+                  ]
+                }
+              },
+              "adapter": {
+                "$ref": "#/$defs/adapter"
+              },
+              "legacy_commands": {
+                "$ref": "#/$defs/commands"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "adapter": {
+      "type": "object",
+      "required": [
+        "validate",
+        "build",
+        "verify"
+      ],
+      "properties": {
+        "validate": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.]+:[A-Za-z0-9_]+$"
+        },
+        "build": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.]+:[A-Za-z0-9_]+$"
+        },
+        "verify": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.]+:[A-Za-z0-9_]+$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "commands": {
+      "type": "object",
+      "required": [
+        "validate",
+        "build",
+        "verify"
+      ],
+      "properties": {
+        "validate": {
+          "type": "string",
+          "minLength": 1
+        },
+        "build": {
+          "type": "string",
+          "minLength": 1
+        },
+        "verify": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/generated/documentation-reference-standard/manifest.json
+++ b/generated/documentation-reference-standard/manifest.json
@@ -26,7 +26,7 @@
       "sha256": "0daffac7e07d744a752affde559c65708568fd2ce6fc95d7672185717145d3cc"
     }
   ],
-  "input_set_sha256": "b96d60b414c18921aa43fb76a1b2a820a97d09fce00ddb0e084ba42c300a0b09",
+  "input_set_sha256": "59d3af152f7f9624883c20a2f770a53b21a83ccd3f317ac52514179c826cacaf",
   "inputs": [
     {
       "bytes": 5712,
@@ -42,6 +42,21 @@
       "bytes": 403,
       "path": "publication/documentation-reference-standard.json",
       "sha256": "35f4170ba7e70cabc664b6f880f41af40a897909c982c4cdc30cb03d5f412fdd"
+    },
+    {
+      "bytes": 5375,
+      "path": "mrd/documentation/03-publication-architecture.mrd.json",
+      "sha256": "e266a4a60b6037129a106f5f7f977161cd01d69983560a8de790d7d9d6cf9c71"
+    },
+    {
+      "bytes": 4479,
+      "path": "mrd/documentation/04-publication-family-registry.mrd.json",
+      "sha256": "e72c7546e6e02b13a384e4ce722a057e5fdae50ee8d0e099af4f1ac491775d17"
+    },
+    {
+      "bytes": 3657,
+      "path": "contracts/publication/family/v1/registry.schema.json",
+      "sha256": "526acd37af7fa91a96fa4a2b0a7af0594299167c915190fd0c0364805ce4f58e"
     },
     {
       "bytes": 5511,
@@ -74,9 +89,19 @@
       "sha256": "c95235389e40f4761f345225db13a4465d16d4024f029858206571b6bd6ab4a7"
     },
     {
-      "bytes": 20315,
+      "bytes": 300,
+      "path": "src/kis_mcp_doc/canonical.py",
+      "sha256": "0a6b0eba30e070cf0a290c85dc7947036993f81c09217f7d2c9b9e451eac3fb4"
+    },
+    {
+      "bytes": 20576,
+      "path": "src/kis_mcp_doc/publication_kernel.py",
+      "sha256": "4d52bd6ede3033ee2f6cd33b284870ef616325aea108db8bb14ca056adb66707"
+    },
+    {
+      "bytes": 20056,
       "path": "src/kis_mcp_doc/documentation_reference.py",
-      "sha256": "a4587ece5b73b39b0f3060001ba1879452f0dc3c43405b682329c1b16dc78578"
+      "sha256": "cfad1c628d782bdb05709a6f200c7c1a451a5725c27bb781ca2490955876b125"
     }
   ],
   "specification": {

--- a/generated/governance-spec/manifest.json
+++ b/generated/governance-spec/manifest.json
@@ -96,8 +96,12 @@
     "name": "kis-mcp-doc",
     "sources": [
       {
+        "path": "src/kis_mcp_doc/canonical.py",
+        "sha256": "0a6b0eba30e070cf0a290c85dc7947036993f81c09217f7d2c9b9e451eac3fb4"
+      },
+      {
         "path": "src/kis_mcp_doc/governance.py",
-        "sha256": "4157674cc1f92bb4d69e5a0883f26745d6d6f751e47e5504257da338fe8c8602"
+        "sha256": "65ab4548ae8663ced06519ff7f679482d48ab047abd08fe5680f28629be40c94"
       },
       {
         "path": "src/kis_mcp_doc/harvest.py",
@@ -108,8 +112,12 @@
         "sha256": "0ed515ceb43183e19b6eb6e40ba20a09aa782635e0aabd69c51fd21fc99cc05b"
       },
       {
+        "path": "src/kis_mcp_doc/publication_kernel.py",
+        "sha256": "4d52bd6ede3033ee2f6cd33b284870ef616325aea108db8bb14ca056adb66707"
+      },
+      {
         "path": "src/kis_mcp_doc/render.py",
-        "sha256": "ef1deb1f9c0e8d5cbb81319f320f23dac6987c548044a801698b9a2d5e7025c0"
+        "sha256": "34f2430f0ea41d8b681547414c58a738349925f4ce5cb30a2a51fe0495fc2bae"
       },
       {
         "path": "contracts/publication/v2/governance-spec.schema.json",
@@ -214,6 +222,11 @@
         "sha256": "fb9f3210b022d8def12a92bfccc1cb45e5ccf1146fa9d59168baf3f630ded153"
       },
       {
+        "bytes": 3657,
+        "path": "contracts/publication/family/v1/registry.schema.json",
+        "sha256": "526acd37af7fa91a96fa4a2b0a7af0594299167c915190fd0c0364805ce4f58e"
+      },
+      {
         "bytes": 5712,
         "path": "mrd/documentation/01-reference-standard.mrd.json",
         "sha256": "da30a9f44828194a6b0b1e382c39936ae3d07705521dd6c07af60286b5133dc1"
@@ -222,6 +235,16 @@
         "bytes": 8944,
         "path": "mrd/documentation/02-reference-registry.mrd.json",
         "sha256": "5a1f98e9fb937df209e303abc6fa3af3fd73c922a868e76519939d6dd42ec24c"
+      },
+      {
+        "bytes": 5375,
+        "path": "mrd/documentation/03-publication-architecture.mrd.json",
+        "sha256": "e266a4a60b6037129a106f5f7f977161cd01d69983560a8de790d7d9d6cf9c71"
+      },
+      {
+        "bytes": 4479,
+        "path": "mrd/documentation/04-publication-family-registry.mrd.json",
+        "sha256": "e72c7546e6e02b13a384e4ce722a057e5fdae50ee8d0e099af4f1ac491775d17"
       },
       {
         "bytes": 403,

--- a/generated/work-management-spec/manifest.json
+++ b/generated/work-management-spec/manifest.json
@@ -2,7 +2,7 @@
   "bundle_sha256": "8b8a399ab61249dc29ed05dd60b396895873d3cd0dacf9ff4bd18f2301eeef24",
   "contract": {
     "name": "kis-work-management-spec-build",
-    "version": 1
+    "version": 2
   },
   "files": [
     {
@@ -66,6 +66,24 @@
       "sha256": "4babc2503e9a01835ee7cfa930e16310c87a0cf0e9ceb13285010510cf0aae52"
     }
   ],
+  "generator": {
+    "name": "kis-mcp-doc",
+    "sources": [
+      {
+        "path": "src/kis_mcp_doc/canonical.py",
+        "sha256": "0a6b0eba30e070cf0a290c85dc7947036993f81c09217f7d2c9b9e451eac3fb4"
+      },
+      {
+        "path": "src/kis_mcp_doc/publication_kernel.py",
+        "sha256": "4d52bd6ede3033ee2f6cd33b284870ef616325aea108db8bb14ca056adb66707"
+      },
+      {
+        "path": "src/kis_mcp_doc/work_management.py",
+        "sha256": "c08a68865007763fa63ba2c1971b6060c8483fa8f12e01d8425e5dc6bbaac78c"
+      }
+    ],
+    "version": "0.1.0"
+  },
   "inputs": {
     "mrds": [
       {
@@ -130,6 +148,21 @@
         "bytes": 403,
         "path": "publication/documentation-reference-standard.json",
         "sha256": "35f4170ba7e70cabc664b6f880f41af40a897909c982c4cdc30cb03d5f412fdd"
+      },
+      {
+        "bytes": 5375,
+        "path": "mrd/documentation/03-publication-architecture.mrd.json",
+        "sha256": "e266a4a60b6037129a106f5f7f977161cd01d69983560a8de790d7d9d6cf9c71"
+      },
+      {
+        "bytes": 4479,
+        "path": "mrd/documentation/04-publication-family-registry.mrd.json",
+        "sha256": "e72c7546e6e02b13a384e4ce722a057e5fdae50ee8d0e099af4f1ac491775d17"
+      },
+      {
+        "bytes": 3657,
+        "path": "contracts/publication/family/v1/registry.schema.json",
+        "sha256": "526acd37af7fa91a96fa4a2b0a7af0594299167c915190fd0c0364805ce4f58e"
       },
       {
         "bytes": 85543,

--- a/mrd/documentation/03-publication-architecture.mrd.json
+++ b/mrd/documentation/03-publication-architecture.mrd.json
@@ -1,0 +1,130 @@
+{
+  "_mrd": {
+    "schema_version": 1,
+    "id": "KIS-DOC-CON-POL-002",
+    "title": "Documentation Publication Architecture",
+    "module": "documentation",
+    "class": "CON",
+    "type": "POL",
+    "layer": "L1",
+    "record_mode": "prescriptive",
+    "status": "active",
+    "version": "1.0.0",
+    "dependencies": [
+      {
+        "mrd_id": "KIS-DOC-CON-POL-001",
+        "relationship": "depends_on"
+      },
+      {
+        "mrd_id": "KIS-DOC-SEM-REG-002",
+        "relationship": "governs"
+      },
+      {
+        "source": "repo:contracts/publication/family/v1/registry.schema.json",
+        "relationship": "references"
+      }
+    ],
+    "provenance": {
+      "sources": [
+        {
+          "source_id": "KIS-OPERATOR-DIRECTION-2026-08-26-PUBLICATION-KERNEL",
+          "kind": "operator_direction",
+          "role": "normative_adoption_basis",
+          "locator": "conversation:2026-08-26",
+          "revision": "implementation-approved",
+          "sha256": null
+        },
+        {
+          "source_id": "GH-ISSUE-18",
+          "kind": "operator_approved_work_item",
+          "role": "traceability",
+          "locator": "github:NielPieterse0/kis-mcp-doc#18",
+          "revision": "2026-08-26",
+          "sha256": null
+        }
+      ],
+      "source_fingerprint": "sha256:5b6189c2fe6ee2fdb487108a9deb1201a7030fa3f5f9aeab5f655cd1136c0a25",
+      "fact_quality": "direct"
+    },
+    "supersedes": [],
+    "superseded_by": null
+  },
+  "content": {
+    "concern": "documentation_publication_architecture",
+    "purpose": "Define one shared deterministic publication mechanism while keeping semantic validation, rendering, canonical fact interpretation, and family-specific manifest meaning in the owning documentation family.",
+    "registry_owner": "KIS-DOC-SEM-REG-002",
+    "adapter_protocol": {
+      "version": 1,
+      "validate": "adapter(root, family) returns an object with status and diagnostics",
+      "build": "adapter(root, family, replace=boolean) returns the family build manifest",
+      "verify": "adapter(root, family) returns an object with status and diagnostics"
+    },
+    "kernel_owns": [
+      "deterministic generated-file declarations and bundle hashes",
+      "safe staged publication-bundle replacement",
+      "exact generated file inventory and content drift checks",
+      "publication-family registry loading, validation, discovery, and orchestration"
+    ],
+    "family_adapters_own": [
+      "semantic validation",
+      "domain-specific rendering",
+      "canonical fact interpretation",
+      "family-specific diagnostics",
+      "family-specific manifest and source semantics",
+      "family-specific optional build parameters"
+    ],
+    "bundle_contract": {
+      "manifest_name": "manifest.json",
+      "replacement": "stage_complete_bundle_before_replacing_current_output",
+      "drift": "compare_exact_expected_inventory_and_bytes",
+      "write_back_authority": false
+    },
+    "requirements": [
+      {
+        "rule_id": "KIS-DOC-PUB-001",
+        "statement": "Cross-family publication mechanics MUST be implemented by the shared publication kernel and MUST NOT be independently redefined by a publication family without an explicit family-specific requirement.",
+        "enforcement": "review"
+      },
+      {
+        "rule_id": "KIS-DOC-PUB-002",
+        "statement": "Every publication family MUST retain a named semantic owner and adapter; the publication kernel MUST NOT interpret or rewrite canonical domain facts.",
+        "enforcement": "validator"
+      },
+      {
+        "rule_id": "KIS-DOC-PUB-003",
+        "statement": "Publication-family discovery MUST use KIS-DOC-SEM-REG-002 as its canonical registry and MUST NOT maintain a second hard-coded family inventory.",
+        "enforcement": "validator"
+      },
+      {
+        "rule_id": "KIS-DOC-PUB-004",
+        "statement": "Existing family-specific validation, build, and generated-output verification commands MUST remain compatible while a family remains active.",
+        "enforcement": "review"
+      },
+      {
+        "rule_id": "KIS-DOC-PUB-005",
+        "statement": "Generated publication output MUST remain a deterministic downstream projection with no write-back authority.",
+        "enforcement": "generator"
+      },
+      {
+        "rule_id": "KIS-DOC-PUB-006",
+        "statement": "External references, inferred evidence, and moving live web content MUST NOT become canonical KIS facts or silent deterministic build inputs through the publication kernel.",
+        "enforcement": "validator"
+      },
+      {
+        "rule_id": "KIS-DOC-PUB-007",
+        "statement": "A publication bundle MUST be staged completely before replacement of the current bundle, and replacement failure MUST restore the previous complete bundle when recovery is possible.",
+        "enforcement": "generator"
+      },
+      {
+        "rule_id": "KIS-DOC-PUB-008",
+        "statement": "Exact publication verification MUST detect missing, extra, changed, stale, or tampered generated files and manifest drift.",
+        "enforcement": "generator"
+      },
+      {
+        "rule_id": "KIS-DOC-PUB-009",
+        "statement": "Every registered publication adapter MUST conform to the versioned adapter protocol for invocation shape and validation or verification result envelopes.",
+        "enforcement": "validator"
+      }
+    ]
+  }
+}

--- a/mrd/documentation/04-publication-family-registry.mrd.json
+++ b/mrd/documentation/04-publication-family-registry.mrd.json
@@ -1,0 +1,128 @@
+{
+  "_mrd": {
+    "schema_version": 1,
+    "id": "KIS-DOC-SEM-REG-002",
+    "title": "Publication Family Registry",
+    "module": "documentation",
+    "class": "SEM",
+    "type": "REG",
+    "layer": "L1",
+    "record_mode": "prescriptive",
+    "status": "active",
+    "version": "1.0.0",
+    "dependencies": [
+      {
+        "mrd_id": "KIS-DOC-CON-POL-002",
+        "relationship": "depends_on"
+      },
+      {
+        "source": "repo:contracts/publication/family/v1/registry.schema.json",
+        "relationship": "validated_by"
+      }
+    ],
+    "provenance": {
+      "sources": [
+        {
+          "source_id": "KIS-OPERATOR-DIRECTION-2026-08-26-PUBLICATION-KERNEL",
+          "kind": "operator_direction",
+          "role": "registry_adoption_basis",
+          "locator": "conversation:2026-08-26",
+          "revision": "implementation-approved",
+          "sha256": null
+        },
+        {
+          "source_id": "GH-ISSUE-18",
+          "kind": "operator_approved_work_item",
+          "role": "traceability",
+          "locator": "github:NielPieterse0/kis-mcp-doc#18",
+          "revision": "2026-08-26",
+          "sha256": null
+        },
+        {
+          "source_id": "KIS-CHG010-WRK-WFL-001",
+          "kind": "canonical_machine_readable_record",
+          "role": "post_010_publication_shape_basis",
+          "locator": ".work/changes/010-hrd-reader-experience-and-reference-separation/change.mrd.json",
+          "revision": "1.1.0",
+          "sha256": "c7050f80722400a481a35b1a26979f16c88b5b88b879101f5337cb80ebce739d"
+        }
+      ],
+      "source_fingerprint": "sha256:dbdadfe5335334920b10cdda767424425997945ec1c96f17fcca469eff83a865",
+      "fact_quality": "direct"
+    },
+    "supersedes": [],
+    "superseded_by": null
+  },
+  "content": {
+    "registry_version": "1.0.0",
+    "adapter_protocol_version": 1,
+    "families": [
+      {
+        "id": "governance-spec",
+        "title": "kis-op Governance Specification",
+        "semantic_owner": "KIS-KNOW-CON-POL-002",
+        "mrd_root": "mrd/governance",
+        "publication_config": "publication/governance-spec.json",
+        "output": "generated/governance-spec",
+        "output_classes": [
+          "human_readable_specification",
+          "generated_reference"
+        ],
+        "adapter": {
+          "validate": "kis_mcp_doc.publication_adapters:validate_governance",
+          "build": "kis_mcp_doc.publication_adapters:build_governance",
+          "verify": "kis_mcp_doc.publication_adapters:verify_governance"
+        },
+        "legacy_commands": {
+          "validate": "validate",
+          "build": "build",
+          "verify": "check-generated"
+        }
+      },
+      {
+        "id": "work-management-spec",
+        "title": "KIS Work Management Specification",
+        "semantic_owner": "KIS-WORK-CON-POL-001",
+        "mrd_root": "mrd/work-management",
+        "publication_config": "publication/work-management-spec.json",
+        "output": "generated/work-management-spec",
+        "output_classes": [
+          "human_readable_specification",
+          "generated_reference"
+        ],
+        "adapter": {
+          "validate": "kis_mcp_doc.publication_adapters:validate_work_management",
+          "build": "kis_mcp_doc.publication_adapters:build_work_management",
+          "verify": "kis_mcp_doc.publication_adapters:verify_work_management"
+        },
+        "legacy_commands": {
+          "validate": "work-validate",
+          "build": "work-build",
+          "verify": "work-check-generated"
+        }
+      },
+      {
+        "id": "documentation-reference-standard",
+        "title": "Documentation Reference Standard",
+        "semantic_owner": "KIS-DOC-CON-POL-001",
+        "mrd_root": "mrd/documentation",
+        "publication_config": "publication/documentation-reference-standard.json",
+        "output": "generated/documentation-reference-standard",
+        "output_classes": [
+          "human_readable_specification",
+          "generated_reference"
+        ],
+        "adapter": {
+          "validate": "kis_mcp_doc.publication_adapters:validate_documentation_reference",
+          "build": "kis_mcp_doc.publication_adapters:build_documentation_reference",
+          "verify": "kis_mcp_doc.publication_adapters:verify_documentation_reference"
+        },
+        "legacy_commands": {
+          "validate": "references-validate",
+          "build": "references-build",
+          "verify": "references-check-generated"
+        }
+      }
+    ]
+  }
+}

--- a/scripts/verify.ps1
+++ b/scripts/verify.ps1
@@ -88,6 +88,16 @@ try {
         throw "Work Management generated-output verification failed with exit code $LASTEXITCODE"
     }
 
+    & $PythonCommand -m kis_mcp_doc --root . publications-validate
+    if ($LASTEXITCODE -ne 0) {
+        throw "Publication family registry validation failed with exit code $LASTEXITCODE"
+    }
+
+    & $PythonCommand -m kis_mcp_doc --root . publications-check-generated
+    if ($LASTEXITCODE -ne 0) {
+        throw "Registered publication generated-output verification failed with exit code $LASTEXITCODE"
+    }
+
     & git diff --check
     if ($LASTEXITCODE -ne 0) {
         throw "Whitespace verification failed with exit code $LASTEXITCODE"

--- a/src/kis_mcp_doc/canonical.py
+++ b/src/kis_mcp_doc/canonical.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+
+def canonical_hash(value: object) -> str:
+    payload = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()

--- a/src/kis_mcp_doc/cli.py
+++ b/src/kis_mcp_doc/cli.py
@@ -10,6 +10,11 @@ from .documentation_reference import (
     verify_documentation_reference_standard,
 )
 from .governance import GovernanceRepository
+from .publication_kernel import (
+    build_registered_publication,
+    validate_registered_publications,
+    verify_registered_publications,
+)
 from .render import build_governance_spec, verify_governance_spec
 from .work_management import (
     WorkManagementRepository,
@@ -27,6 +32,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--root", type=Path, default=Path.cwd())
     sub = parser.add_subparsers(dest="command", required=True)
     sub.add_parser("validate")
+    publications_validate = sub.add_parser("publications-validate")
+    publications_validate.add_argument("--family", action="append")
+    publications_build = sub.add_parser("publications-build")
+    publications_build.add_argument("--family", required=True)
+    publications_build.add_argument("--replace", action="store_true")
+    publications_check = sub.add_parser("publications-check-generated")
+    publications_check.add_argument("--family", action="append")
     sub.add_parser("references-validate")
     references_build = sub.add_parser("references-build")
     references_build.add_argument("--output", type=Path)
@@ -51,6 +63,22 @@ def main(argv: list[str] | None = None) -> int:
     root = args.root.resolve()
     repo = _repository(root)
     publication = root / "publication" / "governance-spec.json"
+    if args.command == "publications-validate":
+        result = validate_registered_publications(root, family_ids=args.family)
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0 if result["status"] == "valid" else 1
+    if args.command == "publications-build":
+        result = build_registered_publication(
+            root,
+            args.family,
+            replace=args.replace,
+        )
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0 if result["status"] == "valid" else 1
+    if args.command == "publications-check-generated":
+        result = verify_registered_publications(root, family_ids=args.family)
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0 if result["status"] == "valid" else 1
     if args.command == "validate":
         result = repo.validate()
         print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))

--- a/src/kis_mcp_doc/documentation_reference.py
+++ b/src/kis_mcp_doc/documentation_reference.py
@@ -2,9 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
-import shutil
-import tempfile
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -13,6 +10,7 @@ from jsonschema import Draft202012Validator
 
 from .governance import canonical_hash, canonical_source_bytes
 from .harvest import load_harvest_registry
+from .publication_kernel import exact_bundle_diagnostics, file_declarations, write_bundle
 
 
 _POLICY_PATH = "mrd/documentation/01-reference-standard.mrd.json"
@@ -23,6 +21,9 @@ _REGISTRY_SCHEMA = "contracts/documentation/reference/v1/registry.schema.json"
 _PUBLICATION_SCHEMA = "contracts/documentation/reference/v1/publication.schema.json"
 _MANIFEST_SCHEMA = "contracts/documentation/reference/v1/manifest.schema.json"
 _PUBLICATION = "publication/documentation-reference-standard.json"
+_PUBLICATION_ARCHITECTURE = "mrd/documentation/03-publication-architecture.mrd.json"
+_PUBLICATION_FAMILY_REGISTRY = "mrd/documentation/04-publication-family-registry.mrd.json"
+_PUBLICATION_FAMILY_SCHEMA = "contracts/publication/family/v1/registry.schema.json"
 
 _EXPECTED_REFERENCES = {
     "mcp-2026": "normative_external",
@@ -162,6 +163,22 @@ class DocumentationReferenceRepository:
         return _result(diagnostics, checks)
 
 
+def validate_documentation_reference_publication(
+    repository: DocumentationReferenceRepository,
+) -> dict[str, Any]:
+    try:
+        config = _load_json(repository.root / _PUBLICATION, "documentation reference publication")
+    except ValueError as error:
+        return _verification([_diag("REFERENCE_PUBLICATION_INVALID", str(error))])
+    diagnostics = _schema_diagnostics(
+        repository.root,
+        _PUBLICATION_SCHEMA,
+        config,
+        "documentation reference publication",
+    )
+    return _verification(diagnostics)
+
+
 def build_documentation_reference_standard(
     repository: DocumentationReferenceRepository,
     output: Path,
@@ -181,23 +198,7 @@ def build_documentation_reference_standard(
     manifest_diagnostics = _schema_diagnostics(repository.root, _MANIFEST_SCHEMA, manifest, "documentation reference build manifest")
     if manifest_diagnostics:
         raise ValueError(f"documentation reference build manifest is invalid: {manifest_diagnostics}")
-    output = Path(output)
-    output.parent.mkdir(parents=True, exist_ok=True)
-    staging = Path(tempfile.mkdtemp(prefix=f".{output.name}.", suffix=".tmp", dir=output.parent))
-    try:
-        for relative, payload in files.items():
-            target = staging / Path(*relative.split("/"))
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_bytes(payload)
-        (staging / "manifest.json").write_bytes(_json_bytes(manifest))
-        if output.exists():
-            if not replace:
-                raise FileExistsError(f"output already exists: {output}")
-            shutil.rmtree(output)
-        os.replace(staging, output)
-    except Exception:
-        shutil.rmtree(staging, ignore_errors=True)
-        raise
+    write_bundle(Path(output), files, manifest, replace=replace)
     return manifest
 
 
@@ -230,17 +231,14 @@ def verify_documentation_reference_standard(
     expected_manifest = _build_manifest(repository, documents, config, expected_files, validation)
     if actual_manifest != expected_manifest:
         diagnostics.append(_diag("GENERATED_MANIFEST_MISMATCH", "manifest differs from deterministic current inputs"))
-    expected_paths = set(expected_files) | {"manifest.json"}
-    actual_paths = {path.relative_to(output).as_posix() for path in output.rglob("*") if path.is_file()}
-    if actual_paths != expected_paths:
-        diagnostics.append(_diag("GENERATED_FILE_SET_MISMATCH", "generated file inventory differs from deterministic output"))
-    for relative, payload in expected_files.items():
-        path = output / Path(*relative.split("/"))
-        if not path.is_file():
-            diagnostics.append(_diag("GENERATED_FILE_MISSING", f"generated file missing: {relative}"))
-            continue
-        if path.read_bytes() != payload:
-            diagnostics.append(_diag("GENERATED_FILE_CONTENT_MISMATCH", f"generated file differs from deterministic output: {relative}"))
+    diagnostics.extend(
+        exact_bundle_diagnostics(
+            output,
+            expected_files,
+            expected_manifest,
+            code_prefix=None,
+        )
+    )
     return _verification(diagnostics)
 
 
@@ -263,13 +261,26 @@ def _build_manifest(
     validation: dict[str, Any],
 ) -> dict[str, Any]:
     inputs = []
-    for relative in (_POLICY_PATH, _REGISTRY_PATH, _PUBLICATION, _CORE_SCHEMA, _POLICY_SCHEMA, _REGISTRY_SCHEMA, _PUBLICATION_SCHEMA, _MANIFEST_SCHEMA, "publication/harvest-sources.json", "src/kis_mcp_doc/documentation_reference.py"):
+    for relative in (
+        _POLICY_PATH,
+        _REGISTRY_PATH,
+        _PUBLICATION,
+        _PUBLICATION_ARCHITECTURE,
+        _PUBLICATION_FAMILY_REGISTRY,
+        _PUBLICATION_FAMILY_SCHEMA,
+        _CORE_SCHEMA,
+        _POLICY_SCHEMA,
+        _REGISTRY_SCHEMA,
+        _PUBLICATION_SCHEMA,
+        _MANIFEST_SCHEMA,
+        "publication/harvest-sources.json",
+        "src/kis_mcp_doc/canonical.py",
+        "src/kis_mcp_doc/publication_kernel.py",
+        "src/kis_mcp_doc/documentation_reference.py",
+    ):
         payload = canonical_source_bytes(repository.root / relative)
         inputs.append({"path": relative, "sha256": hashlib.sha256(payload).hexdigest(), "bytes": len(payload)})
-    declarations = [
-        {"path": path, "sha256": hashlib.sha256(payload).hexdigest(), "bytes": len(payload)}
-        for path, payload in sorted(files.items())
-    ]
+    declarations = file_declarations(files)
     return {
         "contract": {"name": "documentation-reference-standard-build", "version": 1},
         "specification": {key: config[key] for key in ("title", "version", "status", "layout_profile")},

--- a/src/kis_mcp_doc/governance.py
+++ b/src/kis_mcp_doc/governance.py
@@ -10,6 +10,8 @@ from jsonschema.exceptions import SchemaError
 from referencing import Registry, Resource
 from referencing.exceptions import Unresolvable
 
+from .canonical import canonical_hash
+
 
 CONCERNS = (
     "classification", "applicability", "ownership", "layering", "dependencies",
@@ -33,11 +35,6 @@ CORE_REASON_CODES = frozenset({
     "MRD_RELATIONSHIP_UNKNOWN", "MRD_OPERATOR_BEHAVIOR_INVALID",
     "MRD_ENFORCEMENT_BINDING_INVALID",
 })
-
-
-def canonical_hash(value: object) -> str:
-    payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(payload).hexdigest()
 
 
 _CANONICAL_TEXT_SUFFIXES = frozenset({

--- a/src/kis_mcp_doc/publication_adapters.py
+++ b/src/kis_mcp_doc/publication_adapters.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .documentation_reference import (
+    DocumentationReferenceRepository,
+    build_documentation_reference_standard,
+    validate_documentation_reference_publication,
+    verify_documentation_reference_standard,
+)
+from .governance import GovernanceRepository
+from .render import build_governance_spec, validate_governance_publication, verify_governance_spec
+from .work_management import (
+    WorkManagementRepository,
+    build_work_management_spec,
+    validate_work_management_publication,
+    verify_work_management_spec,
+)
+
+
+def _family_output(root: Path, family: dict[str, Any], output: Path | None) -> Path:
+    return Path(output) if output is not None else root / family["output"]
+
+
+def _combined_validation(
+    semantic: dict[str, Any],
+    publication: dict[str, Any],
+    *additional: dict[str, Any],
+) -> dict[str, Any]:
+    results = (semantic, publication, *additional)
+    diagnostics = [item for result in results for item in result.get("diagnostics", [])]
+    invalid = any(result.get("status") != "valid" for result in results)
+    return {
+        "status": "invalid" if invalid else "valid",
+        "diagnostics": diagnostics,
+        "semantic": semantic,
+        "publication": publication,
+    }
+
+
+def _validate_output_classes(family: dict[str, Any], required: set[str]) -> dict[str, Any]:
+    actual = set(family.get("output_classes", []))
+    if actual != required:
+        return {
+            "status": "invalid",
+            "diagnostics": [{
+                "code": "PUBLICATION_FAMILY_OUTPUT_CLASS_MISMATCH",
+                "message": f"registered output classes must equal {sorted(required)}",
+            }],
+        }
+    return {"status": "valid", "diagnostics": []}
+
+
+def validate_governance(root: Path, family: dict[str, Any]) -> dict[str, Any]:
+    repository = GovernanceRepository(root, root / family["mrd_root"])
+    return _combined_validation(
+        repository.validate(),
+        validate_governance_publication(repository, root / family["publication_config"]),
+        _validate_output_classes(family, {"human_readable_specification", "generated_reference"}),
+    )
+
+
+def build_governance(root: Path, family: dict[str, Any], *, output: Path | None = None, replace: bool = False) -> dict[str, Any]:
+    repository = GovernanceRepository(root, root / family["mrd_root"])
+    return build_governance_spec(
+        repository,
+        root / family["publication_config"],
+        _family_output(root, family, output),
+        replace=replace,
+    )
+
+
+def verify_governance(root: Path, family: dict[str, Any]) -> dict[str, Any]:
+    repository = GovernanceRepository(root, root / family["mrd_root"])
+    return verify_governance_spec(repository, root / family["publication_config"], root / family["output"])
+
+
+def validate_work_management(root: Path, family: dict[str, Any]) -> dict[str, Any]:
+    repository = WorkManagementRepository(root, root / family["mrd_root"])
+    return _combined_validation(
+        repository.validate(),
+        validate_work_management_publication(repository),
+        _validate_output_classes(family, {"human_readable_specification", "generated_reference"}),
+    )
+
+
+def build_work_management(root: Path, family: dict[str, Any], *, output: Path | None = None, replace: bool = False) -> dict[str, Any]:
+    repository = WorkManagementRepository(root, root / family["mrd_root"])
+    return build_work_management_spec(repository, _family_output(root, family, output), replace=replace)
+
+
+def verify_work_management(root: Path, family: dict[str, Any]) -> dict[str, Any]:
+    repository = WorkManagementRepository(root, root / family["mrd_root"])
+    return verify_work_management_spec(repository, root / family["output"])
+
+
+def validate_documentation_reference(root: Path, family: dict[str, Any]) -> dict[str, Any]:
+    repository = DocumentationReferenceRepository(root)
+    return _combined_validation(
+        repository.validate(),
+        validate_documentation_reference_publication(repository),
+        _validate_output_classes(family, {"human_readable_specification", "generated_reference"}),
+    )
+
+
+def build_documentation_reference(root: Path, family: dict[str, Any], *, output: Path | None = None, replace: bool = False) -> dict[str, Any]:
+    return build_documentation_reference_standard(
+        DocumentationReferenceRepository(root),
+        _family_output(root, family, output),
+        replace=replace,
+    )
+
+
+def verify_documentation_reference(root: Path, family: dict[str, Any]) -> dict[str, Any]:
+    return verify_documentation_reference_standard(DocumentationReferenceRepository(root), root / family["output"])

--- a/src/kis_mcp_doc/publication_kernel.py
+++ b/src/kis_mcp_doc/publication_kernel.py
@@ -1,0 +1,489 @@
+from __future__ import annotations
+
+import hashlib
+import importlib
+import inspect
+import json
+import os
+import shutil
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any, Callable
+
+from jsonschema import Draft202012Validator
+
+from .canonical import canonical_hash
+
+_ARCHITECTURE_PATH = "mrd/documentation/03-publication-architecture.mrd.json"
+_REGISTRY_PATH = "mrd/documentation/04-publication-family-registry.mrd.json"
+_REGISTRY_SCHEMA = "contracts/publication/family/v1/registry.schema.json"
+_CORE_MRD_SCHEMA = "contracts/mrd/v1/mrd.schema.json"
+_DOCUMENTATION_POLICY = "mrd/documentation/01-reference-standard.mrd.json"
+
+
+def _json_bytes(value: object) -> bytes:
+    return (json.dumps(value, indent=2, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _diag(code: str, message: str) -> dict[str, str]:
+    return {"code": code, "message": message}
+
+
+def _safe_relative_path(relative: str) -> Path:
+    if not relative or "\\" in relative:
+        raise ValueError(f"publication bundle path must be a normalized relative path: {relative!r}")
+    path = Path(*relative.split("/"))
+    if (
+        path.is_absolute()
+        or ".." in path.parts
+        or "." in path.parts
+        or path.as_posix() != relative
+    ):
+        raise ValueError(f"publication bundle path must be a normalized relative path: {relative!r}")
+    return path
+
+
+def _registered_path(relative: str, prefix: str) -> Path:
+    path = _safe_relative_path(relative)
+    if len(path.parts) < 2 or path.parts[0] != prefix:
+        raise ValueError(f"registered path must stay under {prefix}/: {relative}")
+    return path
+
+
+def file_declarations(files: dict[str, bytes]) -> list[dict[str, Any]]:
+    declarations: list[dict[str, Any]] = []
+    for relative, payload in sorted(files.items()):
+        _safe_relative_path(relative)
+        if not isinstance(payload, bytes):
+            raise TypeError(f"publication bundle payload must be bytes: {relative}")
+        declarations.append(
+            {
+                "path": relative,
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "bytes": len(payload),
+            }
+        )
+    return declarations
+
+
+def bundle_manifest_fields(files: dict[str, bytes]) -> dict[str, Any]:
+    declarations = file_declarations(files)
+    return {"bundle_sha256": canonical_hash(declarations)}
+
+
+def write_bundle(
+    output: Path,
+    files: dict[str, bytes],
+    manifest: dict[str, Any],
+    *,
+    replace: bool = False,
+) -> None:
+    output = Path(output)
+    if "manifest.json" in files:
+        raise ValueError("manifest.json is owned by the publication bundle writer")
+    if output.exists() and not replace:
+        raise FileExistsError(f"output already exists: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f".{output.name}.", suffix=".tmp", dir=output.parent))
+    backup: Path | None = None
+    try:
+        for relative, payload in sorted(files.items()):
+            target = staging / _safe_relative_path(relative)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(payload)
+        (staging / "manifest.json").write_bytes(_json_bytes(manifest))
+
+        if output.exists():
+            backup = output.parent / f".{output.name}.{uuid.uuid4().hex}.bak"
+            os.replace(output, backup)
+        try:
+            os.replace(staging, output)
+        except Exception:
+            if backup is not None and backup.exists() and not output.exists():
+                os.replace(backup, output)
+                backup = None
+            raise
+        if backup is not None and backup.exists():
+            shutil.rmtree(backup, ignore_errors=True)
+            backup = None
+    except Exception:
+        if staging.exists():
+            shutil.rmtree(staging, ignore_errors=True)
+        if backup is not None and backup.exists() and not output.exists():
+            os.replace(backup, output)
+        raise
+
+
+def _bundle_code(code_prefix: str | None, suffix: str) -> str:
+    return f"{code_prefix}_{suffix}" if code_prefix else suffix
+
+
+def bundle_diagnostics(
+    output: Path,
+    expected_files: dict[str, bytes],
+    expected_manifest: dict[str, Any],
+    *,
+    code_prefix: str | None = "PUBLICATION",
+    normalizer: Callable[[str, bytes], bytes] | None = None,
+) -> list[dict[str, str]]:
+    output = Path(output)
+    diagnostics: list[dict[str, str]] = []
+    expected_payloads = dict(expected_files)
+    expected_payloads["manifest.json"] = _json_bytes(expected_manifest)
+    expected_paths = set(expected_payloads)
+    actual_paths = (
+        {path.relative_to(output).as_posix() for path in output.rglob("*") if path.is_file()}
+        if output.is_dir()
+        else set()
+    )
+    if actual_paths != expected_paths:
+        diagnostics.append(
+            _diag(
+                _bundle_code(code_prefix, "GENERATED_FILE_SET_MISMATCH"),
+                "generated publication file inventory differs from deterministic expected output",
+            )
+        )
+    for relative, expected in sorted(expected_payloads.items()):
+        path = output / _safe_relative_path(relative)
+        if not path.is_file():
+            diagnostics.append(
+                _diag(_bundle_code(code_prefix, "GENERATED_FILE_MISSING"), f"generated file missing: {relative}")
+            )
+            continue
+        actual = path.read_bytes()
+        if normalizer is not None:
+            expected = normalizer(relative, expected)
+            actual = normalizer(relative, actual)
+        if actual != expected:
+            diagnostics.append(
+                _diag(
+                    _bundle_code(code_prefix, "GENERATED_FILE_CONTENT_MISMATCH"),
+                    f"generated file differs from deterministic expected output: {relative}",
+                )
+            )
+    return diagnostics
+
+
+def exact_bundle_diagnostics(
+    output: Path,
+    expected_files: dict[str, bytes],
+    expected_manifest: dict[str, Any],
+    *,
+    code_prefix: str | None = "PUBLICATION",
+) -> list[dict[str, str]]:
+    return bundle_diagnostics(
+        output,
+        expected_files,
+        expected_manifest,
+        code_prefix=code_prefix,
+    )
+
+
+def _load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"unable to load {label}: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
+
+
+def _schema_errors(root: Path, schema_relative: str, instance: object) -> list[str]:
+    schema = _load_json(root / schema_relative, f"schema {schema_relative}")
+    Draft202012Validator.check_schema(schema)
+    return [
+        f"{'/'.join(str(part) for part in error.absolute_path) or '$'}: {error.message}"
+        for error in sorted(
+            Draft202012Validator(schema).iter_errors(instance),
+            key=lambda error: tuple(str(part) for part in error.absolute_path),
+        )
+    ]
+
+
+def _resolve_entrypoint(value: str) -> Callable[..., Any]:
+    module_name, separator, attribute = value.partition(":")
+    if not separator or not module_name or not attribute:
+        raise ValueError(f"invalid adapter entrypoint: {value}")
+    module = importlib.import_module(module_name)
+    target = getattr(module, attribute)
+    if not callable(target):
+        raise TypeError(f"adapter entrypoint is not callable: {value}")
+    return target
+
+
+def _validate_adapter_signature(target: Callable[..., Any], phase: str) -> None:
+    signature = inspect.signature(target)
+    if phase == "build":
+        signature.bind(Path("."), {}, replace=False)
+    else:
+        signature.bind(Path("."), {})
+
+
+def _phase_result(family_id: str, phase: str, result: object) -> dict[str, Any]:
+    if (
+        not isinstance(result, dict)
+        or result.get("status") not in {"valid", "invalid"}
+        or not isinstance(result.get("diagnostics"), list)
+    ):
+        return {
+            "status": "invalid",
+            "diagnostics": [_diag(
+                "PUBLICATION_FAMILY_ADAPTER_RESULT_INVALID",
+                f"{family_id}.{phase} must return status and diagnostics",
+            )],
+        }
+    return result
+
+
+class PublicationFamilyRegistry:
+    def __init__(self, root: Path) -> None:
+        self.root = Path(root).resolve()
+        self.path = self.root / _REGISTRY_PATH
+
+    def load(self) -> dict[str, Any]:
+        return _load_json(self.path, "publication family registry")
+
+    def validate(self) -> dict[str, Any]:
+        diagnostics: list[dict[str, str]] = []
+        try:
+            registry = self.load()
+        except ValueError as error:
+            return {"status": "invalid", "diagnostics": [_diag("PUBLICATION_FAMILY_REGISTRY_INVALID", str(error))]}
+
+        try:
+            architecture = _load_json(self.root / _ARCHITECTURE_PATH, "publication architecture MRD")
+            for error in _schema_errors(self.root, _CORE_MRD_SCHEMA, architecture):
+                diagnostics.append(_diag("PUBLICATION_ARCHITECTURE_MRD_SCHEMA_INVALID", error))
+            for error in _schema_errors(self.root, _CORE_MRD_SCHEMA, registry):
+                diagnostics.append(_diag("PUBLICATION_FAMILY_MRD_SCHEMA_INVALID", error))
+            for error in _schema_errors(self.root, _REGISTRY_SCHEMA, registry):
+                diagnostics.append(_diag("PUBLICATION_FAMILY_REGISTRY_SCHEMA_INVALID", error))
+        except (ValueError, OSError, TypeError) as error:
+            diagnostics.append(_diag("PUBLICATION_FAMILY_REGISTRY_SCHEMA_INVALID", str(error)))
+            architecture = {}
+
+        if architecture.get("_mrd", {}).get("id") != "KIS-DOC-CON-POL-002":
+            diagnostics.append(_diag("PUBLICATION_ARCHITECTURE_ID_INVALID", "publication architecture MRD must be KIS-DOC-CON-POL-002"))
+        if registry.get("_mrd", {}).get("id") != "KIS-DOC-SEM-REG-002":
+            diagnostics.append(_diag("PUBLICATION_FAMILY_REGISTRY_ID_INVALID", "publication family registry MRD must be KIS-DOC-SEM-REG-002"))
+        architecture_protocol = architecture.get("content", {}).get("adapter_protocol", {}).get("version")
+        registry_protocol = registry.get("content", {}).get("adapter_protocol_version")
+        if architecture_protocol != 1 or registry_protocol != architecture_protocol:
+            diagnostics.append(_diag(
+                "PUBLICATION_ADAPTER_PROTOCOL_VERSION_INVALID",
+                "publication adapter protocol version must resolve to version 1 in architecture and registry",
+            ))
+
+        architecture_provenance = architecture.get("_mrd", {}).get("provenance", {})
+        if architecture_provenance.get("source_fingerprint") != "sha256:" + canonical_hash(architecture_provenance.get("sources", [])):
+            diagnostics.append(
+                _diag("PUBLICATION_ARCHITECTURE_PROVENANCE_FINGERPRINT_MISMATCH", "publication architecture provenance fingerprint differs from its source set")
+            )
+
+        provenance = registry.get("_mrd", {}).get("provenance", {})
+        if provenance.get("source_fingerprint") != "sha256:" + canonical_hash(provenance.get("sources", [])):
+            diagnostics.append(
+                _diag("PUBLICATION_FAMILY_PROVENANCE_FINGERPRINT_MISMATCH", "publication family registry provenance fingerprint differs from its source set")
+            )
+
+        try:
+            policy = _load_json(self.root / _DOCUMENTATION_POLICY, "documentation reference policy")
+            governed_output_classes = {
+                item.get("class") for item in policy.get("content", {}).get("output_classes", [])
+            }
+        except ValueError as error:
+            diagnostics.append(_diag("PUBLICATION_OUTPUT_CLASS_AUTHORITY_INVALID", str(error)))
+            governed_output_classes = set()
+
+        known_mrd_ids: set[str] = set()
+        for path in self.root.glob("mrd/**/*.mrd.json"):
+            try:
+                doc = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, json.JSONDecodeError):
+                continue
+            doc_id = doc.get("_mrd", {}).get("id")
+            if isinstance(doc_id, str):
+                known_mrd_ids.add(doc_id)
+
+        seen_ids: set[str] = set()
+        seen_outputs: set[str] = set()
+        families = registry.get("content", {}).get("families", [])
+        if not isinstance(families, list):
+            families = []
+        for family in families:
+            if not isinstance(family, dict):
+                continue
+            family_id = family.get("id")
+            output = family.get("output")
+            if isinstance(family_id, str):
+                if family_id in seen_ids:
+                    diagnostics.append(_diag("PUBLICATION_FAMILY_ID_DUPLICATE", f"duplicate publication family id: {family_id}"))
+                seen_ids.add(family_id)
+            if isinstance(output, str):
+                if output in seen_outputs:
+                    diagnostics.append(_diag("PUBLICATION_FAMILY_OUTPUT_DUPLICATE", f"duplicate publication output: {output}"))
+                seen_outputs.add(output)
+                try:
+                    _registered_path(output, "generated")
+                except ValueError as error:
+                    diagnostics.append(_diag("PUBLICATION_FAMILY_OUTPUT_INVALID", str(error)))
+            semantic_owner = family.get("semantic_owner")
+            if semantic_owner not in known_mrd_ids:
+                diagnostics.append(_diag("PUBLICATION_FAMILY_SEMANTIC_OWNER_UNRESOLVED", f"semantic owner does not resolve: {semantic_owner}"))
+            mrd_root = family.get("mrd_root")
+            try:
+                mrd_path = _registered_path(mrd_root, "mrd") if isinstance(mrd_root, str) else None
+            except ValueError as error:
+                diagnostics.append(_diag("PUBLICATION_FAMILY_MRD_ROOT_INVALID", str(error)))
+                mrd_path = None
+            if mrd_path is None or not (self.root / mrd_path).is_dir():
+                diagnostics.append(_diag("PUBLICATION_FAMILY_MRD_ROOT_UNRESOLVED", f"MRD root does not resolve: {mrd_root}"))
+            publication_config = family.get("publication_config")
+            try:
+                config_path = _registered_path(publication_config, "publication") if isinstance(publication_config, str) else None
+            except ValueError as error:
+                diagnostics.append(_diag("PUBLICATION_FAMILY_CONFIG_INVALID", str(error)))
+                config_path = None
+            if config_path is None or not (self.root / config_path).is_file():
+                diagnostics.append(_diag("PUBLICATION_FAMILY_CONFIG_UNRESOLVED", f"publication config does not resolve: {publication_config}"))
+            output_classes = family.get("output_classes", [])
+            if isinstance(output_classes, list):
+                for output_class in output_classes:
+                    if output_class not in governed_output_classes:
+                        diagnostics.append(_diag("PUBLICATION_OUTPUT_CLASS_UNGOVERNED", f"publication output class is not governed: {output_class}"))
+            adapters = family.get("adapter", {})
+            if isinstance(adapters, dict):
+                for phase in ("validate", "build", "verify"):
+                    entrypoint = adapters.get(phase)
+                    if not isinstance(entrypoint, str):
+                        continue
+                    try:
+                        target = _resolve_entrypoint(entrypoint)
+                    except (ImportError, AttributeError, TypeError, ValueError) as error:
+                        diagnostics.append(_diag("PUBLICATION_FAMILY_ADAPTER_UNRESOLVED", f"{family_id}.{phase}: {error}"))
+                        continue
+                    try:
+                        _validate_adapter_signature(target, phase)
+                    except (TypeError, ValueError) as error:
+                        diagnostics.append(_diag(
+                            "PUBLICATION_FAMILY_ADAPTER_SIGNATURE_INVALID",
+                            f"{family_id}.{phase}: {error}",
+                        ))
+        return {"status": "invalid" if diagnostics else "valid", "diagnostics": diagnostics}
+
+    def family(self, family_id: str) -> dict[str, Any]:
+        for family in self.load().get("content", {}).get("families", []):
+            if family.get("id") == family_id:
+                return family
+        raise KeyError(family_id)
+
+
+def _run_registered_phase(
+    root: Path,
+    phase: str,
+    *,
+    family_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    registry = PublicationFamilyRegistry(root)
+    registry_result = registry.validate()
+    if registry_result["status"] != "valid":
+        return {"status": "invalid", "registry": registry_result, "families": {}}
+    registered_families = registry.load()["content"]["families"]
+    selected = set(family_ids) if family_ids is not None else None
+    if selected is not None:
+        registered_ids = {family["id"] for family in registered_families}
+        unknown = sorted(selected - registered_ids)
+        if unknown:
+            return {
+                "status": "invalid",
+                "registry": registry_result,
+                "families": {},
+                "diagnostics": [_diag("PUBLICATION_FAMILY_UNKNOWN", f"unknown publication family: {family_id}") for family_id in unknown],
+            }
+    results: dict[str, Any] = {}
+    for family in registered_families:
+        if selected is not None and family["id"] not in selected:
+            continue
+        adapter = _resolve_entrypoint(family["adapter"][phase])
+        try:
+            phase_result = adapter(Path(root).resolve(), family)
+            results[family["id"]] = _phase_result(family["id"], phase, phase_result)
+        except Exception as error:
+            results[family["id"]] = {
+                "status": "invalid",
+                "diagnostics": [_diag("PUBLICATION_FAMILY_ADAPTER_FAILED", f"{family['id']}.{phase}: {error}")],
+            }
+    valid = all(result.get("status") == "valid" for result in results.values())
+    return {"status": "valid" if valid else "invalid", "registry": registry_result, "families": results}
+
+
+def validate_registered_publications(root: Path, *, family_ids: list[str] | None = None) -> dict[str, Any]:
+    return _run_registered_phase(root, "validate", family_ids=family_ids)
+
+
+def verify_registered_publications(root: Path, *, family_ids: list[str] | None = None) -> dict[str, Any]:
+    return _run_registered_phase(root, "verify", family_ids=family_ids)
+
+
+def build_registered_publication(
+    root: Path,
+    family_id: str,
+    *,
+    replace: bool = False,
+) -> dict[str, Any]:
+    registry = PublicationFamilyRegistry(root)
+    registry_result = registry.validate()
+    if registry_result["status"] != "valid":
+        return {
+            "status": "invalid",
+            "registry": registry_result,
+            "family": family_id,
+            "diagnostics": [_diag(
+                "PUBLICATION_FAMILY_REGISTRY_INVALID",
+                "publication family registry is invalid",
+            )],
+        }
+    try:
+        family = registry.family(family_id)
+    except KeyError:
+        return {
+            "status": "invalid",
+            "registry": registry_result,
+            "family": family_id,
+            "diagnostics": [_diag(
+                "PUBLICATION_FAMILY_UNKNOWN",
+                f"unknown publication family: {family_id}",
+            )],
+        }
+    adapter = _resolve_entrypoint(family["adapter"]["build"])
+    try:
+        manifest = adapter(Path(root).resolve(), family, replace=replace)
+    except Exception as error:
+        return {
+            "status": "invalid",
+            "registry": registry_result,
+            "family": family_id,
+            "diagnostics": [_diag(
+                "PUBLICATION_FAMILY_ADAPTER_FAILED",
+                f"{family_id}.build: {error}",
+            )],
+        }
+    if not isinstance(manifest, dict):
+        return {
+            "status": "invalid",
+            "registry": registry_result,
+            "family": family_id,
+            "diagnostics": [_diag(
+                "PUBLICATION_FAMILY_ADAPTER_RESULT_INVALID",
+                f"{family_id}.build must return a manifest object",
+            )],
+        }
+    return {
+        "status": "valid",
+        "registry": registry_result,
+        "family": family_id,
+        "diagnostics": [],
+        "manifest": manifest,
+    }

--- a/src/kis_mcp_doc/render.py
+++ b/src/kis_mcp_doc/render.py
@@ -2,9 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
-import shutil
-import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +10,7 @@ from jsonschema import Draft202012Validator
 from .governance import GovernanceRepository, canonical_hash, canonical_source_bytes
 from .harvest import load_harvest_registry
 from .litho import load_litho_evidence
+from .publication_kernel import exact_bundle_diagnostics, file_declarations, write_bundle
 
 
 _PUBLICATION_SCHEMA = "contracts/publication/v2/governance-spec.schema.json"
@@ -23,6 +21,9 @@ _HARVEST_REGISTRY = "publication/harvest-sources.json"
 _DOCUMENTATION_POLICY = "mrd/documentation/01-reference-standard.mrd.json"
 _DOCUMENTATION_REGISTRY = "mrd/documentation/02-reference-registry.mrd.json"
 _DOCUMENTATION_PUBLICATION = "publication/documentation-reference-standard.json"
+_PUBLICATION_ARCHITECTURE = "mrd/documentation/03-publication-architecture.mrd.json"
+_PUBLICATION_FAMILY_REGISTRY = "mrd/documentation/04-publication-family-registry.mrd.json"
+_PUBLICATION_FAMILY_SCHEMA = "contracts/publication/family/v1/registry.schema.json"
 _DOCUMENTATION_OUTPUT_CLASS = "human_readable_specification"
 _REFERENCE_OUTPUT_CLASS = "generated_reference"
 
@@ -50,37 +51,19 @@ def build_governance_spec(
         else None
     )
     files = _build_output_files(repository, config, documents, litho_evidence)
-
-    parent = output.parent
-    parent.mkdir(parents=True, exist_ok=True)
-    staging = Path(tempfile.mkdtemp(prefix=f".{output.name}.", suffix=".tmp", dir=parent))
-    try:
-        for relative, payload in files.items():
-            path = staging / Path(*relative.split("/"))
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_bytes(payload)
-        manifest = _build_manifest(
-            repository,
-            publication_path,
-            config,
-            documents,
-            files,
-            validation,
-            harvest_registry,
-            litho_evidence,
-        )
-        _validate_contract(repository.root, _MANIFEST_SCHEMA, manifest, "build manifest")
-        (staging / "manifest.json").write_bytes(_json_bytes(manifest))
-        if output.exists():
-            if not replace:
-                raise FileExistsError(f"output already exists: {output}")
-            shutil.rmtree(output)
-        os.replace(staging, output)
-        return manifest
-    except Exception:
-        if staging.exists():
-            shutil.rmtree(staging, ignore_errors=True)
-        raise
+    manifest = _build_manifest(
+        repository,
+        publication_path,
+        config,
+        documents,
+        files,
+        validation,
+        harvest_registry,
+        litho_evidence,
+    )
+    _validate_contract(repository.root, _MANIFEST_SCHEMA, manifest, "build manifest")
+    write_bundle(output, files, manifest, replace=replace)
+    return manifest
 
 
 def verify_governance_spec(
@@ -195,20 +178,20 @@ def verify_governance_spec(
     if manifest_files != expected_declarations:
         diagnostics.append(_verification_diag("GENERATED_DECLARATION_MISMATCH", "manifest generated-file declarations differ from deterministic current output"))
 
+    diagnostics.extend(
+        exact_bundle_diagnostics(
+            output,
+            expected_payloads,
+            manifest,
+            code_prefix=None,
+        )
+    )
     declared_files = {item["path"]: item for item in manifest_files}
-    expected_files = set(expected_payloads) | {"manifest.json"}
-    actual_files = {path.relative_to(output).as_posix() for path in output.rglob("*") if path.is_file()}
-    if actual_files != expected_files:
-        diagnostics.append(_verification_diag("GENERATED_FILE_SET_MISMATCH", "generated bundle file inventory differs from deterministic expected output"))
-
-    for relative, expected_payload in expected_payloads.items():
+    for relative in expected_payloads:
         path = output / Path(*relative.split("/"))
         if not path.is_file():
-            diagnostics.append(_verification_diag("GENERATED_FILE_MISSING", f"generated file missing: {relative}"))
             continue
         actual_payload = path.read_bytes()
-        if actual_payload != expected_payload:
-            diagnostics.append(_verification_diag("GENERATED_FILE_CONTENT_MISMATCH", f"generated file does not match deterministic current output: {relative}"))
         declaration = declared_files.get(relative)
         if declaration is not None and (
             hashlib.sha256(actual_payload).hexdigest() != declaration.get("sha256")
@@ -232,6 +215,19 @@ def _validate_contract(root: Path, schema_relative: str, instance: object, label
         error = errors[0]
         location = "/".join(str(part) for part in error.absolute_path) or "$"
         raise ValueError(f"{label} invalid at {location}: {error.message}")
+
+
+def validate_governance_publication(
+    repository: GovernanceRepository,
+    publication_path: Path,
+) -> dict[str, Any]:
+    try:
+        _load_publication_config(repository, publication_path)
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as error:
+        return _verification_result([
+            _verification_diag("PUBLICATION_CONFIG_INVALID", str(error))
+        ])
+    return _verification_result([])
 
 
 def _load_publication_config(repository: GovernanceRepository, publication_path: Path) -> dict[str, Any]:
@@ -279,9 +275,11 @@ def _validate_documentation_reference_binding(root: Path, config: dict[str, Any]
 def _generator_source_declarations(repository: GovernanceRepository) -> list[dict[str, Any]]:
     declarations = []
     for relative in (
+        "src/kis_mcp_doc/canonical.py",
         "src/kis_mcp_doc/governance.py",
         "src/kis_mcp_doc/harvest.py",
         "src/kis_mcp_doc/litho.py",
+        "src/kis_mcp_doc/publication_kernel.py",
         "src/kis_mcp_doc/render.py",
         _PUBLICATION_SCHEMA,
         _MANIFEST_SCHEMA,
@@ -307,10 +305,7 @@ def _mrd_input_declarations(repository: GovernanceRepository, documents: dict[st
 
 
 def _file_declarations(files: dict[str, bytes]) -> list[dict[str, Any]]:
-    return [
-        {"path": path, "sha256": hashlib.sha256(payload).hexdigest(), "bytes": len(payload)}
-        for path, payload in sorted(files.items())
-    ]
+    return file_declarations(files)
 
 
 def _build_output_files(
@@ -396,7 +391,14 @@ def _source_file_declarations(
             for dependency in document["_mrd"]["dependencies"]
             if "source" in dependency and dependency["source"].startswith("repo:")
         }
-        | {_DOCUMENTATION_POLICY, _DOCUMENTATION_REGISTRY, _DOCUMENTATION_PUBLICATION}
+        | {
+            _DOCUMENTATION_POLICY,
+            _DOCUMENTATION_REGISTRY,
+            _DOCUMENTATION_PUBLICATION,
+            _PUBLICATION_ARCHITECTURE,
+            _PUBLICATION_FAMILY_REGISTRY,
+            _PUBLICATION_FAMILY_SCHEMA,
+        }
     )
     declarations = []
     for relative in paths:

--- a/src/kis_mcp_doc/work_management.py
+++ b/src/kis_mcp_doc/work_management.py
@@ -10,12 +10,16 @@ from typing import Any
 from jsonschema import Draft202012Validator
 
 from .governance import canonical_hash, canonical_source_bytes
+from .publication_kernel import bundle_diagnostics, file_declarations, write_bundle
 
 
 _WORK_PUBLICATION = "publication/work-management-spec.json"
 _DOCUMENTATION_POLICY = "mrd/documentation/01-reference-standard.mrd.json"
 _DOCUMENTATION_REGISTRY = "mrd/documentation/02-reference-registry.mrd.json"
 _DOCUMENTATION_PUBLICATION = "publication/documentation-reference-standard.json"
+_PUBLICATION_ARCHITECTURE = "mrd/documentation/03-publication-architecture.mrd.json"
+_PUBLICATION_FAMILY_REGISTRY = "mrd/documentation/04-publication-family-registry.mrd.json"
+_PUBLICATION_FAMILY_SCHEMA = "contracts/publication/family/v1/registry.schema.json"
 _WORK_EVIDENCE = "evidence/work-management/canonical-snapshot.json"
 _DOCUMENTATION_OUTPUT_CLASS = "human_readable_specification"
 _REFERENCE_OUTPUT_CLASS = "generated_reference"
@@ -725,6 +729,17 @@ def _load_work_publication(repo: WorkManagementRepository) -> dict[str, Any]:
     return config
 
 
+def validate_work_management_publication(repo: WorkManagementRepository) -> dict[str, Any]:
+    try:
+        _load_work_publication(repo)
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as error:
+        return {
+            "status": "invalid",
+            "diagnostics": [{"code": "WORK_PUBLICATION_CONFIG_INVALID", "message": str(error)}],
+        }
+    return {"status": "valid", "diagnostics": []}
+
+
 def _validate_documentation_reference_binding(root: Path, config: dict[str, Any]) -> None:
     binding = config.get("documentation_reference")
     expected = {
@@ -751,9 +766,29 @@ def _validate_documentation_reference_binding(root: Path, config: dict[str, Any]
 
 def _work_source_file_declarations(repo: WorkManagementRepository) -> list[dict[str, Any]]:
     declarations = []
-    for relative in (_DOCUMENTATION_POLICY, _DOCUMENTATION_REGISTRY, _DOCUMENTATION_PUBLICATION, _WORK_EVIDENCE):
+    for relative in (
+        _DOCUMENTATION_POLICY,
+        _DOCUMENTATION_REGISTRY,
+        _DOCUMENTATION_PUBLICATION,
+        _PUBLICATION_ARCHITECTURE,
+        _PUBLICATION_FAMILY_REGISTRY,
+        _PUBLICATION_FAMILY_SCHEMA,
+        _WORK_EVIDENCE,
+    ):
         payload = canonical_source_bytes(repo.root / relative)
         declarations.append({"path": relative, "sha256": hashlib.sha256(payload).hexdigest(), "bytes": len(payload)})
+    return declarations
+
+
+def _work_generator_declarations(repo: WorkManagementRepository) -> list[dict[str, Any]]:
+    declarations = []
+    for relative in (
+        "src/kis_mcp_doc/canonical.py",
+        "src/kis_mcp_doc/publication_kernel.py",
+        "src/kis_mcp_doc/work_management.py",
+    ):
+        payload = canonical_source_bytes(repo.root / relative)
+        declarations.append({"path": relative, "sha256": hashlib.sha256(payload).hexdigest()})
     return declarations
 
 
@@ -777,6 +812,7 @@ def build_work_management_spec(repo: WorkManagementRepository, output: Path, *, 
     config = _load_work_publication(repo)
     docs=list(repo.load().values())
     output=Path(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
     staging=Path(tempfile.mkdtemp(prefix=f".{output.name}.",suffix=".tmp",dir=output.parent))
     try:
         pages=[(_page_name(i,doc),doc) for i,doc in enumerate(docs,2)]
@@ -859,18 +895,21 @@ def build_work_management_spec(repo: WorkManagementRepository, output: Path, *, 
             "",
         ]
         spec="\n".join(root); (staging/'001-specification.md').write_bytes(spec.encode("utf-8")); (staging/'specification.md').write_bytes(spec.encode("utf-8"))
-        files=[]
-        for path in sorted(staging.rglob('*')):
-            if path.is_file():
-                b=path.read_bytes(); files.append({'path':path.relative_to(staging).as_posix(),'sha256':hashlib.sha256(b).hexdigest(),'bytes':len(b)})
+        bundle_files={
+            path.relative_to(staging).as_posix(): path.read_bytes()
+            for path in sorted(staging.rglob('*'))
+            if path.is_file()
+        }
+        files=file_declarations(bundle_files)
         mrds=[]
         for path in sorted(repo.mrd_root.glob('*.mrd.json')):
             b=canonical_source_bytes(path); d=json.loads(path.read_text(encoding='utf-8')); mrds.append({'id':d['_mrd']['id'],'path':path.relative_to(repo.root).as_posix(),'sha256':hashlib.sha256(b).hexdigest(),'version':d['_mrd']['version']})
         publication_path = repo.root / _WORK_PUBLICATION
         publication_bytes = canonical_source_bytes(publication_path)
         manifest={
-            'contract':{'name':'kis-work-management-spec-build','version':1},
+            'contract':{'name':'kis-work-management-spec-build','version':2},
             'specification':{'title':config['title'],'version':config['version'],'status':config['status'],'layout_profile':'mcp-spec'},
+            'generator':{'name':'kis-mcp-doc','version':'0.1.0','sources':_work_generator_declarations(repo)},
             'inputs':{
                 'mrds':mrds,
                 'source_set_sha256':canonical_hash(mrds),
@@ -881,13 +920,15 @@ def build_work_management_spec(repo: WorkManagementRepository, output: Path, *, 
             'files':files,
             'bundle_sha256':canonical_hash(files),
         }
-        (staging/'manifest.json').write_bytes((json.dumps(manifest,indent=2,sort_keys=True)+'\n').encode("utf-8"))
-        if output.exists():
-            if not replace: raise FileExistsError(output)
-            shutil.rmtree(output)
-        output.parent.mkdir(parents=True,exist_ok=True); staging.replace(output); return manifest
+        shutil.rmtree(staging,ignore_errors=True)
+        write_bundle(output,bundle_files,manifest,replace=replace)
+        return manifest
     except Exception:
         shutil.rmtree(staging,ignore_errors=True); raise
+
+
+def _normalize_generated_line_endings(_relative: str, payload: bytes) -> bytes:
+    return payload.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
 
 
 def verify_work_management_spec(repo: WorkManagementRepository, output: Path) -> dict[str, Any]:
@@ -897,9 +938,20 @@ def verify_work_management_spec(repo: WorkManagementRepository, output: Path) ->
     if temp.exists(): shutil.rmtree(temp)
     try:
         build_work_management_spec(repo,temp)
-        expected={p.relative_to(temp).as_posix():canonical_source_bytes(p) for p in temp.rglob('*') if p.is_file()}
-        actual={p.relative_to(output).as_posix():canonical_source_bytes(p) for p in output.rglob('*') if p.is_file()}
-        if expected!=actual: return {'status':'invalid','diagnostics':[{'code':'WORK_GENERATED_DRIFT','message':'generated Work Management specification differs from deterministic current output'}]}
+        expected_manifest=json.loads((temp/'manifest.json').read_text(encoding='utf-8'))
+        expected_files={
+            p.relative_to(temp).as_posix(): p.read_bytes()
+            for p in temp.rglob('*')
+            if p.is_file() and p.name != 'manifest.json'
+        }
+        drift=bundle_diagnostics(
+            output,
+            expected_files,
+            expected_manifest,
+            code_prefix='WORK',
+            normalizer=_normalize_generated_line_endings,
+        )
+        if drift: return {'status':'invalid','diagnostics':[{'code':'WORK_GENERATED_DRIFT','message':'generated Work Management specification differs from deterministic current output'}]}
         return {'status':'valid','diagnostics':[]}
     finally:
         shutil.rmtree(temp,ignore_errors=True)

--- a/tests/test_governance_renderer.py
+++ b/tests/test_governance_renderer.py
@@ -230,8 +230,11 @@ def test_manifest_binds_canonical_repo_dependencies(tmp_path: Path) -> None:
         "contracts/mrd/v1/mrd.schema.json",
         "contracts/governance/v1/content.schema.json",
         "contracts/governance/v1/governance-mrd.schema.json",
+        "contracts/publication/family/v1/registry.schema.json",
         "mrd/documentation/01-reference-standard.mrd.json",
         "mrd/documentation/02-reference-registry.mrd.json",
+        "mrd/documentation/03-publication-architecture.mrd.json",
+        "mrd/documentation/04-publication-family-registry.mrd.json",
         "publication/documentation-reference-standard.json",
     }
 

--- a/tests/test_publication_kernel.py
+++ b/tests/test_publication_kernel.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import kis_mcp_doc.publication_adapters as publication_adapters
+import kis_mcp_doc.publication_kernel as publication_kernel
+from kis_mcp_doc.cli import main
+from kis_mcp_doc.publication_kernel import (
+    PublicationFamilyRegistry,
+    build_registered_publication,
+    bundle_manifest_fields,
+    exact_bundle_diagnostics,
+    file_declarations,
+    validate_registered_publications,
+    verify_registered_publications,
+    write_bundle,
+)
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_registry_discovers_all_governed_publication_families_and_output_classes() -> None:
+    registry = PublicationFamilyRegistry(ROOT)
+    assert registry.validate() == {"status": "valid", "diagnostics": []}
+    families = registry.load()["content"]["families"]
+    assert [family["id"] for family in families] == [
+        "governance-spec", "work-management-spec", "documentation-reference-standard"
+    ]
+    assert families[0]["output_classes"] == ["human_readable_specification", "generated_reference"]
+    assert families[1]["output_classes"] == ["human_readable_specification", "generated_reference"]
+    assert registry.load()["content"]["adapter_protocol_version"] == 1
+
+
+def test_registry_rejects_adapter_protocol_version_drift(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    import shutil
+    shutil.copytree(ROOT, root, ignore=shutil.ignore_patterns('.git', '.venv', '.work'))
+    path = root / "mrd/documentation/04-publication-family-registry.mrd.json"
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    doc["content"]["adapter_protocol_version"] = 2
+    path.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+    codes = {item["code"] for item in PublicationFamilyRegistry(root).validate()["diagnostics"]}
+    assert "PUBLICATION_ADAPTER_PROTOCOL_VERSION_INVALID" in codes
+    assert "PUBLICATION_FAMILY_REGISTRY_SCHEMA_INVALID" in codes
+
+
+def test_registry_rejects_duplicate_output_and_unsupported_output_class(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    import shutil
+    shutil.copytree(ROOT, root, ignore=shutil.ignore_patterns('.git', '.venv', '.work'))
+    path = root / "mrd/documentation/04-publication-family-registry.mrd.json"
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    doc["content"]["families"][0]["output_classes"] = ["generated_reference"]
+    doc["content"]["families"][1]["id"] = doc["content"]["families"][0]["id"]
+    doc["content"]["families"][1]["output"] = doc["content"]["families"][0]["output"]
+    doc["content"]["families"][2]["output_classes"] = ["not-governed"]
+    path.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+    result = PublicationFamilyRegistry(root).validate()
+    codes = {item["code"] for item in result["diagnostics"]}
+    assert "PUBLICATION_FAMILY_ID_DUPLICATE" in codes
+    assert "PUBLICATION_FAMILY_OUTPUT_DUPLICATE" in codes
+    assert "PUBLICATION_FAMILY_REGISTRY_SCHEMA_INVALID" in codes
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "code"),
+    [
+        ("mrd_root", "mrd/../../outside", "PUBLICATION_FAMILY_MRD_ROOT_INVALID"),
+        ("publication_config", "publication/../outside.json", "PUBLICATION_FAMILY_CONFIG_INVALID"),
+        ("output", "generated/../outside", "PUBLICATION_FAMILY_OUTPUT_INVALID"),
+    ],
+)
+def test_registry_rejects_traversal_in_registered_paths(
+    tmp_path: Path, field: str, value: str, code: str
+) -> None:
+    root = tmp_path / "repo"
+    import shutil
+    shutil.copytree(ROOT, root, ignore=shutil.ignore_patterns('.git', '.venv', '.work'))
+    path = root / "mrd/documentation/04-publication-family-registry.mrd.json"
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    doc["content"]["families"][0][field] = value
+    path.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+    codes = {item["code"] for item in PublicationFamilyRegistry(root).validate()["diagnostics"]}
+    assert code in codes
+    assert "PUBLICATION_FAMILY_REGISTRY_SCHEMA_INVALID" in codes
+
+
+def test_family_adapter_rejects_registered_output_class_drift(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    import shutil
+    shutil.copytree(ROOT, root, ignore=shutil.ignore_patterns('.git', '.venv', '.work'))
+    path = root / "mrd/documentation/04-publication-family-registry.mrd.json"
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    doc["content"]["families"][0]["output_classes"] = ["generated_reference"]
+    path.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+    result = validate_registered_publications(root, family_ids=["governance-spec"])
+    assert result["status"] == "invalid"
+    assert any(
+        item["code"] == "PUBLICATION_FAMILY_OUTPUT_CLASS_MISMATCH"
+        for item in result["families"]["governance-spec"]["diagnostics"]
+    )
+
+
+def test_registered_validation_rejects_invalid_publication_config(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    import shutil
+    shutil.copytree(ROOT, root, ignore=shutil.ignore_patterns('.git', '.venv', '.work'))
+    publication = root / "publication/governance-spec.json"
+    config = json.loads(publication.read_text(encoding="utf-8"))
+    config["status"] = "invalid-status"
+    publication.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    result = validate_registered_publications(root, family_ids=["governance-spec"])
+    assert result["status"] == "invalid"
+    assert any(
+        item["code"] == "PUBLICATION_CONFIG_INVALID"
+        for item in result["families"]["governance-spec"]["diagnostics"]
+    )
+
+
+def test_registry_rejects_adapter_signature_drift(monkeypatch) -> None:
+    monkeypatch.setattr(publication_kernel, "_resolve_entrypoint", lambda _value: (lambda only_one: None))
+    codes = {item["code"] for item in PublicationFamilyRegistry(ROOT).validate()["diagnostics"]}
+    assert "PUBLICATION_FAMILY_ADAPTER_SIGNATURE_INVALID" in codes
+
+
+def test_file_declarations_and_bundle_hash_are_deterministic() -> None:
+    files = {"b.txt": b"two", "a.txt": b"one"}
+    first = file_declarations(files)
+    second = file_declarations(dict(reversed(list(files.items()))))
+    assert first == second
+    assert [item["path"] for item in first] == ["a.txt", "b.txt"]
+    assert bundle_manifest_fields(files) == bundle_manifest_fields(dict(reversed(list(files.items()))))
+
+
+@pytest.mark.parametrize("relative", ["../outside.txt", "a\\b.txt", "a//b.txt"])
+def test_bundle_paths_must_be_normalized_and_relative(relative: str) -> None:
+    with pytest.raises(ValueError, match="normalized relative path"):
+        file_declarations({relative: b"payload"})
+
+
+def test_write_bundle_stages_complete_bundle_and_exact_verification_detects_tamper(tmp_path: Path) -> None:
+    output = tmp_path / "bundle"
+    manifest = {"files": file_declarations({"a.txt": b"one"}), **bundle_manifest_fields({"a.txt": b"one"})}
+    write_bundle(output, {"a.txt": b"one"}, manifest)
+    assert exact_bundle_diagnostics(output, {"a.txt": b"one"}, manifest) == []
+    (output / "a.txt").write_bytes(b"tampered")
+    codes = {item["code"] for item in exact_bundle_diagnostics(output, {"a.txt": b"one"}, manifest)}
+    assert "PUBLICATION_GENERATED_FILE_CONTENT_MISMATCH" in codes
+
+
+def test_write_bundle_refuses_existing_output_without_replace(tmp_path: Path) -> None:
+    output = tmp_path / "bundle"
+    write_bundle(output, {"a.txt": b"one"}, {"files": file_declarations({"a.txt": b"one"})})
+    with pytest.raises(FileExistsError):
+        write_bundle(output, {"a.txt": b"two"}, {"files": file_declarations({"a.txt": b"two"})})
+    assert (output / "a.txt").read_bytes() == b"one"
+
+
+def test_write_bundle_restores_previous_complete_bundle_when_replacement_fails(tmp_path: Path, monkeypatch) -> None:
+    output = tmp_path / "bundle"
+    write_bundle(output, {"a.txt": b"one"}, {"files": file_declarations({"a.txt": b"one"})})
+    real_replace = publication_kernel.os.replace
+    calls = 0
+
+    def fail_new_bundle_once(source, target):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("simulated replacement failure")
+        return real_replace(source, target)
+
+    monkeypatch.setattr(publication_kernel.os, "replace", fail_new_bundle_once)
+    with pytest.raises(OSError, match="simulated replacement failure"):
+        write_bundle(
+            output,
+            {"a.txt": b"two"},
+            {"files": file_declarations({"a.txt": b"two"})},
+            replace=True,
+        )
+    assert (output / "a.txt").read_bytes() == b"one"
+
+
+def test_registered_publication_verification_covers_every_family() -> None:
+    result = verify_registered_publications(ROOT)
+    assert result["status"] == "valid"
+    assert set(result["families"]) == {
+        "governance-spec", "work-management-spec", "documentation-reference-standard"
+    }
+    assert all(item["status"] == "valid" for item in result["families"].values())
+
+
+def test_registered_phase_rejects_invalid_adapter_result(monkeypatch) -> None:
+    def invalid_result(_root, _family):
+        return {"unexpected": True}
+
+    monkeypatch.setattr(publication_adapters, "validate_governance", invalid_result)
+    result = validate_registered_publications(ROOT, family_ids=["governance-spec"])
+    assert result["status"] == "invalid"
+    assert result["families"]["governance-spec"]["diagnostics"] == [{
+        "code": "PUBLICATION_FAMILY_ADAPTER_RESULT_INVALID",
+        "message": "governance-spec.validate must return status and diagnostics",
+    }]
+
+
+def test_registered_build_unknown_family_is_structured() -> None:
+    result = build_registered_publication(ROOT, "unknown-family")
+    assert result["status"] == "invalid"
+    assert result["diagnostics"] == [{
+        "code": "PUBLICATION_FAMILY_UNKNOWN",
+        "message": "unknown publication family: unknown-family",
+    }]
+
+
+def test_registry_cli_validate_and_check_agree_with_registered_families() -> None:
+    assert main(["--root", str(ROOT), "publications-validate"]) == 0
+    assert main(["--root", str(ROOT), "publications-check-generated"]) == 0
+    for validate_command, verify_command in (
+        ("validate", "check-generated"),
+        ("work-validate", "work-check-generated"),
+        ("references-validate", "references-check-generated"),
+    ):
+        assert main(["--root", str(ROOT), validate_command]) == 0
+        assert main(["--root", str(ROOT), verify_command]) == 0
+
+
+def test_registry_cli_build_dispatches_through_family_adapter(tmp_path: Path, capsys) -> None:
+    root = tmp_path / "repo"
+    import shutil
+    shutil.copytree(ROOT, root, ignore=shutil.ignore_patterns('.git', '.venv', '.work'))
+    output = root / "generated/documentation-reference-standard"
+    shutil.rmtree(output)
+    assert main([
+        "--root", str(root), "publications-build",
+        "--family", "documentation-reference-standard",
+    ]) == 0
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "valid"
+    assert result["family"] == "documentation-reference-standard"
+    assert result["diagnostics"] == []
+    assert "manifest" in result
+    assert (output / "manifest.json").is_file()
+    assert (output / "001-specification.md").is_file()
+
+
+def test_registry_cli_build_unknown_family_is_structured(capsys) -> None:
+    assert main([
+        "--root", str(ROOT), "publications-build", "--family", "unknown-family"
+    ]) == 1
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "invalid"
+    assert result["diagnostics"] == [{
+        "code": "PUBLICATION_FAMILY_UNKNOWN",
+        "message": "unknown publication family: unknown-family",
+    }]
+
+
+def test_registry_cli_build_existing_output_is_structured(tmp_path: Path, capsys) -> None:
+    root = tmp_path / "repo"
+    import shutil
+    shutil.copytree(ROOT, root, ignore=shutil.ignore_patterns('.git', '.venv', '.work'))
+    before = (root / "generated/documentation-reference-standard/manifest.json").read_bytes()
+    assert main([
+        "--root", str(root), "publications-build", "--family", "documentation-reference-standard"
+    ]) == 1
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "invalid"
+    assert result["diagnostics"][0]["code"] == "PUBLICATION_FAMILY_ADAPTER_FAILED"
+    assert (root / "generated/documentation-reference-standard/manifest.json").read_bytes() == before
+
+
+def test_legacy_build_commands_remain_available(tmp_path: Path) -> None:
+    assert main(["--root", str(ROOT), "build", "--output", str(tmp_path / "governance")]) == 0
+    assert main(["--root", str(ROOT), "work-build", "--output", str(tmp_path / "work")]) == 0
+    assert main(["--root", str(ROOT), "references-build", "--output", str(tmp_path / "references")]) == 0
+    assert (tmp_path / "governance/manifest.json").is_file()
+    assert (tmp_path / "work/manifest.json").is_file()
+    assert (tmp_path / "references/manifest.json").is_file()
+
+
+def test_registry_rejects_unknown_selected_family() -> None:
+    result = verify_registered_publications(ROOT, family_ids=["unknown-family"])
+    assert result["status"] == "invalid"
+    assert result["diagnostics"] == [
+        {"code": "PUBLICATION_FAMILY_UNKNOWN", "message": "unknown publication family: unknown-family"}
+    ]

--- a/tests/test_work_management_spec.py
+++ b/tests/test_work_management_spec.py
@@ -10,7 +10,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def copied_work_repository(tmp_path):
     root = tmp_path / "repo"
-    for name in ("contracts", "mrd", "publication", "evidence"):
+    for name in ("contracts", "mrd", "publication", "evidence", "src"):
         shutil.copytree(ROOT / name, root / name)
     return root, WorkManagementRepository(root)
 
@@ -29,6 +29,17 @@ def test_work_management_spec_is_deterministic(tmp_path):
     assert a==b
 
 
+def test_work_management_manifest_v2_declares_generator_provenance(tmp_path):
+    manifest=build_work_management_spec(WorkManagementRepository(ROOT),tmp_path/"build")
+    assert manifest["contract"] == {"name":"kis-work-management-spec-build","version":2}
+    assert manifest["generator"]["name"] == "kis-mcp-doc"
+    assert {item["path"] for item in manifest["generator"]["sources"]} == {
+        "src/kis_mcp_doc/canonical.py",
+        "src/kis_mcp_doc/publication_kernel.py",
+        "src/kis_mcp_doc/work_management.py",
+    }
+
+
 def test_work_management_publication_consumes_documentation_reference_profile(tmp_path):
     repo=WorkManagementRepository(ROOT); out=tmp_path/"build"
     manifest=build_work_management_spec(repo,out)
@@ -40,8 +51,11 @@ def test_work_management_publication_consumes_documentation_reference_profile(tm
     }
     source_paths={item["path"] for item in manifest["inputs"]["source_files"]}
     assert source_paths == {
+        "contracts/publication/family/v1/registry.schema.json",
         "mrd/documentation/01-reference-standard.mrd.json",
         "mrd/documentation/02-reference-registry.mrd.json",
+        "mrd/documentation/03-publication-architecture.mrd.json",
+        "mrd/documentation/04-publication-family-registry.mrd.json",
         "publication/documentation-reference-standard.json",
         "evidence/work-management/canonical-snapshot.json",
     }


### PR DESCRIPTION
Implements issue #18.

Creates the governed shared publication kernel and publication-family registry for Governance, Work Management, and Documentation Reference publication families.

Key points:
- shared deterministic bundle mechanics and rollback-safe replacement
- canonical family registry with multi-output-class support
- family-specific adapters retain semantic ownership
- registry-driven validate/build/check commands while legacy commands remain available
- normalized registered paths and adapter protocol v1
- Work Management manifest contract v2 for generator provenance
- no Governance or Work Management semantic MRD changes
- no reader-facing generated-document changes from Change 010; only manifests change

Verification:
- focused publication/HRD suites pass
- full pytest passes
- canonical scripts/verify.ps1 passes
- exact-commit verification passes for 0d0b220afb8a7749c6ecf66c05db952a5d7290e0
- final architecture review has no findings
- earlier API-contract findings were corrected and covered by focused tests