### PR TITLE
012 — Deterministic Diagrams and Semantic Coverage

### DIFF
--- a/.work/changes/012-deterministic-diagrams-and-semantic-coverage/change.mrd.json
+++ b/.work/changes/012-deterministic-diagrams-and-semantic-coverage/change.mrd.json
@@ -1,0 +1,174 @@
+{
+  "_mrd": {
+    "schema_version": 1,
+    "id": "KIS-CHG012-WRK-WFL-001",
+    "title": "Deterministic Diagrams and Semantic Coverage",
+    "module": "change-012",
+    "class": "WRK",
+    "type": "WFL",
+    "layer": "L3",
+    "record_mode": "descriptive",
+    "status": "active",
+    "version": "1.0.0",
+    "dependencies": [
+      {"mrd_id": "KIS-DOC-CON-POL-001", "relationship": "depends_on"},
+      {"mrd_id": "KIS-DOC-CON-POL-002", "relationship": "depends_on"},
+      {"mrd_id": "KIS-DOC-SEM-REG-002", "relationship": "depends_on"}
+    ],
+    "provenance": {
+      "sources": [
+        {
+          "source_id": "KIS-OPERATOR-DIRECTION-2026-08-26-DIAGRAMS-COVERAGE",
+          "kind": "operator_direction",
+          "role": "approved_change_basis",
+          "locator": "conversation:2026-08-26",
+          "revision": "implementation-approved",
+          "sha256": null
+        },
+        {
+          "source_id": "GH-ISSUE-20",
+          "kind": "operator_approved_work_item",
+          "role": "approved_change_basis",
+          "locator": "github:NielPieterse0/kis-mcp-doc#20",
+          "revision": "2026-08-26",
+          "sha256": null
+        },
+        {
+          "source_id": "KIS-CHG010-WRK-WFL-001",
+          "kind": "canonical_machine_readable_record",
+          "role": "reader_experience_basis",
+          "locator": ".work/changes/010-hrd-reader-experience-and-reference-separation/change.mrd.json",
+          "revision": "1.1.0",
+          "sha256": null
+        },
+        {
+          "source_id": "KIS-CHG011-WRK-WFL-001",
+          "kind": "canonical_machine_readable_record",
+          "role": "publication_architecture_basis",
+          "locator": ".work/changes/011-publication-kernel-and-family-registry/change.mrd.json",
+          "revision": "1.0.0",
+          "sha256": null
+        }
+      ],
+      "source_fingerprint": "sha256:84dc9badf40f8caa79e54bb2c0ccbfc4e00ed40b21e1a19f5bd0a9ab8f91c35f",
+      "fact_quality": "direct"
+    },
+    "supersedes": [],
+    "superseded_by": null
+  },
+  "content": {
+    "change_id": "012-deterministic-diagrams-and-semantic-coverage",
+    "work_item": {
+      "repository": "NielPieterse0/kis-mcp-doc",
+      "issue": 20,
+      "project": "NielPieterse0/1",
+      "record_id": "SPEC-012"
+    },
+    "outcome": "Add a small set of source-derived explanatory diagrams and deterministic semantic-coverage maps to the Governance and Work Management publication families so readers can understand key flows and tooling can prove that governed rules and lookup facts remain published.",
+    "classification": {
+      "complexity": "medium",
+      "risk_triggers": ["architecture_boundary"],
+      "reason": "The change extends two publication-family output structures and traceability behavior but does not alter canonical domain semantics or public command/schema contracts."
+    },
+    "authority_model": [
+      "Governance MRDs remain the sole owners of Governance facts, requirements, lifecycle states, and relationships.",
+      "Work Management MRDs remain the sole owners of Work states, delivery stages, fields, selection rules, Project configuration, and provider-boundary semantics.",
+      "KIS-DOC-CON-POL-001 continues to define documentation output classes and generated-output authority boundaries.",
+      "KIS-DOC-CON-POL-002 and KIS-DOC-SEM-REG-002 continue to govern publication mechanics and family discovery.",
+      "A diagram is a supplemental deterministic projection of canonical facts and has no write-back authority.",
+      "Semantic coverage is generated-reference traceability data and cannot become a second owner of any rule or fact."
+    ],
+    "design_decisions": [
+      "D1: Add diagrams only where the canonical model contains enough explicit structure to derive every node and edge without inference.",
+      "D2: Governance gains an authority/ownership flow and MRD lifecycle diagram; Work Management gains a Work Status versus Delivery Stage diagram and a provider field-authority/handoff diagram.",
+      "D3: Use Mermaid source embedded in generated Markdown so the diagram text remains deterministic, diffable, accessible beside explanatory prose, and covered by existing bundle hashing.",
+      "D4: Do not create an independent diagram registry or hand-maintained diagram source. Diagram content is generated directly from the owning MRD content during publication.",
+      "D5: Add data/semantic-coverage.json to Governance and Work Management bundles as generated_reference traceability data.",
+      "D6: Governance coverage maps every stable rule ID plus the exact applicability, relationship, and validation-reference facts introduced by Change 010 to a generated page and anchor.",
+      "D7: Work Management coverage maps every source MRD plus managed fields, vocabulary values, Work states, Delivery Stages, selection rules, Project fields, and Project views to generated pages and anchors.",
+      "D8: Coverage generation must fail closed on duplicate identifiers, missing pages, or unresolved anchors before a bundle can be written.",
+      "D9: Existing human-readable content and exact lookup tables remain the primary accessible representation; diagrams supplement rather than replace them.",
+      "D10: The change does not introduce a new schema contract for semantic coverage; the generated structure remains family-owned until reuse needs justify a separately governed contract."
+    ],
+    "requirements": [
+      "R1: Every diagram node, label, edge, count, and grouping MUST derive from canonical Governance or Work Management MRD data used by the owning publication family.",
+      "R2: Diagram generation MUST NOT infer or invent a relationship that is absent from canonical source data.",
+      "R3: Diagrams MUST remain supplemental generated projections and MUST NOT replace normative prose, exact tables, or source/authority statements.",
+      "R4: Governance authority-flow content MUST derive from the canonical ownership contract and MUST preserve its one-current-owner, non-owner, derived, and conflict postures.",
+      "R5: Governance lifecycle diagram transitions MUST exactly equal the transitions declared for each canonical record mode.",
+      "R6: Work Status and Delivery Stage MUST be presented as separate dimensions; the diagram MUST NOT imply a state-to-stage mapping that the canonical model does not define.",
+      "R7: Work authority/handoff diagram groups MUST derive from the canonical provider-boundary field_authority contract and MUST preserve authority and direction values.",
+      "R8: Each semantic-coverage entry MUST identify a stable kind, stable fact/rule identifier, canonical source MRD, generated page, and stable anchor.",
+      "R9: Coverage generation MUST reject duplicate kind/identifier pairs, unknown target pages, and anchors that are absent from the generated target page.",
+      "R10: Generated semantic coverage MUST be deterministic, manifest-bound, stale-detectable, and tamper-detectable through the existing publication kernel and family verification paths.",
+      "R11: Governance and Work Management canonical MRDs MUST remain unchanged.",
+      "R12: Existing specification/reference navigation, normative statements, and exact lookup availability MUST remain intact.",
+      "R13: Existing family-specific and registry-driven publication validation/build/check paths MUST continue to pass without weakened assertions.",
+      "R14: All implementation and verification activity MUST remain within C:/Projects."
+    ],
+    "implementation_plan": [
+      "P1: Add stable hidden anchors to existing specification/reference projections without changing canonical fact ownership.",
+      "P2: Generate Governance rule/reference coverage and Work Management MRD/fact coverage as deterministic JSON bundle files.",
+      "P3: Validate coverage resolution before bundle write and rely on existing manifest/bundle verification for stale and tamper detection.",
+      "P4: Add the four approved Mermaid diagrams directly in the relevant canonical projection pages.",
+      "P5: Link semantic coverage from documentation indexes/specification traceability sections where useful without turning it into primary reader content.",
+      "P6: Add positive derivation/coverage tests and negative tests for duplicate or unresolved coverage entries.",
+      "P7: Regenerate both publication families, inspect reader-facing diffs, run full/canonical/exact verification, and complete architecture/documentation review before publication."
+    ],
+    "verification_criteria": [
+      "V1: Focused tests prove each diagram is generated from the exact owning canonical data and contains no extra modeled relationship.",
+      "V2: Governance semantic coverage contains every canonical rule ID and every exact applicability, relationship, and validation-reference fact intentionally published by the family.",
+      "V3: Work Management semantic coverage contains every source MRD plus all managed fields, vocabulary values, Work states, Delivery Stages, selection rules, Project fields, and Project views intentionally published by the family.",
+      "V4: Every coverage page and anchor resolves in the generated bundle and a negative fixture proves broken coverage is rejected.",
+      "V5: Repeated generation from identical inputs is byte-stable for diagrams, coverage data, Markdown, and manifests.",
+      "V6: Tampering with diagram-bearing pages or semantic-coverage data causes existing family verification to fail.",
+      "V7: Direct diffs under mrd/governance/**, mrd/work-management/**, and mrd/documentation/** are empty.",
+      "V8: Existing Governance and Work Management semantic/readability tests remain green without weakening assertions.",
+      "V9: Full repository pytest and scripts/verify.ps1 pass on the final implementation tree and exact commit.",
+      "V10: Architecture/documentation review finds no invented semantics, authority inversion, inaccessible replacement of exact text, or unnecessary visual complexity."
+    ],
+    "tasks": [
+      {"id": "T0", "status": "done", "text": "Create GitHub issue 20 and isolated Change 012 worktree from merged main 2568b62e20560690ed91a44e48f1682543c38884."},
+      {"id": "T1", "status": "done", "text": "Create the governed Change 012 scope and implementation MRD."},
+      {"id": "T2", "status": "done", "text": "Implement source-derived Governance and Work Management diagrams plus semantic-coverage generation and validation."},
+      {"id": "T3", "status": "done", "text": "Add complete positive/negative diagram and semantic-coverage tests and traceability navigation."},
+      {"id": "T4", "status": "done", "text": "Regenerate both publication families and review reader-facing changes against canonical source data."},
+      {"id": "T5", "status": "in_progress", "text": "Run focused/full/canonical/exact verification and required specialist reviews."},
+      {"id": "T6", "status": "planned", "text": "Publish, verify exact-head GitHub Actions, merge, reconcile main, close issue 20, and clean the 012 worktree."}
+    ],
+    "risks": [
+      "Visual inference: a diagram can imply a relationship that the source model never declared.",
+      "Coverage theatre: a coverage file can look complete while omitting classes of facts unless the covered fact classes are explicitly tested.",
+      "Anchor churn: unstable anchors can break external links even when the prose remains correct.",
+      "Accessibility regression: diagrams can become a poor substitute for exact textual representation if tables or prose are removed.",
+      "Publication churn: adding hidden anchors broadly changes generated Markdown and manifests, so deterministic regeneration and focused human review are required."
+    ],
+    "explicit_exclusions": [
+      "Any change to Governance, Work Management, or Documentation canonical MRDs or semantics.",
+      "Any new documentation output class, publication-family contract, or semantic-coverage schema contract.",
+      "Any inferred diagram edge, hand-authored diagram authority, or generated write-back path.",
+      "Any task-oriented human documentation, site/portal redesign, parent KIS change, or external reference refresh.",
+      "Any edit, reset, cleanup, or deletion of the preserved change/009-publication-kernel worktree.",
+      "Any filesystem or execution work outside C:/Projects."
+    ],
+    "closeout": {
+      "state": "implementation_verified_awaiting_exact_commit_review_and_publication",
+      "verification": [
+        "Governance and Work Management focused suites passed with positive and negative semantic-coverage tests.",
+        "Full repository pytest passed: 117 tests.",
+        "scripts/verify.ps1 passed with locked offline dependencies, all semantic validators, all legacy generated-output checks, and all registry-driven publication checks.",
+        "Direct diffs under mrd/governance/**, mrd/work-management/**, mrd/documentation/**, contracts/**, and publication/** are empty.",
+        "Tracked Governance and Work bundles were byte-matched to fresh deterministic builds after a Windows directory-handle lock prevented atomic directory rename; no tracked directory deletion or process termination was used.",
+        "All execution, temporary generation, and quarantine work remained under C:/Projects."
+      ],
+      "reviews": [
+        "Working-tree architecture review projectors failed before review because the local worktree source could not be fingerprinted; no findings or approval were produced. Exact-commit architecture and documentation review remain required."
+      ],
+      "publication": {"status": "pending_exact_commit_and_github_checks", "issue": 20},
+      "merge": null,
+      "unresolved": [
+        "Exact-commit architecture/documentation review, exact-commit verification, GitHub publication, CI, merge, reconciliation, and cleanup remain pending."
+      ]
+    }
+  }
+}

--- a/.work/changes/012-deterministic-diagrams-and-semantic-coverage/scope.json
+++ b/.work/changes/012-deterministic-diagrams-and-semantic-coverage/scope.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 4,
+  "change_id": "012-deterministic-diagrams-and-semantic-coverage",
+  "status": "active",
+  "branch": "change/012-deterministic-diagrams-and-semantic-coverage",
+  "worktree": ".work/worktrees/012-deterministic-diagrams-and-semantic-coverage",
+  "base": "main",
+  "outcome": "Add source-derived explanatory diagrams and machine-verifiable semantic coverage to the Governance and Work Management publication families without changing canonical domain semantics.",
+  "owned_paths": [
+    ".work/changes/012-deterministic-diagrams-and-semantic-coverage/**",
+    "src/kis_mcp_doc/render.py",
+    "src/kis_mcp_doc/work_management.py",
+    "generated/governance-spec/**",
+    "generated/work-management-spec/**",
+    "tests/test_governance_renderer.py",
+    "tests/test_work_management_spec.py"
+  ],
+  "shared_paths": [],
+  "excluded_paths": [
+    "AGENTS.md",
+    "contracts/**",
+    "mrd/governance/**",
+    "mrd/work-management/**",
+    "mrd/documentation/**",
+    "publication/**",
+    "evidence/**",
+    "C:/Projects/kis-mcp/**",
+    "C:/Projects/References/**",
+    ".work/worktrees/009-publication-kernel/**"
+  ],
+  "dependencies": [
+    "010-hrd-reader-experience-and-reference-separation",
+    "011-publication-kernel-and-family-registry"
+  ],
+  "integration_owner": null,
+  "complexity": "medium",
+  "risk_triggers": [
+    "architecture_boundary"
+  ],
+  "base_evidence": {
+    "local_sha": "2568b62e20560690ed91a44e48f1682543c38884",
+    "local_tree": "5151a62bb38cd2fc2a546c98a1d349f2e99ad475",
+    "upstream_sha": "2568b62e20560690ed91a44e48f1682543c38884",
+    "upstream_tree": "5151a62bb38cd2fc2a546c98a1d349f2e99ad475",
+    "upstream_ref": "github:main",
+    "evidence_source": "verified_github_default",
+    "relation": "equal"
+  },
+  "work_management": {
+    "project_id": "kis-mcp",
+    "record_id": "SPEC-012",
+    "source_repository": "NielPieterse0/kis-mcp-doc",
+    "source_number": 20,
+    "source_kind": "issue",
+    "documentation_impact": "planned"
+  }
+}

--- a/generated/governance-spec/000-index.md
+++ b/generated/governance-spec/000-index.md
@@ -26,4 +26,5 @@ This generated collection follows the `mcp-spec` publication profile. Source MRD
 
 - [MRD index](data/mrd-index.json)
 - [Dependency map](data/dependency-map.json)
+- [Semantic coverage](data/semantic-coverage.json)
 - [Build manifest](manifest.json)

--- a/generated/governance-spec/001-specification.md
+++ b/generated/governance-spec/001-specification.md
@@ -38,4 +38,4 @@ Substantive changes are made in the owning MRD, contract, schema, code, configur
 
 ## Traceability
 
-See the [documentation index](000-index.md), [MRD index](data/mrd-index.json), [dependency map](data/dependency-map.json), and [build manifest](manifest.json) for exact source identities, hashes, and generated-file declarations.
+See the [documentation index](000-index.md), [MRD index](data/mrd-index.json), [dependency map](data/dependency-map.json), [semantic coverage](data/semantic-coverage.json), and [build manifest](manifest.json) for exact source identities, page/anchor mappings, hashes, and generated-file declarations.

--- a/generated/governance-spec/002-classification.md
+++ b/generated/governance-spec/002-classification.md
@@ -11,14 +11,19 @@ KIS MRDs use a functional classification model. Classification describes what an
 
 The catalog contains 12 functional classes and 47 allowed MRD types. Classification is based on function so that the same governed need keeps the same meaning across repository layouts and technology choices.
 
+<span id="rule-kis-mrd-class-001"></span>
 Every MRD MUST declare exactly one class and one type from this catalog.
 
+<span id="rule-kis-mrd-class-002"></span>
 Classification MUST describe what an artifact does, not where the artifact is stored.
 
+<span id="rule-kis-mrd-class-003"></span>
 A new MRD type MUST NOT be introduced when an existing catalog type adequately represents the artifact.
 
+<span id="rule-kis-mrd-class-004"></span>
 Artifacts MUST NOT be created merely to populate unused catalog types; absence of an unused type has no compliance implication.
 
+<span id="rule-kis-mrd-class-005"></span>
 The catalog MAY be extended by a versioned governance amendment when a genuine artifact need cannot be represented by an existing type.
 
 ## Classes

--- a/generated/governance-spec/003-applicability-and-selection.md
+++ b/generated/governance-spec/003-applicability-and-selection.md
@@ -11,10 +11,13 @@ Governance artifacts are selected according to the need being governed. The 47-t
 
 Selection starts from the 47-type catalog with `not_applicable` as the default disposition. A selected type can be classified as `required`, `optional`, `not_applicable`, `deferred`. The goal is to represent the governed need without creating duplicate authority.
 
+<span id="rule-kis-mrd-app-001"></span>
 A repository or change MUST NOT instantiate all 47 MRD types by default; it MUST select only types whose applicability conditions are satisfied.
 
+<span id="rule-kis-mrd-app-002"></span>
 Selection MUST classify the governed need by function before considering file location, technology, framework, or current implementation shape.
 
+<span id="rule-kis-mrd-app-003"></span>
 When several types could represent the same need, the minimum sufficient non-duplicative set MUST be selected and each governed fact MUST retain one canonical owner.
 
 ## Selection process
@@ -28,6 +31,7 @@ Apply the following process in order. It starts with the governed need and only 
 5. Record required gaps or justified deferrals before implementation.
 6. Propose a catalog amendment only when no existing type can represent the need.
 
+<span id="rule-kis-mrd-app-004"></span>
 A required applicability trigger with no selected or existing canonical artifact MUST be reported as a governance gap before dependent implementation is accepted.
 
 ## Applicability reference
@@ -38,8 +42,10 @@ The complete 47-type selection catalog is an exact lookup surface. See the [MRD 
 
 Technology and stack choices do not create new MRD types by themselves. First represent the need with the existing functional vocabulary when that vocabulary is sufficient.
 
+<span id="rule-kis-mrd-app-005"></span>
 A technology or stack change, including adoption of tools such as uv, MUST first be represented using existing functional types such as version constraints, configuration, package manifests, contracts, or workflows when those types are sufficient.
 
+<span id="rule-kis-mrd-app-006"></span>
 A new MRD type MAY be proposed only when the need cannot be represented without semantic distortion by any existing type, and the proposal MUST enter through a versioned governance amendment.
 
 ## Requirement traceability

--- a/generated/governance-spec/004-authority-ownership-and-relationships.md
+++ b/generated/governance-spec/004-authority-ownership-and-relationships.md
@@ -11,11 +11,27 @@ Every governed fact has one current canonical owner. Other artifacts can referen
 
 The ownership contract assigns one current canonical owner to each governed fact. Non-owners reference rather than restate authority, derived artifacts remain projections, and ownership conflicts are surfaced and resolved against the current owner.
 
+<span id="rule-kis-mrd-own-001"></span>
 Every governed fact MUST have exactly one current canonical owner.
 
+<span id="rule-kis-mrd-own-002"></span>
 A non-owning MRD or repository artifact MAY summarize or project an owned fact for its audience but MUST reference the canonical owner and MUST NOT redefine the fact as independent authority.
 
+<span id="rule-kis-mrd-own-003"></span>
 Generated HRDs, indexes, dependency maps, and other META projections MUST remain downstream of their canonical sources and MUST NOT become write-back authority.
+
+## Authority and ownership model
+
+The diagram groups the four fields of the canonical ownership contract. Connector lines show contract composition only; they do not invent relationships between governed actors.
+
+```mermaid
+flowchart TD
+  contract["Canonical ownership contract"]
+  contract --> owner["Canonical owner count: 1"]
+  contract --> nonowner["Non-owner posture: reference_not_restate"]
+  contract --> derived["Derived posture: projection_only"]
+  contract --> conflict["Conflict posture: surface_diagnostic_and_resolve_against_current_owner"]
+```
 
 ## Canonical owner kinds
 
@@ -33,10 +49,13 @@ Non-owning artifacts preserve authority by declaring typed relationships to the 
 
 See the [governed relationship vocabulary](021-relationship-vocabulary.md) for every relationship code and meaning.
 
+<span id="rule-kis-mrd-own-004"></span>
 Relationships between governed artifacts MUST use the governed relationship vocabulary; ad hoc relationship labels MUST NOT silently create new semantics.
 
+<span id="rule-kis-mrd-own-005"></span>
 When two sources appear to own the same current fact, kis-op MUST surface the conflict and resolve ownership through the applicable authority order before accepting dependent work.
 
+<span id="rule-kis-mrd-own-006"></span>
 Supersession MUST preserve the previous owner's stable identity and lineage while making the replacement unambiguous.
 
 ## Requirement traceability

--- a/generated/governance-spec/005-layering.md
+++ b/generated/governance-spec/005-layering.md
@@ -11,10 +11,13 @@ Authority layers constrain the direction of MRD dependencies. They express which
 
 The governance model uses six authority layers from `L0` through `L5`. Lower layer numbers have higher authority for dependency direction; the layer does not describe storage location or implementation order.
 
+<span id="rule-kis-mrd-layer-001"></span>
 An MRD MAY depend only on an MRD in the same layer or a higher-authority layer with a lower layer number.
 
+<span id="rule-kis-mrd-layer-002"></span>
 An MRD MUST NOT depend on an MRD in a lower-authority layer with a higher layer number.
 
+<span id="rule-kis-mrd-layer-003"></span>
 Layer assignment expresses authority ordering, not storage location or implementation order.
 
 ## Authority layers

--- a/generated/governance-spec/006-dependency-rules.md
+++ b/generated/governance-spec/006-dependency-rules.md
@@ -11,16 +11,22 @@ Dependencies make authority relationships explicit and verifiable. Each dependen
 
 A governed dependency must identify a stable target, resolve successfully, follow the authority-layer direction, and remain part of an acyclic graph. Generated dependency maps are projections of that validated graph, not a second source of truth.
 
+<span id="rule-kis-mrd-dep-001"></span>
 Every dependency target MUST resolve.
 
+<span id="rule-kis-mrd-dep-002"></span>
 MRD-to-MRD dependency direction MUST satisfy the L0-L5 authority ordering.
 
+<span id="rule-kis-mrd-dep-003"></span>
 The MRD dependency graph MUST be acyclic.
 
+<span id="rule-kis-mrd-dep-004"></span>
 Duplicate dependency edges MUST be rejected.
 
+<span id="rule-kis-mrd-dep-005"></span>
 Dependency identities MUST be stable; canonical non-MRD dependencies MUST use repo: paths.
 
+<span id="rule-kis-mrd-dep-006"></span>
 A META-DEP projection MAY be generated from the validated dependency graph and MUST NOT become primary authority.
 
 ## Dependency targets

--- a/generated/governance-spec/007-provenance.md
+++ b/generated/governance-spec/007-provenance.md
@@ -11,20 +11,28 @@ Provenance identifies the authority, origin, and quality of governed facts. It k
 
 Record mode expresses both authority and mutability, while fact quality describes how directly a fact is supported by admitted evidence. This separation prevents harvested, inferred, or generated material from silently becoming prescriptive authority.
 
+<span id="rule-kis-mrd-prov-001"></span>
 Record mode MUST express authority and mutability; KIS does not define a separate generation_mode in the core standard.
 
+<span id="rule-kis-mrd-prov-002"></span>
 Code harvesting MAY produce candidate or meta/descriptive MRDs but MUST NOT automatically create prescriptive authority.
 
+<span id="rule-kis-mrd-prov-003"></span>
 A harvested candidate becomes prescriptive only through explicit adoption or review; after adoption, implementation MUST conform to the prescriptive MRD.
 
+<span id="rule-kis-mrd-prov-004"></span>
 Inferred facts MUST NOT become normative automatically and MUST NOT appear as active prescriptive facts.
 
+<span id="rule-kis-mrd-prov-005"></span>
 Generated human-readable documents and META projections MUST NOT write back authority into their sources.
 
+<span id="rule-kis-mrd-prov-006"></span>
 The provenance source fingerprint MUST deterministically identify the declared provenance source set.
 
+<span id="rule-kis-mrd-prov-007"></span>
 Author intent, invariants, choices, and contracts; derive implementation observations; capture runtime evidence; evaluate conformance between them.
 
+<span id="rule-kis-mrd-prov-008"></span>
 A repo_path provenance source MUST carry the SHA-256 of the resolved repository file; a mismatch MUST invalidate provenance.
 
 ## Record modes

--- a/generated/governance-spec/008-lifecycle.md
+++ b/generated/governance-spec/008-lifecycle.md
@@ -7,6 +7,31 @@
 
 MRD lifecycle depends on record mode. Prescriptive authority, descriptive evidence, and generated metadata follow different states and mutability rules.
 
+## Lifecycle diagram
+
+Each record mode is shown as its own canonical state machine. Only transitions declared by the lifecycle MRD are drawn.
+
+```mermaid
+flowchart LR
+  subgraph prescriptive["prescriptive"]
+    prescriptive_draft["draft"]
+    prescriptive_active["active"]
+    prescriptive_superseded["superseded"]
+    prescriptive_draft --> prescriptive_active
+    prescriptive_active --> prescriptive_superseded
+  end
+  subgraph descriptive["descriptive"]
+    descriptive_created["created"]
+    descriptive_retained["retained"]
+    descriptive_created --> descriptive_retained
+  end
+  subgraph meta["meta"]
+    meta_generated["generated"]
+    meta_replaced["replaced"]
+    meta_generated --> meta_replaced
+  end
+```
+
 ## State machines
 
 Each record mode has its own state machine. Prescriptive MRDs move from draft authority to active authority and then supersession; descriptive evidence and generated metadata use lifecycles that match their different mutability rules.
@@ -21,16 +46,22 @@ The following table shows the allowed states and transitions for each record mod
 
 ## Lifecycle requirements
 
+<span id="rule-kis-mrd-life-001"></span>
 Active prescriptive MRDs MUST have resolved dependencies and valid provenance.
 
+<span id="rule-kis-mrd-life-002"></span>
 Descriptive EVD records MUST be immutable after creation.
 
+<span id="rule-kis-mrd-life-003"></span>
 META records MUST be regenerated from their sources rather than manually maintained.
 
+<span id="rule-kis-mrd-life-004"></span>
 A derived or generated artifact MUST be treated as stale when its declared source fingerprint no longer matches its admitted sources.
 
+<span id="rule-kis-mrd-life-005"></span>
 Superseded MRDs MUST remain addressable for lineage and MUST identify their replacement when one exists.
 
+<span id="rule-kis-mrd-life-006"></span>
 Git history is the change history; a duplicate body changelog is not required by the core MRD standard.
 
 ## Requirement traceability

--- a/generated/governance-spec/009-kis-op-governance-behavior.md
+++ b/generated/governance-spec/009-kis-op-governance-behavior.md
@@ -11,12 +11,16 @@ kis-op applies governance as an ordered workflow from authority resolution throu
 
 kis-op applies governance through seven ordered phases. It resolves authority and applicable MRDs before mutation, validates blocking conditions before execution, and keeps generated review surfaces downstream of validated sources.
 
+<span id="rule-kis-op-gov-001"></span>
 kis-op MUST resolve applicable repository authority and the active governed change scope before proposing or performing repository mutation.
 
+<span id="rule-kis-op-gov-002"></span>
 kis-op MUST use the 47-type catalog as a selection vocabulary, not as a checklist requiring one artifact of every type.
 
+<span id="rule-kis-op-gov-003"></span>
 kis-op MUST prefer an existing MRD type when it can represent the governed need without semantic distortion and MUST NOT silently invent a new type.
 
+<span id="rule-kis-op-gov-004"></span>
 kis-op MUST fail closed on unresolved required authority, ownership, dependency, provenance, or blocking validation failures and MUST report the reason rather than infer authority.
 
 ## Governance application lifecycle
@@ -45,10 +49,13 @@ A completed governance application produces the following review and machine-rea
 
 ## Scope and review boundaries
 
+<span id="rule-kis-op-gov-005"></span>
 kis-op MUST keep generated HRDs downstream of machine-readable authority and MUST direct substantive corrections to the owning MRD or canonical source before regeneration.
 
+<span id="rule-kis-op-gov-006"></span>
 kis-op MUST preserve bounded scope and MUST NOT expand a governance-specification task into unrelated Knowledge, UI, discovery, or platform implementation work unless that work is required to generate or validate the requested governance specification.
 
+<span id="rule-kis-op-gov-007"></span>
 When governance requires human judgment, kis-op MUST identify the review gate explicitly and MUST NOT misrepresent an advisory or review-based conclusion as deterministic machine enforcement.
 
 ## Requirement traceability

--- a/generated/governance-spec/010-validation-and-enforcement.md
+++ b/generated/governance-spec/010-validation-and-enforcement.md
@@ -11,14 +11,19 @@ Governance validation combines structural checks, deterministic semantic checks,
 
 Validation first establishes that the governance set is structurally valid, then evaluates the cross-record semantics that depend on that structure. A blocking failure prevents the affected governance state from being accepted as valid and produces machine-readable diagnostics.
 
+<span id="rule-kis-mrd-val-001"></span>
 Every MRD MUST pass structural, dependency, provenance, and lifecycle validation before it is accepted as valid.
 
+<span id="rule-kis-mrd-val-002"></span>
 Validation failures MUST emit stable reason codes and machine-readable diagnostics.
 
+<span id="rule-kis-mrd-val-003"></span>
 A validation result MUST report classification, layering, dependencies, provenance, lifecycle, and schema check status.
 
+<span id="rule-kis-mrd-val-004"></span>
 Governance MRDs MUST validate through the public composed governance MRD profile, which binds the reusable core envelope to governance content.
 
+<span id="rule-kis-mrd-val-005"></span>
 Any structural schema failure in the governance MRD set MUST short-circuit semantic validation for the entire set, because cross-record semantics are valid only over a structurally valid governance set.
 
 ## Enforcement modes

--- a/generated/governance-spec/020-applicability-catalog.md
+++ b/generated/governance-spec/020-applicability-catalog.md
@@ -11,53 +11,54 @@ Use this catalog after the specification's minimum-sufficient selection process 
 
 | Code | Name | Use when |
 |---|---|---|
-| `SEM-ENT` | Entity definition schema | Use when a governed domain needs a canonical entity shape, identity, fields, or structural definition. |
-| `SEM-ENUM` | Enumeration schema | Use when a finite controlled vocabulary or closed set of allowed values must be authoritative. |
-| `SEM-ONT` | Ontology | Use when governed concepts and their semantic relationships need an explicit ontology. |
-| `SEM-REG` | Registry | Use when named governed entries require one authoritative registry with stable identifiers. |
-| `SEM-DOM` | Domain definition register | Use when a domain boundary, scope, vocabulary ownership, or domain definition must be registered. |
-| `SEM-ASR` | Assertion rules | Use when invariants or semantic assertions must be stated independently of implementation code. |
-| `CON-VRS` | Version constraint | Use when allowed, required, minimum, maximum, or compatible versions must be constrained. |
-| `CON-BND` | Boundary rule | Use when an authority, security, filesystem, network, module, or responsibility boundary must be constrained. |
-| `CON-POL` | Policy implementation | Use when durable policy determines what is permitted, prohibited, required, or conditionally allowed. |
-| `CON-CTR` | Constraint contract | Use when constraints themselves require a reusable machine-consumable contract. |
-| `DEC-TAB` | Decision table | Use when an outcome can be selected deterministically from a finite set of conditions in tabular form. |
-| `DEC-TRE` | Decision tree | Use when ordered or branching conditions determine a governed outcome more clearly than a table. |
-| `DEC-SCR` | Scoring model | Use when weighted criteria or scores determine a governed classification, threshold, or decision. |
-| `WRK-STM` | State machine | Use when governed state, permitted transitions, and terminal states must be explicit. |
-| `WRK-PRC` | Process definition | Use when a repeatable ordered process with defined inputs, steps, and outputs must be prescribed. |
-| `WRK-APR` | Approval workflow | Use when approval, rejection, escalation, or sign-off flow must be governed. |
-| `WRK-CTR` | Phase contract | Use when a workflow phase requires explicit entry, exit, handoff, or completion conditions. |
-| `WRK-WFL` | Workflow definition | Use when several governed steps, roles, decisions, or phases form an end-to-end workflow. |
-| `WRK-ACT` | Action or automation workflow | Use when a bounded action or automation sequence must be executable under governance. |
-| `CFG-ENV` | Environment config | Use when environment-specific values select allowed behavior without redefining policy. |
-| `CFG-FLG` | Feature flag | Use when a governed feature can be enabled or disabled through an explicit flag. |
-| `CFG-PRM` | Runtime parameter | Use when a runtime parameter selects among already-permitted behaviors or limits. |
-| `MAP-FLD` | Field mapping | Use when fields in one governed structure translate deterministically to fields in another. |
-| `MAP-FMT` | Format translation | Use when one representation or serialization format must translate deterministically to another. |
-| `MAP-MIG` | Migration map | Use when a versioned structure, identifier, or data model requires an explicit migration mapping. |
-| `CTR-API` | API contract | Use when callable request/response behavior requires an explicit API interface contract. |
-| `CTR-EVT` | Event contract | Use when produced or consumed events require stable names, payloads, and delivery semantics. |
-| `CTR-SVC` | Service contract | Use when a service boundary, capability, inputs, outputs, or service-level interface must be contracted. |
-| `MAN-PKG` | Package manifest | Use when a package's governed identity, contents, dependencies, or distribution metadata must be declared. |
-| `MAN-BOM` | Bill of materials | Use when constituent components or dependencies must be inventoried as a bill of materials. |
-| `MAN-REL` | Release manifest | Use when a release needs an authoritative manifest of version, contents, provenance, and release facts. |
-| `MAN-SKL` | Skill manifest | Use when a reusable skill package needs a governed capability and asset manifest. |
-| `MAN-ACT` | Action manifest | Use when available actions or automations must be inventoried separately from their workflow definitions. |
-| `PRM-SYS` | System prompt | Use when durable system-level model instructions are governed as an explicit prompt artifact. |
-| `PRM-ROL` | Role prompt | Use when a durable role-specific behavior or responsibility prompt must be governed. |
-| `PRM-CTX` | Context prompt | Use when reusable context assembly or context framing instructions must be governed. |
-| `PRM-TOL` | Tool prompt | Use when model-facing instructions for invoking or interpreting a tool must be governed. |
-| `EVL-TST` | Test suite | Use when deterministic or machine-evaluable conformance tests define acceptance of governed behavior. |
-| `EVL-RUB` | Rubric | Use when qualitative or multi-criterion review requires an explicit scoring or assessment rubric. |
-| `EVL-BEN` | Benchmark | Use when comparable performance, quality, or capability measurement requires a stable benchmark. |
-| `EVD-LOG` | Log | Use when an immutable operational or governance log is itself required evidence. |
-| `EVD-APR` | Approval record | Use when an approval decision must be retained as evidence distinct from the approval workflow. |
-| `EVD-LIN` | Lineage record | Use when lineage, derivation, handoff, or provenance events must be retained as evidence. |
-| `EVD-TSR` | Test result snapshot | Use when a test or verification result must be retained as an immutable evidence snapshot. |
-| `META-IDX` | Index | Generate when consumers need a derived index over governed artifacts; never author it as primary truth. |
-| `META-DEP` | Dependency map | Generate when consumers need a derived dependency graph or map; never author it as primary truth. |
-| `META-MAP` | Metadata map | Generate when consumers need derived metadata joins or lookup maps; never author it as primary truth. |
+| <span id="fact-applicability-sem-ent"></span>`SEM-ENT` | Entity definition schema | Use when a governed domain needs a canonical entity shape, identity, fields, or structural definition. |
+| <span id="fact-applicability-sem-enum"></span>`SEM-ENUM` | Enumeration schema | Use when a finite controlled vocabulary or closed set of allowed values must be authoritative. |
+| <span id="fact-applicability-sem-ont"></span>`SEM-ONT` | Ontology | Use when governed concepts and their semantic relationships need an explicit ontology. |
+| <span id="fact-applicability-sem-reg"></span>`SEM-REG` | Registry | Use when named governed entries require one authoritative registry with stable identifiers. |
+| <span id="fact-applicability-sem-dom"></span>`SEM-DOM` | Domain definition register | Use when a domain boundary, scope, vocabulary ownership, or domain definition must be registered. |
+| <span id="fact-applicability-sem-asr"></span>`SEM-ASR` | Assertion rules | Use when invariants or semantic assertions must be stated independently of implementation code. |
+| <span id="fact-applicability-con-vrs"></span>`CON-VRS` | Version constraint | Use when allowed, required, minimum, maximum, or compatible versions must be constrained. |
+| <span id="fact-applicability-con-bnd"></span>`CON-BND` | Boundary rule | Use when an authority, security, filesystem, network, module, or responsibility boundary must be constrained. |
+| <span id="fact-applicability-con-pol"></span>`CON-POL` | Policy implementation | Use when durable policy determines what is permitted, prohibited, required, or conditionally allowed. |
+| <span id="fact-applicability-con-ctr"></span>`CON-CTR` | Constraint contract | Use when constraints themselves require a reusable machine-consumable contract. |
+| <span id="fact-applicability-dec-tab"></span>`DEC-TAB` | Decision table | Use when an outcome can be selected deterministically from a finite set of conditions in tabular form. |
+| <span id="fact-applicability-dec-tre"></span>`DEC-TRE` | Decision tree | Use when ordered or branching conditions determine a governed outcome more clearly than a table. |
+| <span id="fact-applicability-dec-scr"></span>`DEC-SCR` | Scoring model | Use when weighted criteria or scores determine a governed classification, threshold, or decision. |
+| <span id="fact-applicability-wrk-stm"></span>`WRK-STM` | State machine | Use when governed state, permitted transitions, and terminal states must be explicit. |
+| <span id="fact-applicability-wrk-prc"></span>`WRK-PRC` | Process definition | Use when a repeatable ordered process with defined inputs, steps, and outputs must be prescribed. |
+| <span id="fact-applicability-wrk-apr"></span>`WRK-APR` | Approval workflow | Use when approval, rejection, escalation, or sign-off flow must be governed. |
+| <span id="fact-applicability-wrk-ctr"></span>`WRK-CTR` | Phase contract | Use when a workflow phase requires explicit entry, exit, handoff, or completion conditions. |
+| <span id="fact-applicability-wrk-wfl"></span>`WRK-WFL` | Workflow definition | Use when several governed steps, roles, decisions, or phases form an end-to-end workflow. |
+| <span id="fact-applicability-wrk-act"></span>`WRK-ACT` | Action or automation workflow | Use when a bounded action or automation sequence must be executable under governance. |
+| <span id="fact-applicability-cfg-env"></span>`CFG-ENV` | Environment config | Use when environment-specific values select allowed behavior without redefining policy. |
+| <span id="fact-applicability-cfg-flg"></span>`CFG-FLG` | Feature flag | Use when a governed feature can be enabled or disabled through an explicit flag. |
+| <span id="fact-applicability-cfg-prm"></span>`CFG-PRM` | Runtime parameter | Use when a runtime parameter selects among already-permitted behaviors or limits. |
+| <span id="fact-applicability-map-fld"></span>`MAP-FLD` | Field mapping | Use when fields in one governed structure translate deterministically to fields in another. |
+| <span id="fact-applicability-map-fmt"></span>`MAP-FMT` | Format translation | Use when one representation or serialization format must translate deterministically to another. |
+| <span id="fact-applicability-map-mig"></span>`MAP-MIG` | Migration map | Use when a versioned structure, identifier, or data model requires an explicit migration mapping. |
+| <span id="fact-applicability-ctr-api"></span>`CTR-API` | API contract | Use when callable request/response behavior requires an explicit API interface contract. |
+| <span id="fact-applicability-ctr-evt"></span>`CTR-EVT` | Event contract | Use when produced or consumed events require stable names, payloads, and delivery semantics. |
+| <span id="fact-applicability-ctr-svc"></span>`CTR-SVC` | Service contract | Use when a service boundary, capability, inputs, outputs, or service-level interface must be contracted. |
+| <span id="fact-applicability-man-pkg"></span>`MAN-PKG` | Package manifest | Use when a package's governed identity, contents, dependencies, or distribution metadata must be declared. |
+| <span id="fact-applicability-man-bom"></span>`MAN-BOM` | Bill of materials | Use when constituent components or dependencies must be inventoried as a bill of materials. |
+| <span id="fact-applicability-man-rel"></span>`MAN-REL` | Release manifest | Use when a release needs an authoritative manifest of version, contents, provenance, and release facts. |
+| <span id="fact-applicability-man-skl"></span>`MAN-SKL` | Skill manifest | Use when a reusable skill package needs a governed capability and asset manifest. |
+| <span id="fact-applicability-man-act"></span>`MAN-ACT` | Action manifest | Use when available actions or automations must be inventoried separately from their workflow definitions. |
+| <span id="fact-applicability-prm-sys"></span>`PRM-SYS` | System prompt | Use when durable system-level model instructions are governed as an explicit prompt artifact. |
+| <span id="fact-applicability-prm-rol"></span>`PRM-ROL` | Role prompt | Use when a durable role-specific behavior or responsibility prompt must be governed. |
+| <span id="fact-applicability-prm-ctx"></span>`PRM-CTX` | Context prompt | Use when reusable context assembly or context framing instructions must be governed. |
+| <span id="fact-applicability-prm-tol"></span>`PRM-TOL` | Tool prompt | Use when model-facing instructions for invoking or interpreting a tool must be governed. |
+| <span id="fact-applicability-evl-tst"></span>`EVL-TST` | Test suite | Use when deterministic or machine-evaluable conformance tests define acceptance of governed behavior. |
+| <span id="fact-applicability-evl-rub"></span>`EVL-RUB` | Rubric | Use when qualitative or multi-criterion review requires an explicit scoring or assessment rubric. |
+| <span id="fact-applicability-evl-ben"></span>`EVL-BEN` | Benchmark | Use when comparable performance, quality, or capability measurement requires a stable benchmark. |
+| <span id="fact-applicability-evd-log"></span>`EVD-LOG` | Log | Use when an immutable operational or governance log is itself required evidence. |
+| <span id="fact-applicability-evd-apr"></span>`EVD-APR` | Approval record | Use when an approval decision must be retained as evidence distinct from the approval workflow. |
+| <span id="fact-applicability-evd-lin"></span>`EVD-LIN` | Lineage record | Use when lineage, derivation, handoff, or provenance events must be retained as evidence. |
+| <span id="fact-applicability-evd-tsr"></span>`EVD-TSR` | Test result snapshot | Use when a test or verification result must be retained as an immutable evidence snapshot. |
+| <span id="fact-applicability-meta-idx"></span>`META-IDX` | Index | Generate when consumers need a derived index over governed artifacts; never author it as primary truth. |
+| <span id="fact-applicability-meta-dep"></span>`META-DEP` | Dependency map | Generate when consumers need a derived dependency graph or map; never author it as primary truth. |
+| <span id="fact-applicability-meta-map"></span>`META-MAP` | Metadata map | Generate when consumers need derived metadata joins or lookup maps; never author it as primary truth. |
+
 
 ## Source and authority
 

--- a/generated/governance-spec/021-relationship-vocabulary.md
+++ b/generated/governance-spec/021-relationship-vocabulary.md
@@ -11,17 +11,18 @@ Relationships preserve authority by expressing how one governed artifact relates
 
 | Relationship | Meaning |
 |---|---|
-| `depends_on` | The source requires the target authority to be valid or interpretable. |
-| `validated_by` | The source is structurally or semantically checked by the target contract or validator. |
-| `governs` | The source prescribes requirements for the target. |
-| `constrains` | The source restricts permitted values or behavior of the target. |
-| `selects` | The source chooses among behaviors already permitted by the target authority. |
-| `maps_to` | The source translates deterministically to the target representation. |
-| `implements` | The source is an implementation of target authority. |
-| `evidences` | The source records evidence about the target without becoming its authority. |
-| `projects` | The source is a generated view of the target and has no write-back authority. |
-| `references` | The source points to the target owner without restating the governed fact as new authority. |
-| `supersedes` | The source replaces the target while preserving lineage. |
+| <span id="fact-relationship-depends-on"></span>`depends_on` | The source requires the target authority to be valid or interpretable. |
+| <span id="fact-relationship-validated-by"></span>`validated_by` | The source is structurally or semantically checked by the target contract or validator. |
+| <span id="fact-relationship-governs"></span>`governs` | The source prescribes requirements for the target. |
+| <span id="fact-relationship-constrains"></span>`constrains` | The source restricts permitted values or behavior of the target. |
+| <span id="fact-relationship-selects"></span>`selects` | The source chooses among behaviors already permitted by the target authority. |
+| <span id="fact-relationship-maps-to"></span>`maps_to` | The source translates deterministically to the target representation. |
+| <span id="fact-relationship-implements"></span>`implements` | The source is an implementation of target authority. |
+| <span id="fact-relationship-evidences"></span>`evidences` | The source records evidence about the target without becoming its authority. |
+| <span id="fact-relationship-projects"></span>`projects` | The source is a generated view of the target and has no write-back authority. |
+| <span id="fact-relationship-references"></span>`references` | The source points to the target owner without restating the governed fact as new authority. |
+| <span id="fact-relationship-supersedes"></span>`supersedes` | The source replaces the target while preserving lineage. |
+
 
 ## Source and authority
 

--- a/generated/governance-spec/022-validation-reason-codes.md
+++ b/generated/governance-spec/022-validation-reason-codes.md
@@ -9,37 +9,38 @@
 
 Use these stable codes to diagnose validation failures without parsing human-readable error text.
 
-- `MRD_SCHEMA_INVALID`
-- `MRD_RULE_ID_DUPLICATE`
-- `MRD_GOVERNANCE_CONCERN_MISSING`
-- `MRD_GOVERNANCE_CONCERN_DUPLICATE`
-- `MRD_ID_CLASS_TYPE_MISMATCH`
-- `MRD_CLASS_UNKNOWN`
-- `MRD_TYPE_INVALID`
-- `MRD_CATALOG_COUNT_MISMATCH`
-- `MRD_LAYER_INVALID`
-- `MRD_DEPENDENCY_UNRESOLVED`
-- `MRD_DEPENDENCY_LAYER_VIOLATION`
-- `MRD_DEPENDENCY_CYCLE`
-- `MRD_DEPENDENCY_DUPLICATE`
-- `MRD_SOURCE_UNRESOLVED`
-- `MRD_SOURCE_FINGERPRINT_MISMATCH`
-- `MRD_SOURCE_HASH_MISMATCH`
-- `MRD_NORMATIVE_INFERENCE_PROHIBITED`
-- `MRD_RECORD_MODE_INVALID`
-- `MRD_STATUS_INVALID`
-- `MRD_EVD_RECORD_MODE_INVALID`
-- `MRD_META_RECORD_MODE_INVALID`
-- `MRD_SUPERSESSION_UNRESOLVED`
-- `MRD_CLASS_CATALOG_MISMATCH`
-- `MRD_LAYER_CATALOG_MISMATCH`
-- `MRD_RECORD_MODE_CATALOG_MISMATCH`
-- `MRD_META_FACT_QUALITY_INVALID`
-- `MRD_VALIDATION_CONTRACT_MISMATCH`
-- `MRD_APPLICABILITY_CATALOG_MISMATCH`
-- `MRD_RELATIONSHIP_UNKNOWN`
-- `MRD_OPERATOR_BEHAVIOR_INVALID`
-- `MRD_ENFORCEMENT_BINDING_INVALID`
+- <span id="fact-reason-mrd-schema-invalid"></span>`MRD_SCHEMA_INVALID`
+- <span id="fact-reason-mrd-rule-id-duplicate"></span>`MRD_RULE_ID_DUPLICATE`
+- <span id="fact-reason-mrd-governance-concern-missing"></span>`MRD_GOVERNANCE_CONCERN_MISSING`
+- <span id="fact-reason-mrd-governance-concern-duplicate"></span>`MRD_GOVERNANCE_CONCERN_DUPLICATE`
+- <span id="fact-reason-mrd-id-class-type-mismatch"></span>`MRD_ID_CLASS_TYPE_MISMATCH`
+- <span id="fact-reason-mrd-class-unknown"></span>`MRD_CLASS_UNKNOWN`
+- <span id="fact-reason-mrd-type-invalid"></span>`MRD_TYPE_INVALID`
+- <span id="fact-reason-mrd-catalog-count-mismatch"></span>`MRD_CATALOG_COUNT_MISMATCH`
+- <span id="fact-reason-mrd-layer-invalid"></span>`MRD_LAYER_INVALID`
+- <span id="fact-reason-mrd-dependency-unresolved"></span>`MRD_DEPENDENCY_UNRESOLVED`
+- <span id="fact-reason-mrd-dependency-layer-violation"></span>`MRD_DEPENDENCY_LAYER_VIOLATION`
+- <span id="fact-reason-mrd-dependency-cycle"></span>`MRD_DEPENDENCY_CYCLE`
+- <span id="fact-reason-mrd-dependency-duplicate"></span>`MRD_DEPENDENCY_DUPLICATE`
+- <span id="fact-reason-mrd-source-unresolved"></span>`MRD_SOURCE_UNRESOLVED`
+- <span id="fact-reason-mrd-source-fingerprint-mismatch"></span>`MRD_SOURCE_FINGERPRINT_MISMATCH`
+- <span id="fact-reason-mrd-source-hash-mismatch"></span>`MRD_SOURCE_HASH_MISMATCH`
+- <span id="fact-reason-mrd-normative-inference-prohibited"></span>`MRD_NORMATIVE_INFERENCE_PROHIBITED`
+- <span id="fact-reason-mrd-record-mode-invalid"></span>`MRD_RECORD_MODE_INVALID`
+- <span id="fact-reason-mrd-status-invalid"></span>`MRD_STATUS_INVALID`
+- <span id="fact-reason-mrd-evd-record-mode-invalid"></span>`MRD_EVD_RECORD_MODE_INVALID`
+- <span id="fact-reason-mrd-meta-record-mode-invalid"></span>`MRD_META_RECORD_MODE_INVALID`
+- <span id="fact-reason-mrd-supersession-unresolved"></span>`MRD_SUPERSESSION_UNRESOLVED`
+- <span id="fact-reason-mrd-class-catalog-mismatch"></span>`MRD_CLASS_CATALOG_MISMATCH`
+- <span id="fact-reason-mrd-layer-catalog-mismatch"></span>`MRD_LAYER_CATALOG_MISMATCH`
+- <span id="fact-reason-mrd-record-mode-catalog-mismatch"></span>`MRD_RECORD_MODE_CATALOG_MISMATCH`
+- <span id="fact-reason-mrd-meta-fact-quality-invalid"></span>`MRD_META_FACT_QUALITY_INVALID`
+- <span id="fact-reason-mrd-validation-contract-mismatch"></span>`MRD_VALIDATION_CONTRACT_MISMATCH`
+- <span id="fact-reason-mrd-applicability-catalog-mismatch"></span>`MRD_APPLICABILITY_CATALOG_MISMATCH`
+- <span id="fact-reason-mrd-relationship-unknown"></span>`MRD_RELATIONSHIP_UNKNOWN`
+- <span id="fact-reason-mrd-operator-behavior-invalid"></span>`MRD_OPERATOR_BEHAVIOR_INVALID`
+- <span id="fact-reason-mrd-enforcement-binding-invalid"></span>`MRD_ENFORCEMENT_BINDING_INVALID`
+
 
 ## Source and authority
 

--- a/generated/governance-spec/data/semantic-coverage.json
+++ b/generated/governance-spec/data/semantic-coverage.json
@@ -1,0 +1,1097 @@
+{
+  "entries": [
+    {
+      "anchor": "fact-applicability-cfg-env",
+      "id": "applicability:CFG-ENV",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-cfg-flg",
+      "id": "applicability:CFG-FLG",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-cfg-prm",
+      "id": "applicability:CFG-PRM",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-con-bnd",
+      "id": "applicability:CON-BND",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-con-ctr",
+      "id": "applicability:CON-CTR",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-con-pol",
+      "id": "applicability:CON-POL",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-con-vrs",
+      "id": "applicability:CON-VRS",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-ctr-api",
+      "id": "applicability:CTR-API",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-ctr-evt",
+      "id": "applicability:CTR-EVT",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-ctr-svc",
+      "id": "applicability:CTR-SVC",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-dec-scr",
+      "id": "applicability:DEC-SCR",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-dec-tab",
+      "id": "applicability:DEC-TAB",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-dec-tre",
+      "id": "applicability:DEC-TRE",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-evd-apr",
+      "id": "applicability:EVD-APR",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-evd-lin",
+      "id": "applicability:EVD-LIN",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-evd-log",
+      "id": "applicability:EVD-LOG",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-evd-tsr",
+      "id": "applicability:EVD-TSR",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-evl-ben",
+      "id": "applicability:EVL-BEN",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-evl-rub",
+      "id": "applicability:EVL-RUB",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-evl-tst",
+      "id": "applicability:EVL-TST",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-man-act",
+      "id": "applicability:MAN-ACT",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-man-bom",
+      "id": "applicability:MAN-BOM",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-man-pkg",
+      "id": "applicability:MAN-PKG",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-man-rel",
+      "id": "applicability:MAN-REL",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-man-skl",
+      "id": "applicability:MAN-SKL",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-map-fld",
+      "id": "applicability:MAP-FLD",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-map-fmt",
+      "id": "applicability:MAP-FMT",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-map-mig",
+      "id": "applicability:MAP-MIG",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-meta-dep",
+      "id": "applicability:META-DEP",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-meta-idx",
+      "id": "applicability:META-IDX",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-meta-map",
+      "id": "applicability:META-MAP",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-prm-ctx",
+      "id": "applicability:PRM-CTX",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-prm-rol",
+      "id": "applicability:PRM-ROL",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-prm-sys",
+      "id": "applicability:PRM-SYS",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-prm-tol",
+      "id": "applicability:PRM-TOL",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-sem-asr",
+      "id": "applicability:SEM-ASR",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-sem-dom",
+      "id": "applicability:SEM-DOM",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-sem-ent",
+      "id": "applicability:SEM-ENT",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-sem-enum",
+      "id": "applicability:SEM-ENUM",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-sem-ont",
+      "id": "applicability:SEM-ONT",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-sem-reg",
+      "id": "applicability:SEM-REG",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-wrk-act",
+      "id": "applicability:WRK-ACT",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-wrk-apr",
+      "id": "applicability:WRK-APR",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-wrk-ctr",
+      "id": "applicability:WRK-CTR",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-wrk-prc",
+      "id": "applicability:WRK-PRC",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-wrk-stm",
+      "id": "applicability:WRK-STM",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-applicability-wrk-wfl",
+      "id": "applicability:WRK-WFL",
+      "kind": "reference_fact",
+      "page": "020-applicability-catalog.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-applicability-catalog-mismatch",
+      "id": "reason:MRD_APPLICABILITY_CATALOG_MISMATCH",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-catalog-count-mismatch",
+      "id": "reason:MRD_CATALOG_COUNT_MISMATCH",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-class-catalog-mismatch",
+      "id": "reason:MRD_CLASS_CATALOG_MISMATCH",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-class-unknown",
+      "id": "reason:MRD_CLASS_UNKNOWN",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-dependency-cycle",
+      "id": "reason:MRD_DEPENDENCY_CYCLE",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-dependency-duplicate",
+      "id": "reason:MRD_DEPENDENCY_DUPLICATE",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-dependency-layer-violation",
+      "id": "reason:MRD_DEPENDENCY_LAYER_VIOLATION",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-dependency-unresolved",
+      "id": "reason:MRD_DEPENDENCY_UNRESOLVED",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-enforcement-binding-invalid",
+      "id": "reason:MRD_ENFORCEMENT_BINDING_INVALID",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-evd-record-mode-invalid",
+      "id": "reason:MRD_EVD_RECORD_MODE_INVALID",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-governance-concern-duplicate",
+      "id": "reason:MRD_GOVERNANCE_CONCERN_DUPLICATE",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-governance-concern-missing",
+      "id": "reason:MRD_GOVERNANCE_CONCERN_MISSING",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-id-class-type-mismatch",
+      "id": "reason:MRD_ID_CLASS_TYPE_MISMATCH",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-layer-catalog-mismatch",
+      "id": "reason:MRD_LAYER_CATALOG_MISMATCH",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-layer-invalid",
+      "id": "reason:MRD_LAYER_INVALID",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-meta-fact-quality-invalid",
+      "id": "reason:MRD_META_FACT_QUALITY_INVALID",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-meta-record-mode-invalid",
+      "id": "reason:MRD_META_RECORD_MODE_INVALID",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-normative-inference-prohibited",
+      "id": "reason:MRD_NORMATIVE_INFERENCE_PROHIBITED",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-operator-behavior-invalid",
+      "id": "reason:MRD_OPERATOR_BEHAVIOR_INVALID",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-record-mode-catalog-mismatch",
+      "id": "reason:MRD_RECORD_MODE_CATALOG_MISMATCH",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-record-mode-invalid",
+      "id": "reason:MRD_RECORD_MODE_INVALID",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-relationship-unknown",
+      "id": "reason:MRD_RELATIONSHIP_UNKNOWN",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-rule-id-duplicate",
+      "id": "reason:MRD_RULE_ID_DUPLICATE",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-schema-invalid",
+      "id": "reason:MRD_SCHEMA_INVALID",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-source-fingerprint-mismatch",
+      "id": "reason:MRD_SOURCE_FINGERPRINT_MISMATCH",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-source-hash-mismatch",
+      "id": "reason:MRD_SOURCE_HASH_MISMATCH",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-source-unresolved",
+      "id": "reason:MRD_SOURCE_UNRESOLVED",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-status-invalid",
+      "id": "reason:MRD_STATUS_INVALID",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-supersession-unresolved",
+      "id": "reason:MRD_SUPERSESSION_UNRESOLVED",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-type-invalid",
+      "id": "reason:MRD_TYPE_INVALID",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-reason-mrd-validation-contract-mismatch",
+      "id": "reason:MRD_VALIDATION_CONTRACT_MISMATCH",
+      "kind": "reference_fact",
+      "page": "022-validation-reason-codes.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001"
+    },
+    {
+      "anchor": "fact-relationship-constrains",
+      "id": "relationship:constrains",
+      "kind": "reference_fact",
+      "page": "021-relationship-vocabulary.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002"
+    },
+    {
+      "anchor": "fact-relationship-depends-on",
+      "id": "relationship:depends_on",
+      "kind": "reference_fact",
+      "page": "021-relationship-vocabulary.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002"
+    },
+    {
+      "anchor": "fact-relationship-evidences",
+      "id": "relationship:evidences",
+      "kind": "reference_fact",
+      "page": "021-relationship-vocabulary.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002"
+    },
+    {
+      "anchor": "fact-relationship-governs",
+      "id": "relationship:governs",
+      "kind": "reference_fact",
+      "page": "021-relationship-vocabulary.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002"
+    },
+    {
+      "anchor": "fact-relationship-implements",
+      "id": "relationship:implements",
+      "kind": "reference_fact",
+      "page": "021-relationship-vocabulary.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002"
+    },
+    {
+      "anchor": "fact-relationship-maps-to",
+      "id": "relationship:maps_to",
+      "kind": "reference_fact",
+      "page": "021-relationship-vocabulary.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002"
+    },
+    {
+      "anchor": "fact-relationship-projects",
+      "id": "relationship:projects",
+      "kind": "reference_fact",
+      "page": "021-relationship-vocabulary.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002"
+    },
+    {
+      "anchor": "fact-relationship-references",
+      "id": "relationship:references",
+      "kind": "reference_fact",
+      "page": "021-relationship-vocabulary.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002"
+    },
+    {
+      "anchor": "fact-relationship-selects",
+      "id": "relationship:selects",
+      "kind": "reference_fact",
+      "page": "021-relationship-vocabulary.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002"
+    },
+    {
+      "anchor": "fact-relationship-supersedes",
+      "id": "relationship:supersedes",
+      "kind": "reference_fact",
+      "page": "021-relationship-vocabulary.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002"
+    },
+    {
+      "anchor": "fact-relationship-validated-by",
+      "id": "relationship:validated_by",
+      "kind": "reference_fact",
+      "page": "021-relationship-vocabulary.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002"
+    },
+    {
+      "anchor": "rule-kis-mrd-app-001",
+      "enforcement": "workflow",
+      "id": "KIS-MRD-APP-001",
+      "kind": "rule",
+      "page": "003-applicability-and-selection.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-app-002",
+      "enforcement": "review",
+      "id": "KIS-MRD-APP-002",
+      "kind": "rule",
+      "page": "003-applicability-and-selection.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-app-003",
+      "enforcement": "review",
+      "id": "KIS-MRD-APP-003",
+      "kind": "rule",
+      "page": "003-applicability-and-selection.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-app-004",
+      "enforcement": "validator",
+      "id": "KIS-MRD-APP-004",
+      "kind": "rule",
+      "page": "003-applicability-and-selection.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-app-005",
+      "enforcement": "review",
+      "id": "KIS-MRD-APP-005",
+      "kind": "rule",
+      "page": "003-applicability-and-selection.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-app-006",
+      "enforcement": "workflow",
+      "id": "KIS-MRD-APP-006",
+      "kind": "rule",
+      "page": "003-applicability-and-selection.md",
+      "source_mrd": "KIS-KNOW-DEC-TAB-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-class-001",
+      "enforcement": "validator",
+      "id": "KIS-MRD-CLASS-001",
+      "kind": "rule",
+      "page": "002-classification.md",
+      "source_mrd": "KIS-KNOW-SEM-REG-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-class-002",
+      "enforcement": "review",
+      "id": "KIS-MRD-CLASS-002",
+      "kind": "rule",
+      "page": "002-classification.md",
+      "source_mrd": "KIS-KNOW-SEM-REG-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-class-003",
+      "enforcement": "review",
+      "id": "KIS-MRD-CLASS-003",
+      "kind": "rule",
+      "page": "002-classification.md",
+      "source_mrd": "KIS-KNOW-SEM-REG-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-class-004",
+      "enforcement": "workflow",
+      "id": "KIS-MRD-CLASS-004",
+      "kind": "rule",
+      "page": "002-classification.md",
+      "source_mrd": "KIS-KNOW-SEM-REG-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-class-005",
+      "enforcement": "workflow",
+      "id": "KIS-MRD-CLASS-005",
+      "kind": "rule",
+      "page": "002-classification.md",
+      "source_mrd": "KIS-KNOW-SEM-REG-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-dep-001",
+      "enforcement": "validator",
+      "id": "KIS-MRD-DEP-001",
+      "kind": "rule",
+      "page": "006-dependency-rules.md",
+      "source_mrd": "KIS-KNOW-CON-CTR-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-dep-002",
+      "enforcement": "validator",
+      "id": "KIS-MRD-DEP-002",
+      "kind": "rule",
+      "page": "006-dependency-rules.md",
+      "source_mrd": "KIS-KNOW-CON-CTR-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-dep-003",
+      "enforcement": "validator",
+      "id": "KIS-MRD-DEP-003",
+      "kind": "rule",
+      "page": "006-dependency-rules.md",
+      "source_mrd": "KIS-KNOW-CON-CTR-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-dep-004",
+      "enforcement": "validator",
+      "id": "KIS-MRD-DEP-004",
+      "kind": "rule",
+      "page": "006-dependency-rules.md",
+      "source_mrd": "KIS-KNOW-CON-CTR-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-dep-005",
+      "enforcement": "validator",
+      "id": "KIS-MRD-DEP-005",
+      "kind": "rule",
+      "page": "006-dependency-rules.md",
+      "source_mrd": "KIS-KNOW-CON-CTR-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-dep-006",
+      "enforcement": "generator",
+      "id": "KIS-MRD-DEP-006",
+      "kind": "rule",
+      "page": "006-dependency-rules.md",
+      "source_mrd": "KIS-KNOW-CON-CTR-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-layer-001",
+      "enforcement": "validator",
+      "id": "KIS-MRD-LAYER-001",
+      "kind": "rule",
+      "page": "005-layering.md",
+      "source_mrd": "KIS-KNOW-SEM-ENUM-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-layer-002",
+      "enforcement": "validator",
+      "id": "KIS-MRD-LAYER-002",
+      "kind": "rule",
+      "page": "005-layering.md",
+      "source_mrd": "KIS-KNOW-SEM-ENUM-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-layer-003",
+      "enforcement": "review",
+      "id": "KIS-MRD-LAYER-003",
+      "kind": "rule",
+      "page": "005-layering.md",
+      "source_mrd": "KIS-KNOW-SEM-ENUM-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-life-001",
+      "enforcement": "validator",
+      "id": "KIS-MRD-LIFE-001",
+      "kind": "rule",
+      "page": "008-lifecycle.md",
+      "source_mrd": "KIS-KNOW-WRK-STM-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-life-002",
+      "enforcement": "workflow",
+      "id": "KIS-MRD-LIFE-002",
+      "kind": "rule",
+      "page": "008-lifecycle.md",
+      "source_mrd": "KIS-KNOW-WRK-STM-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-life-003",
+      "enforcement": "generator",
+      "id": "KIS-MRD-LIFE-003",
+      "kind": "rule",
+      "page": "008-lifecycle.md",
+      "source_mrd": "KIS-KNOW-WRK-STM-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-life-004",
+      "enforcement": "generator",
+      "id": "KIS-MRD-LIFE-004",
+      "kind": "rule",
+      "page": "008-lifecycle.md",
+      "source_mrd": "KIS-KNOW-WRK-STM-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-life-005",
+      "enforcement": "validator",
+      "id": "KIS-MRD-LIFE-005",
+      "kind": "rule",
+      "page": "008-lifecycle.md",
+      "source_mrd": "KIS-KNOW-WRK-STM-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-life-006",
+      "enforcement": "review",
+      "id": "KIS-MRD-LIFE-006",
+      "kind": "rule",
+      "page": "008-lifecycle.md",
+      "source_mrd": "KIS-KNOW-WRK-STM-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-own-001",
+      "enforcement": "review",
+      "id": "KIS-MRD-OWN-001",
+      "kind": "rule",
+      "page": "004-authority-ownership-and-relationships.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-own-002",
+      "enforcement": "review",
+      "id": "KIS-MRD-OWN-002",
+      "kind": "rule",
+      "page": "004-authority-ownership-and-relationships.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-own-003",
+      "enforcement": "generator",
+      "id": "KIS-MRD-OWN-003",
+      "kind": "rule",
+      "page": "004-authority-ownership-and-relationships.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-own-004",
+      "enforcement": "validator",
+      "id": "KIS-MRD-OWN-004",
+      "kind": "rule",
+      "page": "004-authority-ownership-and-relationships.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-own-005",
+      "enforcement": "workflow",
+      "id": "KIS-MRD-OWN-005",
+      "kind": "rule",
+      "page": "004-authority-ownership-and-relationships.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-own-006",
+      "enforcement": "validator",
+      "id": "KIS-MRD-OWN-006",
+      "kind": "rule",
+      "page": "004-authority-ownership-and-relationships.md",
+      "source_mrd": "KIS-KNOW-CON-POL-002",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-prov-001",
+      "enforcement": "validator",
+      "id": "KIS-MRD-PROV-001",
+      "kind": "rule",
+      "page": "007-provenance.md",
+      "source_mrd": "KIS-KNOW-CON-POL-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-prov-002",
+      "enforcement": "workflow",
+      "id": "KIS-MRD-PROV-002",
+      "kind": "rule",
+      "page": "007-provenance.md",
+      "source_mrd": "KIS-KNOW-CON-POL-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-prov-003",
+      "enforcement": "workflow",
+      "id": "KIS-MRD-PROV-003",
+      "kind": "rule",
+      "page": "007-provenance.md",
+      "source_mrd": "KIS-KNOW-CON-POL-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-prov-004",
+      "enforcement": "validator",
+      "id": "KIS-MRD-PROV-004",
+      "kind": "rule",
+      "page": "007-provenance.md",
+      "source_mrd": "KIS-KNOW-CON-POL-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-prov-005",
+      "enforcement": "generator",
+      "id": "KIS-MRD-PROV-005",
+      "kind": "rule",
+      "page": "007-provenance.md",
+      "source_mrd": "KIS-KNOW-CON-POL-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-prov-006",
+      "enforcement": "validator",
+      "id": "KIS-MRD-PROV-006",
+      "kind": "rule",
+      "page": "007-provenance.md",
+      "source_mrd": "KIS-KNOW-CON-POL-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-prov-007",
+      "enforcement": "review",
+      "id": "KIS-MRD-PROV-007",
+      "kind": "rule",
+      "page": "007-provenance.md",
+      "source_mrd": "KIS-KNOW-CON-POL-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-prov-008",
+      "enforcement": "validator",
+      "id": "KIS-MRD-PROV-008",
+      "kind": "rule",
+      "page": "007-provenance.md",
+      "source_mrd": "KIS-KNOW-CON-POL-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-val-001",
+      "enforcement": "validator",
+      "id": "KIS-MRD-VAL-001",
+      "kind": "rule",
+      "page": "010-validation-and-enforcement.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001",
+      "source_version": "2.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-val-002",
+      "enforcement": "validator",
+      "id": "KIS-MRD-VAL-002",
+      "kind": "rule",
+      "page": "010-validation-and-enforcement.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001",
+      "source_version": "2.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-val-003",
+      "enforcement": "validator",
+      "id": "KIS-MRD-VAL-003",
+      "kind": "rule",
+      "page": "010-validation-and-enforcement.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001",
+      "source_version": "2.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-val-004",
+      "enforcement": "schema",
+      "id": "KIS-MRD-VAL-004",
+      "kind": "rule",
+      "page": "010-validation-and-enforcement.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001",
+      "source_version": "2.0.0"
+    },
+    {
+      "anchor": "rule-kis-mrd-val-005",
+      "enforcement": "validator",
+      "id": "KIS-MRD-VAL-005",
+      "kind": "rule",
+      "page": "010-validation-and-enforcement.md",
+      "source_mrd": "KIS-KNOW-EVL-TST-001",
+      "source_version": "2.0.0"
+    },
+    {
+      "anchor": "rule-kis-op-gov-001",
+      "enforcement": "workflow",
+      "id": "KIS-OP-GOV-001",
+      "kind": "rule",
+      "page": "009-kis-op-governance-behavior.md",
+      "source_mrd": "KIS-KNOW-WRK-WFL-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-op-gov-002",
+      "enforcement": "workflow",
+      "id": "KIS-OP-GOV-002",
+      "kind": "rule",
+      "page": "009-kis-op-governance-behavior.md",
+      "source_mrd": "KIS-KNOW-WRK-WFL-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-op-gov-003",
+      "enforcement": "review",
+      "id": "KIS-OP-GOV-003",
+      "kind": "rule",
+      "page": "009-kis-op-governance-behavior.md",
+      "source_mrd": "KIS-KNOW-WRK-WFL-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-op-gov-004",
+      "enforcement": "workflow",
+      "id": "KIS-OP-GOV-004",
+      "kind": "rule",
+      "page": "009-kis-op-governance-behavior.md",
+      "source_mrd": "KIS-KNOW-WRK-WFL-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-op-gov-005",
+      "enforcement": "generator",
+      "id": "KIS-OP-GOV-005",
+      "kind": "rule",
+      "page": "009-kis-op-governance-behavior.md",
+      "source_mrd": "KIS-KNOW-WRK-WFL-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-op-gov-006",
+      "enforcement": "workflow",
+      "id": "KIS-OP-GOV-006",
+      "kind": "rule",
+      "page": "009-kis-op-governance-behavior.md",
+      "source_mrd": "KIS-KNOW-WRK-WFL-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "rule-kis-op-gov-007",
+      "enforcement": "review",
+      "id": "KIS-OP-GOV-007",
+      "kind": "rule",
+      "page": "009-kis-op-governance-behavior.md",
+      "source_mrd": "KIS-KNOW-WRK-WFL-001",
+      "source_version": "1.0.0"
+    }
+  ],
+  "family": "governance-spec",
+  "schema_version": 1
+}

--- a/generated/governance-spec/manifest.json
+++ b/generated/governance-spec/manifest.json
@@ -1,79 +1,79 @@
 {
-  "bundle_sha256": "870c90bd4e25ebd3a8b59860aa5b953ad8f82fbe9af770215c7c293d0cad4e51",
+  "bundle_sha256": "9a0238ce5f870591dd277905beb1a8bc0e1303f9ae16448ddf4b5f7e7ab7d7f4",
   "contract": {
     "name": "kis-governance-spec-build",
     "version": 2
   },
   "files": [
     {
-      "bytes": 1136,
+      "bytes": 1187,
       "path": "000-index.md",
-      "sha256": "b2eeeb2e0c37b525977c096271d8f92da16bb8dae78375178130e44ed370855e"
+      "sha256": "b7f5e7732c82f3941d7cd5b751ebcf9710eba3a290071cbf504aaf367dcd02f0"
     },
     {
-      "bytes": 2393,
+      "bytes": 2465,
       "path": "001-specification.md",
-      "sha256": "493d4e4d8d37f8e929eb66cb4c7abb7c43520a2037e510ca737ba3b94e4ea592"
+      "sha256": "02737a117e86a9d3c0b9c2d1ff8d6286c5b44d5567dfb0c8774c2b64df71418a"
     },
     {
-      "bytes": 5969,
+      "bytes": 6179,
       "path": "002-classification.md",
-      "sha256": "a1fa5817420423e624183934877b6c1ef6c3371cba9dbe7174be37335495d1c1"
+      "sha256": "8106c7869f6812169a2cdf624490aa1b3cefca530d4715d326dc076d125dc1eb"
     },
     {
-      "bytes": 3474,
+      "bytes": 3714,
       "path": "003-applicability-and-selection.md",
-      "sha256": "ca9c10eaf3fb0720c675f4181297447efde0aa7b6d7e814180fbc7ae88511f05"
+      "sha256": "958266b8c26302d6b4aa3e5ad213e47b95b9c5d50235e8f3249cede17c8d6b88"
     },
     {
-      "bytes": 3059,
+      "bytes": 3858,
       "path": "004-authority-ownership-and-relationships.md",
-      "sha256": "ea3699a7f2779bc4772da7565edff352af467e32b7d03673ac59a1e7af96e83b"
+      "sha256": "ade31d51ad798e8bc5980eba165eac08b98015d4d30b4273bdaf19157bab4c12"
     },
     {
-      "bytes": 2209,
+      "bytes": 2335,
       "path": "005-layering.md",
-      "sha256": "0fa985ad5b1c2ff9c6efd4e7b2c53f43e1584cd63286e7066ce49ad2c78c9936"
+      "sha256": "60943494fc182a291a196e2e4e41cb58a58acafae58a168918b34bcfb204f075"
     },
     {
-      "bytes": 1931,
+      "bytes": 2171,
       "path": "006-dependency-rules.md",
-      "sha256": "5ad27a3aaf685797dc168d3409081324af80cb60d9ea0a15981302b627cece25"
+      "sha256": "7d87e8f23047d3879cb1230ef4350ecb962b907b368a9d2148321322812e95b2"
     },
     {
-      "bytes": 3473,
+      "bytes": 3801,
       "path": "007-provenance.md",
-      "sha256": "8e7f0a1b6cabc658c35708fc68a1a721a745a48ed593778fd0aeabd47beb13be"
+      "sha256": "80a9718779474d144203b90633f85eb560aa535fb21ebd556232742dfa1e39b4"
     },
     {
-      "bytes": 2159,
+      "bytes": 3124,
       "path": "008-lifecycle.md",
-      "sha256": "19993df77ba1fc6c934d77a7fc9a5c4a69c3c32c7a776ae36203ee604972a809"
+      "sha256": "559b1aea3d3c7cb3be546a12ca2c07fc8ffaae188a176c4ef93f41c2f81df352"
     },
     {
-      "bytes": 4449,
+      "bytes": 4722,
       "path": "009-kis-op-governance-behavior.md",
-      "sha256": "20fbda031c565e4a90717b647801f9d1741475cd1f2b10b07f121f7914b2cb30"
+      "sha256": "4fbdc6d977f92c520ba78bdfd9134579b2db56aecb64105a1da381114d3795da"
     },
     {
-      "bytes": 4638,
+      "bytes": 4838,
       "path": "010-validation-and-enforcement.md",
-      "sha256": "913ace4a35c21373aba252644cb882c30864d52ead872c2e7aba592b51b0fff7"
+      "sha256": "7ddb872cc4f2ac4cc3fe6537cbe76c0d44ccafc482e33b54b6bbe87711645a1a"
     },
     {
-      "bytes": 6702,
+      "bytes": 8822,
       "path": "020-applicability-catalog.md",
-      "sha256": "8a2db845f02852d97015218c1f491b7c5e793e62aa2c257113896a13c0d603b4"
+      "sha256": "687491d5dc476c001165377e213ebbe7923f75246186ad55c0ce7fdcaffdd4c0"
     },
     {
-      "bytes": 1684,
+      "bytes": 2192,
       "path": "021-relationship-vocabulary.md",
-      "sha256": "f77e03b1e428581e9b78d7b9819946c6e7dfe1c8f9d48461cac1bc37c0dec923"
+      "sha256": "59a88fb9f30b4075d94eb7be6eff8b88acaf034a12612d9d4480e740f7d67785"
     },
     {
-      "bytes": 1556,
+      "bytes": 3316,
       "path": "022-validation-reason-codes.md",
-      "sha256": "5491e14b9f6dcfd4d1a71b8cfd8e1d598bcba974dd947d114f77a36be839114e"
+      "sha256": "3d3a189e39bde7d8647485cba8ec818b6e5c983814b7d7e3619664064ca91b58"
     },
     {
       "bytes": 3963,
@@ -86,9 +86,14 @@
       "sha256": "591543630492d656a7f5b8906d060e4f19dd055ba2149044d4657b0af9731534"
     },
     {
-      "bytes": 2393,
+      "bytes": 33783,
+      "path": "data/semantic-coverage.json",
+      "sha256": "4c5c054ce93aecf528f8106cf1be2a74982ebcfd58f64433e75a638428d3f55d"
+    },
+    {
+      "bytes": 2465,
       "path": "specification.md",
-      "sha256": "493d4e4d8d37f8e929eb66cb4c7abb7c43520a2037e510ca737ba3b94e4ea592"
+      "sha256": "02737a117e86a9d3c0b9c2d1ff8d6286c5b44d5567dfb0c8774c2b64df71418a"
     }
   ],
   "generator": {
@@ -117,7 +122,7 @@
       },
       {
         "path": "src/kis_mcp_doc/render.py",
-        "sha256": "34f2430f0ea41d8b681547414c58a738349925f4ce5cb30a2a51fe0495fc2bae"
+        "sha256": "9e7040e8977737e5f40e7557b5e199bd5aca6d7d83c61551271101d074f9c066"
       },
       {
         "path": "contracts/publication/v2/governance-spec.schema.json",

--- a/generated/governance-spec/specification.md
+++ b/generated/governance-spec/specification.md
@@ -38,4 +38,4 @@ Substantive changes are made in the owning MRD, contract, schema, code, configur
 
 ## Traceability
 
-See the [documentation index](000-index.md), [MRD index](data/mrd-index.json), [dependency map](data/dependency-map.json), and [build manifest](manifest.json) for exact source identities, hashes, and generated-file declarations.
+See the [documentation index](000-index.md), [MRD index](data/mrd-index.json), [dependency map](data/dependency-map.json), [semantic coverage](data/semantic-coverage.json), and [build manifest](manifest.json) for exact source identities, page/anchor mappings, hashes, and generated-file declarations.

--- a/generated/work-management-spec/000-index.md
+++ b/generated/work-management-spec/000-index.md
@@ -23,4 +23,5 @@ The validated Work Management MRDs remain authoritative. These pages are determi
 
 ## Traceability
 
+- [Semantic coverage](data/semantic-coverage.json) — canonical MRD and fact-to-page/anchor mappings
 - [Build manifest](manifest.json) — exact MRD and generated-file hashes

--- a/generated/work-management-spec/001-specification.md
+++ b/generated/work-management-spec/001-specification.md
@@ -46,4 +46,4 @@ The captured live GitHub Project evidence is observed. Inventory is complete, an
 
 ## Traceability
 
-See the [documentation index](000-index.md) and [build manifest](manifest.json) for exact source identities, MRD versions, hashes, and generated-file declarations.
+See the [documentation index](000-index.md), [semantic coverage](data/semantic-coverage.json), and [build manifest](manifest.json) for exact source identities, MRD versions, page/anchor mappings, hashes, and generated-file declarations.

--- a/generated/work-management-spec/002-work-management-domain-model.md
+++ b/generated/work-management-spec/002-work-management-domain-model.md
@@ -5,6 +5,8 @@
 
 [Previous: Specification](001-specification.md) | [Next: Work lifecycle](003-work-lifecycle.md) | [Index](000-index.md)
 
+<span id="mrd-kis-work-sem-reg-001"></span>
+
 Work Management describes each work record through a single field model with explicit authority direction. The important distinction is not where a field is displayed, but which system may change it and whether the value is commanded, observed, or handed off to another authority.
 
 ## Authority directions

--- a/generated/work-management-spec/003-work-lifecycle.md
+++ b/generated/work-management-spec/003-work-lifecycle.md
@@ -5,7 +5,118 @@
 
 [Previous: Work Management domain model](002-work-management-domain-model.md) | [Next: Work operations](004-work-operations.md) | [Index](000-index.md)
 
+<span id="mrd-kis-work-wrk-stm-001"></span>
+
 A work item moves through explicit states. Project-visible states describe the shared work queue, while internal states such as Review, Verification, and Documentation describe delivery activity without creating new GitHub Project status values.
+
+## Work status and delivery stage
+
+Work Status and Delivery Stage are separate dimensions. The diagram shows the canonical Work lifecycle graph and Delivery Stage sequence independently; it does not map a work state to a delivery stage.
+
+```mermaid
+flowchart LR
+  subgraph work_status["Work Status"]
+    status_inbox["Inbox"]
+    status_triage["Triage"]
+    status_proposed["Proposed"]
+    status_approved["Approved"]
+    status_ready["Ready"]
+    status_active["Active"]
+    status_review["Review (internal)"]
+    status_verification["Verification (internal)"]
+    status_documentation["Documentation (internal)"]
+    status_blocked["Blocked"]
+    status_on_hold["On Hold"]
+    status_deferred["Deferred"]
+    status_rejected["Rejected"]
+    status_superseded["Superseded"]
+    status_done["Done"]
+    status_active --> status_ready
+    status_active --> status_review
+    status_active --> status_blocked
+    status_active --> status_on_hold
+    status_active --> status_deferred
+    status_active --> status_done
+    status_active --> status_superseded
+    status_approved --> status_ready
+    status_approved --> status_active
+    status_approved --> status_on_hold
+    status_approved --> status_deferred
+    status_approved --> status_superseded
+    status_blocked --> status_ready
+    status_blocked --> status_active
+    status_blocked --> status_on_hold
+    status_blocked --> status_deferred
+    status_blocked --> status_superseded
+    status_deferred --> status_triage
+    status_deferred --> status_proposed
+    status_deferred --> status_approved
+    status_deferred --> status_rejected
+    status_deferred --> status_superseded
+    status_documentation --> status_done
+    status_documentation --> status_active
+    status_documentation --> status_blocked
+    status_documentation --> status_superseded
+    status_inbox --> status_triage
+    status_inbox --> status_deferred
+    status_inbox --> status_rejected
+    status_inbox --> status_superseded
+    status_on_hold --> status_ready
+    status_on_hold --> status_active
+    status_on_hold --> status_deferred
+    status_on_hold --> status_rejected
+    status_on_hold --> status_superseded
+    status_proposed --> status_approved
+    status_proposed --> status_deferred
+    status_proposed --> status_rejected
+    status_proposed --> status_superseded
+    status_ready --> status_active
+    status_ready --> status_on_hold
+    status_ready --> status_deferred
+    status_ready --> status_superseded
+    status_rejected --> status_triage
+    status_rejected --> status_superseded
+    status_review --> status_active
+    status_review --> status_verification
+    status_review --> status_blocked
+    status_review --> status_on_hold
+    status_review --> status_superseded
+    status_triage --> status_proposed
+    status_triage --> status_approved
+    status_triage --> status_deferred
+    status_triage --> status_rejected
+    status_triage --> status_superseded
+    status_verification --> status_active
+    status_verification --> status_documentation
+    status_verification --> status_blocked
+    status_verification --> status_superseded
+  end
+  subgraph delivery_stage["Delivery Stage"]
+    stage_none["none"]
+    stage_change_created["change_created"]
+    stage_implementing["implementing"]
+    stage_pr_open["pr_open"]
+    stage_review["review"]
+    stage_ci_pending["ci_pending"]
+    stage_ci_failed["ci_failed"]
+    stage_ci_passed["ci_passed"]
+    stage_merged["merged"]
+    stage_documentation["documentation"]
+    stage_commissioning["commissioning"]
+    stage_complete["complete"]
+    stage_none --> stage_change_created
+    stage_change_created --> stage_implementing
+    stage_implementing --> stage_pr_open
+    stage_pr_open --> stage_review
+    stage_review --> stage_ci_pending
+    stage_ci_pending --> stage_ci_failed
+    stage_ci_failed --> stage_ci_passed
+    stage_ci_passed --> stage_merged
+    stage_merged --> stage_documentation
+    stage_documentation --> stage_commissioning
+    stage_commissioning --> stage_complete
+  end
+```
 
 ## State model
 
@@ -26,6 +137,22 @@ A work item moves through explicit states. Project-visible states describe the s
 | Rejected | Not accepted for execution in current form. | Yes | `rejected` |
 | Superseded | Replaced by newer authoritative work. | Yes | `superseded` |
 | Done | Required completion gates are satisfied. | Yes | `done` |
+
+<span id="fact-work-state-inbox"></span>
+<span id="fact-work-state-triage"></span>
+<span id="fact-work-state-proposed"></span>
+<span id="fact-work-state-approved"></span>
+<span id="fact-work-state-ready"></span>
+<span id="fact-work-state-active"></span>
+<span id="fact-work-state-review"></span>
+<span id="fact-work-state-verification"></span>
+<span id="fact-work-state-documentation"></span>
+<span id="fact-work-state-blocked"></span>
+<span id="fact-work-state-on-hold"></span>
+<span id="fact-work-state-deferred"></span>
+<span id="fact-work-state-rejected"></span>
+<span id="fact-work-state-superseded"></span>
+<span id="fact-work-state-done"></span>
 
 ## Transitions
 
@@ -65,7 +192,7 @@ At intake, the alias `todo` is normalized to `inbox`.
 
 Delivery is tracked separately from the work state. The configured delivery-stage sequence is:
 
-`none`, `change_created`, `implementing`, `pr_open`, `review`, `ci_pending`, `ci_failed`, `ci_passed`, `merged`, `documentation`, `commissioning`, `complete`
+<span id="fact-delivery-stage-none"></span>`none`, <span id="fact-delivery-stage-change-created"></span>`change_created`, <span id="fact-delivery-stage-implementing"></span>`implementing`, <span id="fact-delivery-stage-pr-open"></span>`pr_open`, <span id="fact-delivery-stage-review"></span>`review`, <span id="fact-delivery-stage-ci-pending"></span>`ci_pending`, <span id="fact-delivery-stage-ci-failed"></span>`ci_failed`, <span id="fact-delivery-stage-ci-passed"></span>`ci_passed`, <span id="fact-delivery-stage-merged"></span>`merged`, <span id="fact-delivery-stage-documentation"></span>`documentation`, <span id="fact-delivery-stage-commissioning"></span>`commissioning`, <span id="fact-delivery-stage-complete"></span>`complete`
 
 The **Delivery Stage** field stores that stage. **Change ID**, **Complexity**, and **Risk Triggers** connect the work record to repository change governance. The sequence starts its governed change at `change_created` and reaches `complete` when delivery is complete.
 

--- a/generated/work-management-spec/004-work-operations.md
+++ b/generated/work-management-spec/004-work-operations.md
@@ -5,6 +5,8 @@
 
 [Previous: Work lifecycle](003-work-lifecycle.md) | [Next: Next-work selection](005-next-work-selection.md) | [Index](000-index.md)
 
+<span id="mrd-kis-work-wrk-wfl-001"></span>
+
 Work Management exposes a bounded set of operations for intake, claiming, state changes, verification, and post-merge commissioning. Each operation has a defined effect and implementation surface so callers can distinguish reads from mutations and evidence collection.
 
 ## Mutation safety

--- a/generated/work-management-spec/005-next-work-selection.md
+++ b/generated/work-management-spec/005-next-work-selection.md
@@ -5,6 +5,8 @@
 
 [Previous: Work operations](004-work-operations.md) | [Next: Authority and reconciliation policy](006-authority-and-reconciliation-policy.md) | [Index](000-index.md)
 
+<span id="mrd-kis-work-dec-scr-001"></span>
+
 Selection is deterministic. Work Management first applies the eligibility rules for the active profile, then ranks only the candidates that remain.
 
 ## Selection procedure
@@ -40,18 +42,19 @@ Profiles reuse the same rule catalog but apply different subsets and preserve pr
 
 | Rule | Kind | Requirement | Failure reason |
 |---|---|---|---|
-| `SEL-001` | `source_issue` | Only issue records are eligible in the provider-backed next-work queue. | `not_issue` |
-| `SEL-002` | `source_open` | Provider-backed source issues must remain open. | `source_not_open` |
-| `SEL-003` | `project_match` | Normalized-domain selection respects an explicit project scope. | `project_mismatch` |
-| `SEL-004` | `eligible_state` | Candidate state must be one of the configured eligible states; domain adapters may preserve their existing equivalent reason code. | `state_not_ready` |
-| `SEL-005` | `valid_priority` | Priority must be present in the canonical priority order. | `missing_or_invalid:{field}` |
-| `SEL-006` | `valid_effort` | Effort must be present in the canonical effort order. | `missing_or_invalid:{field}` |
-| `SEL-007` | `required_fields` | Configured readiness fields must be present before provider-backed selection. | `missing_required:{field}` |
-| `SEL-008` | `unclaimed` | Already claimed work is excluded from next-work selection. | `already_claimed:{owner}` |
-| `SEL-009` | `approval_complete` | Normalized-domain records that require approval must have completed approval. | `approval_incomplete` |
-| `SEL-010` | `dependency_evidence` | Required provider dependency evidence must be observable. | `dependency_evidence_unavailable` |
-| `SEL-011` | `dependencies_clear` | Provider-native blocker evidence must be empty; normalized-domain adapters preserve dependency-specific reason codes. | `native_dependency_blocking` |
-| `SEL-012` | `ranking` | Eligible candidates rank by Priority, Effort, creation order, then stable record identity. | None |
+| <span id="fact-selection-rule-sel-001"></span>`SEL-001` | `source_issue` | Only issue records are eligible in the provider-backed next-work queue. | `not_issue` |
+| <span id="fact-selection-rule-sel-002"></span>`SEL-002` | `source_open` | Provider-backed source issues must remain open. | `source_not_open` |
+| <span id="fact-selection-rule-sel-003"></span>`SEL-003` | `project_match` | Normalized-domain selection respects an explicit project scope. | `project_mismatch` |
+| <span id="fact-selection-rule-sel-004"></span>`SEL-004` | `eligible_state` | Candidate state must be one of the configured eligible states; domain adapters may preserve their existing equivalent reason code. | `state_not_ready` |
+| <span id="fact-selection-rule-sel-005"></span>`SEL-005` | `valid_priority` | Priority must be present in the canonical priority order. | `missing_or_invalid:{field}` |
+| <span id="fact-selection-rule-sel-006"></span>`SEL-006` | `valid_effort` | Effort must be present in the canonical effort order. | `missing_or_invalid:{field}` |
+| <span id="fact-selection-rule-sel-007"></span>`SEL-007` | `required_fields` | Configured readiness fields must be present before provider-backed selection. | `missing_required:{field}` |
+| <span id="fact-selection-rule-sel-008"></span>`SEL-008` | `unclaimed` | Already claimed work is excluded from next-work selection. | `already_claimed:{owner}` |
+| <span id="fact-selection-rule-sel-009"></span>`SEL-009` | `approval_complete` | Normalized-domain records that require approval must have completed approval. | `approval_incomplete` |
+| <span id="fact-selection-rule-sel-010"></span>`SEL-010` | `dependency_evidence` | Required provider dependency evidence must be observable. | `dependency_evidence_unavailable` |
+| <span id="fact-selection-rule-sel-011"></span>`SEL-011` | `dependencies_clear` | Provider-native blocker evidence must be empty; normalized-domain adapters preserve dependency-specific reason codes. | `native_dependency_blocking` |
+| <span id="fact-selection-rule-sel-012"></span>`SEL-012` | `ranking` | Eligible candidates rank by Priority, Effort, creation order, then stable record identity. | None |
+
 
 ## Source and authority
 

--- a/generated/work-management-spec/006-authority-and-reconciliation-policy.md
+++ b/generated/work-management-spec/006-authority-and-reconciliation-policy.md
@@ -5,6 +5,8 @@
 
 [Previous: Next-work selection](005-next-work-selection.md) | [Next: Provider and command-plane boundary](007-provider-and-command-plane-boundary.md) | [Index](000-index.md)
 
+<span id="mrd-kis-work-con-pol-001"></span>
+
 Authority determines which system may change a fact. Reconciliation compares observed provider state with those owners and surfaces drift rather than choosing a new truth. Generated documentation remains downstream of every canonical source.
 
 ## Authority principles

--- a/generated/work-management-spec/007-provider-and-command-plane-boundary.md
+++ b/generated/work-management-spec/007-provider-and-command-plane-boundary.md
@@ -5,7 +5,37 @@
 
 [Previous: Authority and reconciliation policy](006-authority-and-reconciliation-policy.md) | [Next: Work Management conformance](008-work-management-conformance.md) | [Index](000-index.md)
 
+<span id="mrd-kis-work-ctr-svc-001"></span>
+
 The command plane defines the work states and fields that KIS may change. The provider boundary observes and mutates GitHub Project only through the configured read and write models; provider state does not redefine repository-owned facts.
+
+## Authority and handoff flow
+
+Each arrow is derived from the provider-boundary field-authority contract. Labels name the fields carried in that authority direction.
+
+```mermaid
+flowchart LR
+  command["Command"]
+  evidence["Evidence"]
+  handoff["Handoff"]
+  owner_0["actions"] -->|"1 field"| evidence
+  owner_1["derived"] -->|"5 fields"| evidence
+  owner_2["git"] -->|"1 field"| evidence
+  owner_3["github"] -->|"3 fields"| evidence
+  owner_4["repository_change"] -->|"3 fields"| evidence
+  owner_5["work_management"] -->|"14 fields"| command
+  owner_6["work_management_then_repository_change"] -->|"2 fields"| handoff
+```
+
+Diagram details:
+
+- `actions` -> `evidence`: Verification.
+- `derived` -> `evidence`: Commissioning Key, Delivery Stage, Live Verification, Live Verification Evidence, Project ID.
+- `git` -> `evidence`: Authority Revision.
+- `github` -> `evidence`: Blocked By, Created, Repository.
+- `repository_change` -> `evidence`: Change ID, Complexity, Risk Triggers.
+- `work_management` -> `command`: Confidence, Disposition, Effort, Execution Owner, External Link, Iteration, Origin, Priority, Record Type, Review Trigger, Severity, Source Review, Status, Target Date.
+- `work_management_then_repository_change` -> `handoff`: Documentation Impact, Module.
 
 ## Command-plane model
 

--- a/generated/work-management-spec/008-work-management-conformance.md
+++ b/generated/work-management-spec/008-work-management-conformance.md
@@ -5,6 +5,8 @@
 
 [Previous: Provider and command-plane boundary](007-provider-and-command-plane-boundary.md) | [Index](000-index.md)
 
+<span id="mrd-kis-work-evl-tst-001"></span>
+
 A Work Management implementation conforms to this specification only when its source MRDs, dependencies, evidence, generated views, and lifecycle behavior pass the checks below. These checks keep human-readable documentation aligned with machine-readable authority.
 
 ## Conformance requirements

--- a/generated/work-management-spec/020-work-field-and-vocabulary-reference.md
+++ b/generated/work-management-spec/020-work-field-and-vocabulary-reference.md
@@ -17,45 +17,48 @@ Work Management uses three authority directions. **Command** fields are changed 
 
 | Field | Meaning | Authority | Direction | Details |
 |---|---|---|---|---|
-| Status | Operational Work lifecycle status. Set by explicit Work lifecycle operations. | `work_management` | `command` | ID `status`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `status` |
-| Record Type | Purpose classification of the Work record. Set during intake/triage and changed only by explicit Work authority. | `work_management` | `command` | ID `record_type`; provider `single_select`; KIS-managed; applies to all record types; required for `ready_metadata`; vocabulary `record_type` |
-| Priority | Relative scheduling importance. Set by Work Management and consumed by selection ranking. | `work_management` | `command` | ID `priority`; provider `single_select`; KIS-managed; applies to all record types; required for `ready_metadata`; vocabulary `priority` |
-| Effort | Relative implementation or coordination effort. Set by Work Management and consumed by selection ranking. | `work_management` | `command` | ID `effort`; provider `single_select`; KIS-managed; applies to all record types; required for `ready_metadata`; vocabulary `effort` |
-| Execution Owner | Stable identity of the current execution claimant. Set and cleared only by claim/release lifecycle operations. | `work_management` | `command` | ID `execution_owner`; provider `text`; KIS-managed; applies to all record types; required for `active_claim` |
-| Origin | Context that originated the record. Set when the Work record is created or classified. | `work_management` | `command` | ID `origin`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `origin` |
-| Disposition | Explicit decision disposition for records that use disposition semantics. Set by explicit Work decision/review operations. | `work_management` | `command` | ID `disposition`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `disposition` |
-| Severity | Relative material impact for finding/risk records. Set when a finding or risk is classified. | `work_management` | `command` | ID `severity`; provider `single_select`; KIS-managed; applies to finding, security_finding, risk; required for `finding_or_risk`; vocabulary `severity` |
-| Confidence | Evidence confidence for finding/assumption records. Set from the evidence quality supporting the record. | `work_management` | `command` | ID `confidence`; provider `single_select`; KIS-managed; applies to finding, security_finding, assumption; required for `finding_or_assumption`; vocabulary `confidence` |
-| Review Trigger | Condition or date/event trigger for reconsidering paused work. Required when work enters On Hold or Deferred. | `work_management` | `command` | ID `review_trigger`; provider `text`; KIS-managed; applies to all record types; required for `hold_or_defer` |
-| Target Date | Optional target date for planned work or reconsideration. Set explicitly by Work Management. | `work_management` | `command` | ID `target_date`; provider `date`; KIS-managed; applies to all record types |
-| Iteration | Optional provider iteration assignment. Set explicitly by Work Management. | `work_management` | `command` | ID `iteration`; provider `iteration`; KIS-managed; applies to all record types |
-| Source Review | Reference to the review source that produced or governs the record. Set when review-derived records are captured. | `work_management` | `command` | ID `source_review`; provider `text`; KIS-managed; applies to all record types |
-| External Link | Optional bounded external reference associated with the work. Set explicitly by Work Management. | `work_management` | `command` | ID `external_link`; provider `text`; KIS-managed; applies to all record types |
+| <span id="fact-field-status"></span>Status | Operational Work lifecycle status. Set by explicit Work lifecycle operations. | `work_management` | `command` | ID `status`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `status` |
+| <span id="fact-field-record-type"></span>Record Type | Purpose classification of the Work record. Set during intake/triage and changed only by explicit Work authority. | `work_management` | `command` | ID `record_type`; provider `single_select`; KIS-managed; applies to all record types; required for `ready_metadata`; vocabulary `record_type` |
+| <span id="fact-field-priority"></span>Priority | Relative scheduling importance. Set by Work Management and consumed by selection ranking. | `work_management` | `command` | ID `priority`; provider `single_select`; KIS-managed; applies to all record types; required for `ready_metadata`; vocabulary `priority` |
+| <span id="fact-field-effort"></span>Effort | Relative implementation or coordination effort. Set by Work Management and consumed by selection ranking. | `work_management` | `command` | ID `effort`; provider `single_select`; KIS-managed; applies to all record types; required for `ready_metadata`; vocabulary `effort` |
+| <span id="fact-field-execution-owner"></span>Execution Owner | Stable identity of the current execution claimant. Set and cleared only by claim/release lifecycle operations. | `work_management` | `command` | ID `execution_owner`; provider `text`; KIS-managed; applies to all record types; required for `active_claim` |
+| <span id="fact-field-origin"></span>Origin | Context that originated the record. Set when the Work record is created or classified. | `work_management` | `command` | ID `origin`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `origin` |
+| <span id="fact-field-disposition"></span>Disposition | Explicit decision disposition for records that use disposition semantics. Set by explicit Work decision/review operations. | `work_management` | `command` | ID `disposition`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `disposition` |
+| <span id="fact-field-severity"></span>Severity | Relative material impact for finding/risk records. Set when a finding or risk is classified. | `work_management` | `command` | ID `severity`; provider `single_select`; KIS-managed; applies to finding, security_finding, risk; required for `finding_or_risk`; vocabulary `severity` |
+| <span id="fact-field-confidence"></span>Confidence | Evidence confidence for finding/assumption records. Set from the evidence quality supporting the record. | `work_management` | `command` | ID `confidence`; provider `single_select`; KIS-managed; applies to finding, security_finding, assumption; required for `finding_or_assumption`; vocabulary `confidence` |
+| <span id="fact-field-review-trigger"></span>Review Trigger | Condition or date/event trigger for reconsidering paused work. Required when work enters On Hold or Deferred. | `work_management` | `command` | ID `review_trigger`; provider `text`; KIS-managed; applies to all record types; required for `hold_or_defer` |
+| <span id="fact-field-target-date"></span>Target Date | Optional target date for planned work or reconsideration. Set explicitly by Work Management. | `work_management` | `command` | ID `target_date`; provider `date`; KIS-managed; applies to all record types |
+| <span id="fact-field-iteration"></span>Iteration | Optional provider iteration assignment. Set explicitly by Work Management. | `work_management` | `command` | ID `iteration`; provider `iteration`; KIS-managed; applies to all record types |
+| <span id="fact-field-source-review"></span>Source Review | Reference to the review source that produced or governs the record. Set when review-derived records are captured. | `work_management` | `command` | ID `source_review`; provider `text`; KIS-managed; applies to all record types |
+| <span id="fact-field-external-link"></span>External Link | Optional bounded external reference associated with the work. Set explicitly by Work Management. | `work_management` | `command` | ID `external_link`; provider `text`; KIS-managed; applies to all record types |
+
 
 ### Evidence fields
 
 | Field | Meaning | Authority | Direction | Details |
 |---|---|---|---|---|
-| Delivery Stage | Evidence-derived governed delivery stage. Projected from repository/GitHub delivery evidence. | `derived` | `evidence` | ID `delivery_stage`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `delivery_stage` |
-| Blocked By | Provider-observed dependency or blocker reference; explicit empty differs from unavailable evidence. Read from GitHub Project dependency evidence. | `github` | `evidence` | ID `blocked_by`; provider `text`; KIS-managed; applies to all record types |
-| Complexity | Repository change-governance complexity projected into Work. Projected from authoritative schema-v4 governed change scope. | `repository_change` | `evidence` | ID `complexity`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `complexity` |
-| Risk Triggers | Comma-separated repository change-governance risk-trigger tokens. Projected from authoritative governed change scope. | `repository_change` | `evidence` | ID `risk_triggers`; provider `text`; KIS-managed; applies to all record types |
-| Project ID | Stable KIS project registry identity for the work item. Derived from the registered repository-to-project mapping. | `derived` | `evidence` | ID `project_id`; provider `text`; KIS-managed; applies to all record types |
-| Repository | GitHub repository identity of the source item. Read from the GitHub source item/provider binding. | `github` | `evidence` | ID `repository`; provider `repository`; KIS-managed; applies to all record types |
-| Change ID | Canonical governed repository change ID once one exists. Projected from authoritative local change scope. | `repository_change` | `evidence` | ID `change_id`; provider `text`; KIS-managed; applies to all record types; required for `governed_change` |
-| Verification | Repository/source verification state; never live-runtime commissioning state. Projected from provider-native or governed verification evidence. | `actions` | `evidence` | ID `verification`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `verification` |
-| Authority Revision | Revision identity of the authority evidence used for the Work record. Projected from Git/provider revision evidence. | `git` | `evidence` | ID `authority_revision`; provider `text`; KIS-managed; applies to all record types |
-| Created | Provider-native creation timestamp used as deterministic age evidence. Read from GitHub native item metadata. | `github` | `evidence` | ID `created`; provider `native_datetime`; provider-managed; applies to all record types |
-| Live Verification | Post-merge live runtime verification state, distinct from source Verification. Projected by the deterministic commissioning lifecycle under #419. | `derived` | `evidence` | ID `live_verification`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `live_verification` |
-| Commissioning Key | Deterministic commissioning identity: the exact obligation key for one required surface, or the deterministic set key for a source merge with multiple required surfaces. Derived by the commissioning classifier/runner under #419; source projection uses a set-<digest24> key when multiple obligations must be aggregated. | `derived` | `evidence` | ID `commissioning_key`; provider `text`; KIS-managed; applies to all record types |
-| Live Verification Evidence | Compact reference to durable live-verification evidence or linked commissioning work; never free-form logs. Projected from commissioning evidence under #419. | `derived` | `evidence` | ID `live_verification_evidence`; provider `text`; KIS-managed; applies to all record types |
+| <span id="fact-field-delivery-stage"></span>Delivery Stage | Evidence-derived governed delivery stage. Projected from repository/GitHub delivery evidence. | `derived` | `evidence` | ID `delivery_stage`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `delivery_stage` |
+| <span id="fact-field-blocked-by"></span>Blocked By | Provider-observed dependency or blocker reference; explicit empty differs from unavailable evidence. Read from GitHub Project dependency evidence. | `github` | `evidence` | ID `blocked_by`; provider `text`; KIS-managed; applies to all record types |
+| <span id="fact-field-complexity"></span>Complexity | Repository change-governance complexity projected into Work. Projected from authoritative schema-v4 governed change scope. | `repository_change` | `evidence` | ID `complexity`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `complexity` |
+| <span id="fact-field-risk-triggers"></span>Risk Triggers | Comma-separated repository change-governance risk-trigger tokens. Projected from authoritative governed change scope. | `repository_change` | `evidence` | ID `risk_triggers`; provider `text`; KIS-managed; applies to all record types |
+| <span id="fact-field-project-id"></span>Project ID | Stable KIS project registry identity for the work item. Derived from the registered repository-to-project mapping. | `derived` | `evidence` | ID `project_id`; provider `text`; KIS-managed; applies to all record types |
+| <span id="fact-field-repository"></span>Repository | GitHub repository identity of the source item. Read from the GitHub source item/provider binding. | `github` | `evidence` | ID `repository`; provider `repository`; KIS-managed; applies to all record types |
+| <span id="fact-field-change-id"></span>Change ID | Canonical governed repository change ID once one exists. Projected from authoritative local change scope. | `repository_change` | `evidence` | ID `change_id`; provider `text`; KIS-managed; applies to all record types; required for `governed_change` |
+| <span id="fact-field-verification"></span>Verification | Repository/source verification state; never live-runtime commissioning state. Projected from provider-native or governed verification evidence. | `actions` | `evidence` | ID `verification`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `verification` |
+| <span id="fact-field-authority-revision"></span>Authority Revision | Revision identity of the authority evidence used for the Work record. Projected from Git/provider revision evidence. | `git` | `evidence` | ID `authority_revision`; provider `text`; KIS-managed; applies to all record types |
+| <span id="fact-field-created"></span>Created | Provider-native creation timestamp used as deterministic age evidence. Read from GitHub native item metadata. | `github` | `evidence` | ID `created`; provider `native_datetime`; provider-managed; applies to all record types |
+| <span id="fact-field-live-verification"></span>Live Verification | Post-merge live runtime verification state, distinct from source Verification. Projected by the deterministic commissioning lifecycle under #419. | `derived` | `evidence` | ID `live_verification`; provider `single_select`; KIS-managed; applies to all record types; vocabulary `live_verification` |
+| <span id="fact-field-commissioning-key"></span>Commissioning Key | Deterministic commissioning identity: the exact obligation key for one required surface, or the deterministic set key for a source merge with multiple required surfaces. Derived by the commissioning classifier/runner under #419; source projection uses a set-<digest24> key when multiple obligations must be aggregated. | `derived` | `evidence` | ID `commissioning_key`; provider `text`; KIS-managed; applies to all record types |
+| <span id="fact-field-live-verification-evidence"></span>Live Verification Evidence | Compact reference to durable live-verification evidence or linked commissioning work; never free-form logs. Projected from commissioning evidence under #419. | `derived` | `evidence` | ID `live_verification_evidence`; provider `text`; KIS-managed; applies to all record types |
+
 
 ### Handoff fields
 
 | Field | Meaning | Authority | Direction | Details |
 |---|---|---|---|---|
-| Documentation Impact | Expected or completed documentation impact for the work/change. Starts as Work command data and becomes governed change evidence. | `work_management_then_repository_change` | `handoff` | ID `documentation_impact`; provider `single_select`; KIS-managed; applies to all record types; required for `ready_metadata`; vocabulary `documentation_impact` |
-| Module | Optional bounded module or subsystem context for the work. Set by Work and handed to governed change planning when applicable. | `work_management_then_repository_change` | `handoff` | ID `module`; provider `text`; KIS-managed; applies to all record types |
+| <span id="fact-field-documentation-impact"></span>Documentation Impact | Expected or completed documentation impact for the work/change. Starts as Work command data and becomes governed change evidence. | `work_management_then_repository_change` | `handoff` | ID `documentation_impact`; provider `single_select`; KIS-managed; applies to all record types; required for `ready_metadata`; vocabulary `documentation_impact` |
+| <span id="fact-field-module"></span>Module | Optional bounded module or subsystem context for the work. Set by Work and handed to governed change planning when applicable. | `work_management_then_repository_change` | `handoff` | ID `module`; provider `text`; KIS-managed; applies to all record types |
+
 
 ## Authority rules
 
@@ -74,18 +77,19 @@ Operational Work lifecycle status projected to GitHub Project Status.
 
 | Value | Token | Meaning |
 |---|---|---|
-| Inbox | `inbox` | Captured work not yet triaged. |
-| Triage | `triage` | Work being classified and prepared for a disposition. |
-| Proposed | `proposed` | Work proposed for acceptance but not yet approved. |
-| Approved | `approved` | Accepted work that is not yet admitted to the executable queue. |
-| Ready | `ready` | Work admitted for deterministic next-work eligibility subject to readiness, claim, and dependency guards. |
-| Active | `active` | Work currently claimed for execution. |
-| Blocked | `blocked` | Work that cannot proceed because a blocking condition is present. |
-| On Hold | `on_hold` | Work intentionally paused pending a declared review trigger. |
-| Deferred | `deferred` | Work postponed for later reconsideration with a declared review trigger. |
-| Rejected | `rejected` | Work explicitly not accepted for execution in its current form. |
-| Superseded | `superseded` | Work replaced by a newer authoritative record or outcome. |
-| Done | `done` | Work whose required completion and closeout gates are satisfied. |
+| <span id="fact-vocabulary-status-inbox"></span>Inbox | `inbox` | Captured work not yet triaged. |
+| <span id="fact-vocabulary-status-triage"></span>Triage | `triage` | Work being classified and prepared for a disposition. |
+| <span id="fact-vocabulary-status-proposed"></span>Proposed | `proposed` | Work proposed for acceptance but not yet approved. |
+| <span id="fact-vocabulary-status-approved"></span>Approved | `approved` | Accepted work that is not yet admitted to the executable queue. |
+| <span id="fact-vocabulary-status-ready"></span>Ready | `ready` | Work admitted for deterministic next-work eligibility subject to readiness, claim, and dependency guards. |
+| <span id="fact-vocabulary-status-active"></span>Active | `active` | Work currently claimed for execution. |
+| <span id="fact-vocabulary-status-blocked"></span>Blocked | `blocked` | Work that cannot proceed because a blocking condition is present. |
+| <span id="fact-vocabulary-status-on-hold"></span>On Hold | `on_hold` | Work intentionally paused pending a declared review trigger. |
+| <span id="fact-vocabulary-status-deferred"></span>Deferred | `deferred` | Work postponed for later reconsideration with a declared review trigger. |
+| <span id="fact-vocabulary-status-rejected"></span>Rejected | `rejected` | Work explicitly not accepted for execution in its current form. |
+| <span id="fact-vocabulary-status-superseded"></span>Superseded | `superseded` | Work replaced by a newer authoritative record or outcome. |
+| <span id="fact-vocabulary-status-done"></span>Done | `done` | Work whose required completion and closeout gates are satisfied. |
+
 
 ### Record type values
 
@@ -93,19 +97,20 @@ Classification of the purpose of a Work record.
 
 | Value | Token | Meaning |
 |---|---|---|
-| Idea | `idea` | Uncommitted candidate work requiring triage before it becomes actionable. |
-| Task | `task` | A bounded actionable unit of work. |
-| Specification Slice | `specification_slice` | A bounded specification or delivery slice tracked as work. |
-| Review Run | `review_run` | A record representing one review execution and its evidence. |
-| Finding | `finding` | An actionable observation produced by review, verification, audit, or commissioning. |
-| Decision | `decision` | A record of an explicit authoritative choice. |
-| Assumption | `assumption` | A proposition tracked because later evidence may validate or invalidate it. |
-| Risk | `risk` | A potential adverse condition tracked for mitigation or disposition. |
-| Approval | `approval` | A record of an explicit approval decision. |
-| Hold | `hold` | A record whose purpose is to track a pause or hold condition. |
-| Research | `research` | A bounded investigation intended to produce evidence or a decision. |
-| Defect | `defect` | A known incorrect or broken product or system behavior requiring correction. |
-| Security Finding | `security_finding` | A finding whose material impact is security-related. |
+| <span id="fact-vocabulary-record-type-idea"></span>Idea | `idea` | Uncommitted candidate work requiring triage before it becomes actionable. |
+| <span id="fact-vocabulary-record-type-task"></span>Task | `task` | A bounded actionable unit of work. |
+| <span id="fact-vocabulary-record-type-specification-slice"></span>Specification Slice | `specification_slice` | A bounded specification or delivery slice tracked as work. |
+| <span id="fact-vocabulary-record-type-review-run"></span>Review Run | `review_run` | A record representing one review execution and its evidence. |
+| <span id="fact-vocabulary-record-type-finding"></span>Finding | `finding` | An actionable observation produced by review, verification, audit, or commissioning. |
+| <span id="fact-vocabulary-record-type-decision"></span>Decision | `decision` | A record of an explicit authoritative choice. |
+| <span id="fact-vocabulary-record-type-assumption"></span>Assumption | `assumption` | A proposition tracked because later evidence may validate or invalidate it. |
+| <span id="fact-vocabulary-record-type-risk"></span>Risk | `risk` | A potential adverse condition tracked for mitigation or disposition. |
+| <span id="fact-vocabulary-record-type-approval"></span>Approval | `approval` | A record of an explicit approval decision. |
+| <span id="fact-vocabulary-record-type-hold"></span>Hold | `hold` | A record whose purpose is to track a pause or hold condition. |
+| <span id="fact-vocabulary-record-type-research"></span>Research | `research` | A bounded investigation intended to produce evidence or a decision. |
+| <span id="fact-vocabulary-record-type-defect"></span>Defect | `defect` | A known incorrect or broken product or system behavior requiring correction. |
+| <span id="fact-vocabulary-record-type-security-finding"></span>Security Finding | `security_finding` | A finding whose material impact is security-related. |
+
 
 ### Priority values
 
@@ -113,10 +118,11 @@ Relative scheduling importance used by the current deterministic Work queue.
 
 | Value | Token | Meaning |
 |---|---|---|
-| Critical | `critical` | Highest configured scheduling importance. |
-| High | `high` | High scheduling importance below Critical. |
-| Medium | `medium` | Normal scheduling importance below High. |
-| Low | `low` | Lowest configured scheduling importance. |
+| <span id="fact-vocabulary-priority-critical"></span>Critical | `critical` | Highest configured scheduling importance. |
+| <span id="fact-vocabulary-priority-high"></span>High | `high` | High scheduling importance below Critical. |
+| <span id="fact-vocabulary-priority-medium"></span>Medium | `medium` | Normal scheduling importance below High. |
+| <span id="fact-vocabulary-priority-low"></span>Low | `low` | Lowest configured scheduling importance. |
+
 
 ### Effort values
 
@@ -124,10 +130,11 @@ Relative implementation or coordination size used by the current deterministic W
 
 | Value | Token | Meaning |
 |---|---|---|
-| Tiny | `tiny` | Smallest configured relative effort. |
-| Small | `small` | Small relative effort. |
-| Medium | `medium` | Moderate relative effort. |
-| Large | `large` | Largest configured relative effort. |
+| <span id="fact-vocabulary-effort-tiny"></span>Tiny | `tiny` | Smallest configured relative effort. |
+| <span id="fact-vocabulary-effort-small"></span>Small | `small` | Small relative effort. |
+| <span id="fact-vocabulary-effort-medium"></span>Medium | `medium` | Moderate relative effort. |
+| <span id="fact-vocabulary-effort-large"></span>Large | `large` | Largest configured relative effort. |
+
 
 ### Delivery stage values
 
@@ -135,18 +142,19 @@ Evidence-derived stage of governed repository delivery.
 
 | Value | Token | Meaning |
 |---|---|---|
-| None | `none` | No governed delivery stage has been established. |
-| Change Created | `change_created` | A governed repository change has been created. |
-| Implementing | `implementing` | Implementation is in progress. |
-| PR Open | `pr_open` | A pull request is open for the governed change. |
-| Review | `review` | The governed change is in review. |
-| CI Pending | `ci_pending` | Provider-native verification is pending. |
-| CI Failed | `ci_failed` | Provider-native verification failed. |
-| CI Passed | `ci_passed` | Provider-native verification passed for the applicable head. |
-| Merged | `merged` | The governed change has been observed merged. |
-| Documentation | `documentation` | Post-merge documentation reconciliation is due or in progress. |
-| Commissioning | `commissioning` | Live verification or commissioning is pending or in progress. |
-| Complete | `complete` | Delivery and required closeout evidence are complete. |
+| <span id="fact-vocabulary-delivery-stage-none"></span>None | `none` | No governed delivery stage has been established. |
+| <span id="fact-vocabulary-delivery-stage-change-created"></span>Change Created | `change_created` | A governed repository change has been created. |
+| <span id="fact-vocabulary-delivery-stage-implementing"></span>Implementing | `implementing` | Implementation is in progress. |
+| <span id="fact-vocabulary-delivery-stage-pr-open"></span>PR Open | `pr_open` | A pull request is open for the governed change. |
+| <span id="fact-vocabulary-delivery-stage-review"></span>Review | `review` | The governed change is in review. |
+| <span id="fact-vocabulary-delivery-stage-ci-pending"></span>CI Pending | `ci_pending` | Provider-native verification is pending. |
+| <span id="fact-vocabulary-delivery-stage-ci-failed"></span>CI Failed | `ci_failed` | Provider-native verification failed. |
+| <span id="fact-vocabulary-delivery-stage-ci-passed"></span>CI Passed | `ci_passed` | Provider-native verification passed for the applicable head. |
+| <span id="fact-vocabulary-delivery-stage-merged"></span>Merged | `merged` | The governed change has been observed merged. |
+| <span id="fact-vocabulary-delivery-stage-documentation"></span>Documentation | `documentation` | Post-merge documentation reconciliation is due or in progress. |
+| <span id="fact-vocabulary-delivery-stage-commissioning"></span>Commissioning | `commissioning` | Live verification or commissioning is pending or in progress. |
+| <span id="fact-vocabulary-delivery-stage-complete"></span>Complete | `complete` | Delivery and required closeout evidence are complete. |
+
 
 ### Documentation impact values
 
@@ -154,12 +162,13 @@ Repository documentation impact projected from Work to governed change and back 
 
 | Value | Token | Meaning |
 |---|---|---|
-| Not Assessed | `not_assessed` | Documentation impact has not yet been assessed. |
-| None | `none` | No documentation change is required, with rationale recorded where required. |
-| Planned | `planned` | Documentation changes are planned. |
-| In Progress | `in_progress` | Documentation changes are being implemented. |
-| Pre-merge Complete | `pre_merge_complete` | Required pre-merge documentation work is complete. |
-| Post-merge Complete | `post_merge_complete` | Required post-merge documentation reconciliation is complete. |
+| <span id="fact-vocabulary-documentation-impact-not-assessed"></span>Not Assessed | `not_assessed` | Documentation impact has not yet been assessed. |
+| <span id="fact-vocabulary-documentation-impact-none"></span>None | `none` | No documentation change is required, with rationale recorded where required. |
+| <span id="fact-vocabulary-documentation-impact-planned"></span>Planned | `planned` | Documentation changes are planned. |
+| <span id="fact-vocabulary-documentation-impact-in-progress"></span>In Progress | `in_progress` | Documentation changes are being implemented. |
+| <span id="fact-vocabulary-documentation-impact-pre-merge-complete"></span>Pre-merge Complete | `pre_merge_complete` | Required pre-merge documentation work is complete. |
+| <span id="fact-vocabulary-documentation-impact-post-merge-complete"></span>Post-merge Complete | `post_merge_complete` | Required post-merge documentation reconciliation is complete. |
+
 
 ### Complexity values
 
@@ -167,9 +176,10 @@ Projection of repository change-governance complexity; detailed classification c
 
 | Value | Token | Meaning |
 |---|---|---|
-| Small | `small` | Repository change-governance Small classification. |
-| Medium | `medium` | Repository change-governance Medium classification. |
-| Large | `large` | Repository change-governance Large classification. |
+| <span id="fact-vocabulary-complexity-small"></span>Small | `small` | Repository change-governance Small classification. |
+| <span id="fact-vocabulary-complexity-medium"></span>Medium | `medium` | Repository change-governance Medium classification. |
+| <span id="fact-vocabulary-complexity-large"></span>Large | `large` | Repository change-governance Large classification. |
+
 
 ### Origin values
 
@@ -177,11 +187,12 @@ Source context that caused a Work record to be created.
 
 | Value | Token | Meaning |
 |---|---|---|
-| Operator | `operator` | Created directly from operator intent. |
-| Review | `review` | Created from review evidence. |
-| Verification | `verification` | Created from verification evidence. |
-| Implementation | `implementation` | Created from implementation activity or discovery. |
-| Research | `research` | Created from research activity or evidence. |
+| <span id="fact-vocabulary-origin-operator"></span>Operator | `operator` | Created directly from operator intent. |
+| <span id="fact-vocabulary-origin-review"></span>Review | `review` | Created from review evidence. |
+| <span id="fact-vocabulary-origin-verification"></span>Verification | `verification` | Created from verification evidence. |
+| <span id="fact-vocabulary-origin-implementation"></span>Implementation | `implementation` | Created from implementation activity or discovery. |
+| <span id="fact-vocabulary-origin-research"></span>Research | `research` | Created from research activity or evidence. |
+
 
 ### Disposition values
 
@@ -189,12 +200,13 @@ Current decision disposition for records that require an explicit disposition.
 
 | Value | Token | Meaning |
 |---|---|---|
-| Open | `open` | No terminal disposition has been selected. |
-| Accepted | `accepted` | The record or proposition is accepted. |
-| Rejected | `rejected` | The record or proposition is rejected. |
-| Superseded | `superseded` | A newer authoritative record replaces this one. |
-| Mitigated | `mitigated` | The tracked risk or finding has been mitigated. |
-| Deferred | `deferred` | Disposition is intentionally postponed. |
+| <span id="fact-vocabulary-disposition-open"></span>Open | `open` | No terminal disposition has been selected. |
+| <span id="fact-vocabulary-disposition-accepted"></span>Accepted | `accepted` | The record or proposition is accepted. |
+| <span id="fact-vocabulary-disposition-rejected"></span>Rejected | `rejected` | The record or proposition is rejected. |
+| <span id="fact-vocabulary-disposition-superseded"></span>Superseded | `superseded` | A newer authoritative record replaces this one. |
+| <span id="fact-vocabulary-disposition-mitigated"></span>Mitigated | `mitigated` | The tracked risk or finding has been mitigated. |
+| <span id="fact-vocabulary-disposition-deferred"></span>Deferred | `deferred` | Disposition is intentionally postponed. |
+
 
 ### Verification values
 
@@ -202,11 +214,12 @@ Repository/source verification state; it does not represent post-merge live runt
 
 | Value | Token | Meaning |
 |---|---|---|
-| Not Run | `not_run` | Repository/source verification has not run. |
-| Pending | `pending` | Repository/source verification is pending or running. |
-| Passed | `passed` | Repository/source verification passed for the applicable evidence identity. |
-| Failed | `failed` | Repository/source verification failed. |
-| Blocked | `blocked` | Repository/source verification cannot currently complete. |
+| <span id="fact-vocabulary-verification-not-run"></span>Not Run | `not_run` | Repository/source verification has not run. |
+| <span id="fact-vocabulary-verification-pending"></span>Pending | `pending` | Repository/source verification is pending or running. |
+| <span id="fact-vocabulary-verification-passed"></span>Passed | `passed` | Repository/source verification passed for the applicable evidence identity. |
+| <span id="fact-vocabulary-verification-failed"></span>Failed | `failed` | Repository/source verification failed. |
+| <span id="fact-vocabulary-verification-blocked"></span>Blocked | `blocked` | Repository/source verification cannot currently complete. |
+
 
 ### Severity values
 
@@ -214,10 +227,11 @@ Relative material impact of a finding or risk.
 
 | Value | Token | Meaning |
 |---|---|---|
-| Critical | `critical` | Highest material impact requiring urgent attention. |
-| High | `high` | High material impact. |
-| Medium | `medium` | Moderate material impact. |
-| Low | `low` | Limited material impact. |
+| <span id="fact-vocabulary-severity-critical"></span>Critical | `critical` | Highest material impact requiring urgent attention. |
+| <span id="fact-vocabulary-severity-high"></span>High | `high` | High material impact. |
+| <span id="fact-vocabulary-severity-medium"></span>Medium | `medium` | Moderate material impact. |
+| <span id="fact-vocabulary-severity-low"></span>Low | `low` | Limited material impact. |
+
 
 ### Confidence values
 
@@ -225,9 +239,10 @@ Relative confidence classification for finding and assumption evidence; current 
 
 | Value | Token | Meaning |
 |---|---|---|
-| High | `high` | Highest configured confidence label; no additional threshold is defined by current Work authority. |
-| Medium | `medium` | Middle configured confidence label; no additional threshold is defined by current Work authority. |
-| Low | `low` | Lowest configured confidence label; no additional threshold is defined by current Work authority. |
+| <span id="fact-vocabulary-confidence-high"></span>High | `high` | Highest configured confidence label; no additional threshold is defined by current Work authority. |
+| <span id="fact-vocabulary-confidence-medium"></span>Medium | `medium` | Middle configured confidence label; no additional threshold is defined by current Work authority. |
+| <span id="fact-vocabulary-confidence-low"></span>Low | `low` | Lowest configured confidence label; no additional threshold is defined by current Work authority. |
+
 
 ### Live verification values
 
@@ -235,12 +250,13 @@ Post-merge live runtime verification state, distinct from repository/source Veri
 
 | Value | Token | Meaning |
 |---|---|---|
-| Not Assessed | `not_assessed` | The need for live verification has not yet been classified. |
-| Not Required | `not_required` | Deterministic classification found no live verification obligation. |
-| Pending | `pending` | Live verification is required and has not yet completed. |
-| Passed | `passed` | Required live verification passed against the actual exposed capability or runtime path. |
-| Failed | `failed` | Required live verification ran and failed its expected invariant. |
-| Blocked | `blocked` | Required live verification cannot currently complete. |
+| <span id="fact-vocabulary-live-verification-not-assessed"></span>Not Assessed | `not_assessed` | The need for live verification has not yet been classified. |
+| <span id="fact-vocabulary-live-verification-not-required"></span>Not Required | `not_required` | Deterministic classification found no live verification obligation. |
+| <span id="fact-vocabulary-live-verification-pending"></span>Pending | `pending` | Live verification is required and has not yet completed. |
+| <span id="fact-vocabulary-live-verification-passed"></span>Passed | `passed` | Required live verification passed against the actual exposed capability or runtime path. |
+| <span id="fact-vocabulary-live-verification-failed"></span>Failed | `failed` | Required live verification ran and failed its expected invariant. |
+| <span id="fact-vocabulary-live-verification-blocked"></span>Blocked | `blocked` | Required live verification cannot currently complete. |
+
 
 ## Source and authority
 

--- a/generated/work-management-spec/021-work-project-configuration-reference.md
+++ b/generated/work-management-spec/021-work-project-configuration-reference.md
@@ -52,34 +52,35 @@ The configured Project schema belongs to portfolio `default` and uses schema ver
 
 | Field | Type | Options |
 |---|---|---|
-| Status | `single_select` | Inbox, Triage, Proposed, Approved, Ready, Active, Blocked, On Hold, Deferred, Rejected, Superseded, Done |
-| Record Type | `single_select` | Idea, Task, Specification Slice, Review Run, Finding, Decision, Assumption, Risk, Approval, Hold, Research, Defect, Security Finding |
-| Priority | `single_select` | Critical, High, Medium, Low |
-| Effort | `single_select` | Tiny, Small, Medium, Large |
-| Delivery Stage | `single_select` | None, Change Created, Implementing, PR Open, Review, CI Pending, CI Failed, CI Passed, Merged, Documentation, Commissioning, Complete |
-| Execution Owner | `text` | Not applicable |
-| Blocked By | `text` | Not applicable |
-| Documentation Impact | `single_select` | Not Assessed, None, Planned, In Progress, Pre-merge Complete, Post-merge Complete |
-| Complexity | `single_select` | Small, Medium, Large |
-| Risk Triggers | `text` | Not applicable |
-| Project ID | `text` | Not applicable |
-| Repository | `repository` | Not applicable |
-| Module | `text` | Not applicable |
-| Change ID | `text` | Not applicable |
-| Origin | `single_select` | Operator, Review, Verification, Implementation, Research |
-| Disposition | `single_select` | Open, Accepted, Rejected, Superseded, Mitigated, Deferred |
-| Verification | `single_select` | Not Run, Pending, Passed, Failed, Blocked |
-| Severity | `single_select` | Critical, High, Medium, Low |
-| Confidence | `single_select` | High, Medium, Low |
-| Review Trigger | `text` | Not applicable |
-| Target Date | `date` | Not applicable |
-| Iteration | `iteration` | Not applicable |
-| Source Review | `text` | Not applicable |
-| Authority Revision | `text` | Not applicable |
-| External Link | `text` | Not applicable |
-| Live Verification | `single_select` | Not Assessed, Not Required, Pending, Passed, Failed, Blocked |
-| Commissioning Key | `text` | Not applicable |
-| Live Verification Evidence | `text` | Not applicable |
+| <span id="fact-project-field-status"></span>Status | `single_select` | Inbox, Triage, Proposed, Approved, Ready, Active, Blocked, On Hold, Deferred, Rejected, Superseded, Done |
+| <span id="fact-project-field-record-type"></span>Record Type | `single_select` | Idea, Task, Specification Slice, Review Run, Finding, Decision, Assumption, Risk, Approval, Hold, Research, Defect, Security Finding |
+| <span id="fact-project-field-priority"></span>Priority | `single_select` | Critical, High, Medium, Low |
+| <span id="fact-project-field-effort"></span>Effort | `single_select` | Tiny, Small, Medium, Large |
+| <span id="fact-project-field-delivery-stage"></span>Delivery Stage | `single_select` | None, Change Created, Implementing, PR Open, Review, CI Pending, CI Failed, CI Passed, Merged, Documentation, Commissioning, Complete |
+| <span id="fact-project-field-execution-owner"></span>Execution Owner | `text` | Not applicable |
+| <span id="fact-project-field-blocked-by"></span>Blocked By | `text` | Not applicable |
+| <span id="fact-project-field-documentation-impact"></span>Documentation Impact | `single_select` | Not Assessed, None, Planned, In Progress, Pre-merge Complete, Post-merge Complete |
+| <span id="fact-project-field-complexity"></span>Complexity | `single_select` | Small, Medium, Large |
+| <span id="fact-project-field-risk-triggers"></span>Risk Triggers | `text` | Not applicable |
+| <span id="fact-project-field-project-id"></span>Project ID | `text` | Not applicable |
+| <span id="fact-project-field-repository"></span>Repository | `repository` | Not applicable |
+| <span id="fact-project-field-module"></span>Module | `text` | Not applicable |
+| <span id="fact-project-field-change-id"></span>Change ID | `text` | Not applicable |
+| <span id="fact-project-field-origin"></span>Origin | `single_select` | Operator, Review, Verification, Implementation, Research |
+| <span id="fact-project-field-disposition"></span>Disposition | `single_select` | Open, Accepted, Rejected, Superseded, Mitigated, Deferred |
+| <span id="fact-project-field-verification"></span>Verification | `single_select` | Not Run, Pending, Passed, Failed, Blocked |
+| <span id="fact-project-field-severity"></span>Severity | `single_select` | Critical, High, Medium, Low |
+| <span id="fact-project-field-confidence"></span>Confidence | `single_select` | High, Medium, Low |
+| <span id="fact-project-field-review-trigger"></span>Review Trigger | `text` | Not applicable |
+| <span id="fact-project-field-target-date"></span>Target Date | `date` | Not applicable |
+| <span id="fact-project-field-iteration"></span>Iteration | `iteration` | Not applicable |
+| <span id="fact-project-field-source-review"></span>Source Review | `text` | Not applicable |
+| <span id="fact-project-field-authority-revision"></span>Authority Revision | `text` | Not applicable |
+| <span id="fact-project-field-external-link"></span>External Link | `text` | Not applicable |
+| <span id="fact-project-field-live-verification"></span>Live Verification | `single_select` | Not Assessed, Not Required, Pending, Passed, Failed, Blocked |
+| <span id="fact-project-field-commissioning-key"></span>Commissioning Key | `text` | Not applicable |
+| <span id="fact-project-field-live-verification-evidence"></span>Live Verification Evidence | `text` | Not applicable |
+
 
 ### Project views
 
@@ -87,18 +88,19 @@ Views are derived navigation surfaces over the same Project data. Their filters 
 
 | View | Purpose | Layout | Filter | Grouping / sort | Visible fields |
 |---|---|---|---|---|---|
-| 01 Inbox | Untriaged ideas and tasks | `table` | status:Inbox | None | Title, Status, Record Type, Priority, Effort, Repository |
-| 02 Programme Table | All active records and key fields | `table` | status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred | None | Title, Status, Record Type, Priority, Effort, Execution Owner, Repository, Change ID, Delivery Stage |
-| 03 Delivery Board | Delivery flow grouped by lifecycle status | `board` | status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred | vertical group by Status | Title, Priority, Effort, Execution Owner, Repository, Delivery Stage |
-| 04 Roadmap | Dated or iterated specification and implementation slices | `roadmap` | record-type:"Specification Slice",Task status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | None |
-| 05 Specification Slices | Proposed through completed specification records | `table` | record-type:"Specification Slice" status:Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | Title, Status, Priority, Change ID, Delivery Stage, Repository |
-| 06 Decisions | Proposed, accepted, rejected, and superseded decisions | `table` | record-type:Decision status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | Title, Status, Disposition, Review Trigger, Authority Revision, Repository |
-| 07 Assumptions and Risks | Open validation and mitigation work | `table` | record-type:Assumption,Risk status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred | None | Title, Status, Severity, Confidence, Review Trigger, Disposition, Repository |
-| 08 Holds and Deferred | Paused items with review triggers | `table` | status:"On Hold",Deferred | None | Title, Status, Review Trigger, Execution Owner, Blocked By, Target Date, Repository |
-| 09 Reviews and Findings | Review runs and extracted records | `table` | record-type:"Review Run",Finding,"Security Finding" status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | Title, Status, Severity, Confidence, Source Review, Verification, Disposition, Repository |
-| 10 Verification | Work awaiting or failing verification | `table` | verification:Pending,Failed,Blocked status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | Title, Status, Verification, Change ID, Delivery Stage, Repository |
-| 11 Documentation and Closeout | Records awaiting documentation reconciliation or final closeout | `table` | delivery-stage:Documentation,Commissioning status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | Title, Status, Documentation Impact, Change ID, Delivery Stage, Repository |
-| 12 Completed | Closed records retained for history | `table` | status:Done | None | Title, Record Type, Repository, Change ID, Delivery Stage, Verification, Authority Revision |
+| <span id="fact-project-view-01-inbox"></span>01 Inbox | Untriaged ideas and tasks | `table` | status:Inbox | None | Title, Status, Record Type, Priority, Effort, Repository |
+| <span id="fact-project-view-02-programme-table"></span>02 Programme Table | All active records and key fields | `table` | status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred | None | Title, Status, Record Type, Priority, Effort, Execution Owner, Repository, Change ID, Delivery Stage |
+| <span id="fact-project-view-03-delivery-board"></span>03 Delivery Board | Delivery flow grouped by lifecycle status | `board` | status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred | vertical group by Status | Title, Priority, Effort, Execution Owner, Repository, Delivery Stage |
+| <span id="fact-project-view-04-roadmap"></span>04 Roadmap | Dated or iterated specification and implementation slices | `roadmap` | record-type:"Specification Slice",Task status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | None |
+| <span id="fact-project-view-05-specification-slices"></span>05 Specification Slices | Proposed through completed specification records | `table` | record-type:"Specification Slice" status:Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | Title, Status, Priority, Change ID, Delivery Stage, Repository |
+| <span id="fact-project-view-06-decisions"></span>06 Decisions | Proposed, accepted, rejected, and superseded decisions | `table` | record-type:Decision status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | Title, Status, Disposition, Review Trigger, Authority Revision, Repository |
+| <span id="fact-project-view-07-assumptions-and-risks"></span>07 Assumptions and Risks | Open validation and mitigation work | `table` | record-type:Assumption,Risk status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred | None | Title, Status, Severity, Confidence, Review Trigger, Disposition, Repository |
+| <span id="fact-project-view-08-holds-and-deferred"></span>08 Holds and Deferred | Paused items with review triggers | `table` | status:"On Hold",Deferred | None | Title, Status, Review Trigger, Execution Owner, Blocked By, Target Date, Repository |
+| <span id="fact-project-view-09-reviews-and-findings"></span>09 Reviews and Findings | Review runs and extracted records | `table` | record-type:"Review Run",Finding,"Security Finding" status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | Title, Status, Severity, Confidence, Source Review, Verification, Disposition, Repository |
+| <span id="fact-project-view-10-verification"></span>10 Verification | Work awaiting or failing verification | `table` | verification:Pending,Failed,Blocked status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | Title, Status, Verification, Change ID, Delivery Stage, Repository |
+| <span id="fact-project-view-11-documentation-and-closeout"></span>11 Documentation and Closeout | Records awaiting documentation reconciliation or final closeout | `table` | delivery-stage:Documentation,Commissioning status:Inbox,Triage,Proposed,Approved,Ready,Active,Blocked,"On Hold",Deferred,Rejected,Superseded,Done | None | Title, Status, Documentation Impact, Change ID, Delivery Stage, Repository |
+| <span id="fact-project-view-12-completed"></span>12 Completed | Closed records retained for history | `table` | status:Done | None | Title, Record Type, Repository, Change ID, Delivery Stage, Verification, Authority Revision |
+
 
 ## Project bindings
 

--- a/generated/work-management-spec/data/semantic-coverage.json
+++ b/generated/work-management-spec/data/semantic-coverage.json
@@ -1,0 +1,1399 @@
+{
+  "entries": [
+    {
+      "anchor": "fact-delivery-stage-change-created",
+      "id": "change_created",
+      "kind": "delivery_stage",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-delivery-stage-ci-failed",
+      "id": "ci_failed",
+      "kind": "delivery_stage",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-delivery-stage-ci-passed",
+      "id": "ci_passed",
+      "kind": "delivery_stage",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-delivery-stage-ci-pending",
+      "id": "ci_pending",
+      "kind": "delivery_stage",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-delivery-stage-commissioning",
+      "id": "commissioning",
+      "kind": "delivery_stage",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-delivery-stage-complete",
+      "id": "complete",
+      "kind": "delivery_stage",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-delivery-stage-documentation",
+      "id": "documentation",
+      "kind": "delivery_stage",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-delivery-stage-implementing",
+      "id": "implementing",
+      "kind": "delivery_stage",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-delivery-stage-merged",
+      "id": "merged",
+      "kind": "delivery_stage",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-delivery-stage-none",
+      "id": "none",
+      "kind": "delivery_stage",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-delivery-stage-pr-open",
+      "id": "pr_open",
+      "kind": "delivery_stage",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-delivery-stage-review",
+      "id": "review",
+      "kind": "delivery_stage",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-field-authority-revision",
+      "id": "authority_revision",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-blocked-by",
+      "id": "blocked_by",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-change-id",
+      "id": "change_id",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-commissioning-key",
+      "id": "commissioning_key",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-complexity",
+      "id": "complexity",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-confidence",
+      "id": "confidence",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-created",
+      "id": "created",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-delivery-stage",
+      "id": "delivery_stage",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-disposition",
+      "id": "disposition",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-documentation-impact",
+      "id": "documentation_impact",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-effort",
+      "id": "effort",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-execution-owner",
+      "id": "execution_owner",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-external-link",
+      "id": "external_link",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-iteration",
+      "id": "iteration",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-live-verification",
+      "id": "live_verification",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-live-verification-evidence",
+      "id": "live_verification_evidence",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-module",
+      "id": "module",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-origin",
+      "id": "origin",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-priority",
+      "id": "priority",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-project-id",
+      "id": "project_id",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-record-type",
+      "id": "record_type",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-repository",
+      "id": "repository",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-review-trigger",
+      "id": "review_trigger",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-risk-triggers",
+      "id": "risk_triggers",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-severity",
+      "id": "severity",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-source-review",
+      "id": "source_review",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-status",
+      "id": "status",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-target-date",
+      "id": "target_date",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-field-verification",
+      "id": "verification",
+      "kind": "field",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "mrd-kis-work-con-pol-001",
+      "id": "KIS-WORK-CON-POL-001",
+      "kind": "mrd",
+      "page": "006-authority-and-reconciliation-policy.md",
+      "source_mrd": "KIS-WORK-CON-POL-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "mrd-kis-work-ctr-svc-001",
+      "id": "KIS-WORK-CTR-SVC-001",
+      "kind": "mrd",
+      "page": "007-provider-and-command-plane-boundary.md",
+      "source_mrd": "KIS-WORK-CTR-SVC-001",
+      "source_version": "1.0.1"
+    },
+    {
+      "anchor": "mrd-kis-work-dec-scr-001",
+      "id": "KIS-WORK-DEC-SCR-001",
+      "kind": "mrd",
+      "page": "005-next-work-selection.md",
+      "source_mrd": "KIS-WORK-DEC-SCR-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "mrd-kis-work-evl-tst-001",
+      "id": "KIS-WORK-EVL-TST-001",
+      "kind": "mrd",
+      "page": "008-work-management-conformance.md",
+      "source_mrd": "KIS-WORK-EVL-TST-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "mrd-kis-work-sem-reg-001",
+      "id": "KIS-WORK-SEM-REG-001",
+      "kind": "mrd",
+      "page": "002-work-management-domain-model.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "mrd-kis-work-wrk-stm-001",
+      "id": "KIS-WORK-WRK-STM-001",
+      "kind": "mrd",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "mrd-kis-work-wrk-wfl-001",
+      "id": "KIS-WORK-WRK-WFL-001",
+      "kind": "mrd",
+      "page": "004-work-operations.md",
+      "source_mrd": "KIS-WORK-WRK-WFL-001",
+      "source_version": "1.0.0"
+    },
+    {
+      "anchor": "fact-project-field-authority-revision",
+      "id": "Authority Revision",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-blocked-by",
+      "id": "Blocked By",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-change-id",
+      "id": "Change ID",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-commissioning-key",
+      "id": "Commissioning Key",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-complexity",
+      "id": "Complexity",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-confidence",
+      "id": "Confidence",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-delivery-stage",
+      "id": "Delivery Stage",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-disposition",
+      "id": "Disposition",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-documentation-impact",
+      "id": "Documentation Impact",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-effort",
+      "id": "Effort",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-execution-owner",
+      "id": "Execution Owner",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-external-link",
+      "id": "External Link",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-iteration",
+      "id": "Iteration",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-live-verification",
+      "id": "Live Verification",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-live-verification-evidence",
+      "id": "Live Verification Evidence",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-module",
+      "id": "Module",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-origin",
+      "id": "Origin",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-priority",
+      "id": "Priority",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-project-id",
+      "id": "Project ID",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-record-type",
+      "id": "Record Type",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-repository",
+      "id": "Repository",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-review-trigger",
+      "id": "Review Trigger",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-risk-triggers",
+      "id": "Risk Triggers",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-severity",
+      "id": "Severity",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-source-review",
+      "id": "Source Review",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-status",
+      "id": "Status",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-target-date",
+      "id": "Target Date",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-field-verification",
+      "id": "Verification",
+      "kind": "project_field",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-view-01-inbox",
+      "id": "01 Inbox",
+      "kind": "project_view",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-view-02-programme-table",
+      "id": "02 Programme Table",
+      "kind": "project_view",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-view-03-delivery-board",
+      "id": "03 Delivery Board",
+      "kind": "project_view",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-view-04-roadmap",
+      "id": "04 Roadmap",
+      "kind": "project_view",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-view-05-specification-slices",
+      "id": "05 Specification Slices",
+      "kind": "project_view",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-view-06-decisions",
+      "id": "06 Decisions",
+      "kind": "project_view",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-view-07-assumptions-and-risks",
+      "id": "07 Assumptions and Risks",
+      "kind": "project_view",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-view-08-holds-and-deferred",
+      "id": "08 Holds and Deferred",
+      "kind": "project_view",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-view-09-reviews-and-findings",
+      "id": "09 Reviews and Findings",
+      "kind": "project_view",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-view-10-verification",
+      "id": "10 Verification",
+      "kind": "project_view",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-view-11-documentation-and-closeout",
+      "id": "11 Documentation and Closeout",
+      "kind": "project_view",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-project-view-12-completed",
+      "id": "12 Completed",
+      "kind": "project_view",
+      "page": "021-work-project-configuration-reference.md",
+      "source_mrd": "KIS-WORK-CON-POL-001"
+    },
+    {
+      "anchor": "fact-selection-rule-sel-001",
+      "id": "SEL-001",
+      "kind": "selection_rule",
+      "page": "005-next-work-selection.md",
+      "source_mrd": "KIS-WORK-DEC-SCR-001"
+    },
+    {
+      "anchor": "fact-selection-rule-sel-002",
+      "id": "SEL-002",
+      "kind": "selection_rule",
+      "page": "005-next-work-selection.md",
+      "source_mrd": "KIS-WORK-DEC-SCR-001"
+    },
+    {
+      "anchor": "fact-selection-rule-sel-003",
+      "id": "SEL-003",
+      "kind": "selection_rule",
+      "page": "005-next-work-selection.md",
+      "source_mrd": "KIS-WORK-DEC-SCR-001"
+    },
+    {
+      "anchor": "fact-selection-rule-sel-004",
+      "id": "SEL-004",
+      "kind": "selection_rule",
+      "page": "005-next-work-selection.md",
+      "source_mrd": "KIS-WORK-DEC-SCR-001"
+    },
+    {
+      "anchor": "fact-selection-rule-sel-005",
+      "id": "SEL-005",
+      "kind": "selection_rule",
+      "page": "005-next-work-selection.md",
+      "source_mrd": "KIS-WORK-DEC-SCR-001"
+    },
+    {
+      "anchor": "fact-selection-rule-sel-006",
+      "id": "SEL-006",
+      "kind": "selection_rule",
+      "page": "005-next-work-selection.md",
+      "source_mrd": "KIS-WORK-DEC-SCR-001"
+    },
+    {
+      "anchor": "fact-selection-rule-sel-007",
+      "id": "SEL-007",
+      "kind": "selection_rule",
+      "page": "005-next-work-selection.md",
+      "source_mrd": "KIS-WORK-DEC-SCR-001"
+    },
+    {
+      "anchor": "fact-selection-rule-sel-008",
+      "id": "SEL-008",
+      "kind": "selection_rule",
+      "page": "005-next-work-selection.md",
+      "source_mrd": "KIS-WORK-DEC-SCR-001"
+    },
+    {
+      "anchor": "fact-selection-rule-sel-009",
+      "id": "SEL-009",
+      "kind": "selection_rule",
+      "page": "005-next-work-selection.md",
+      "source_mrd": "KIS-WORK-DEC-SCR-001"
+    },
+    {
+      "anchor": "fact-selection-rule-sel-010",
+      "id": "SEL-010",
+      "kind": "selection_rule",
+      "page": "005-next-work-selection.md",
+      "source_mrd": "KIS-WORK-DEC-SCR-001"
+    },
+    {
+      "anchor": "fact-selection-rule-sel-011",
+      "id": "SEL-011",
+      "kind": "selection_rule",
+      "page": "005-next-work-selection.md",
+      "source_mrd": "KIS-WORK-DEC-SCR-001"
+    },
+    {
+      "anchor": "fact-selection-rule-sel-012",
+      "id": "SEL-012",
+      "kind": "selection_rule",
+      "page": "005-next-work-selection.md",
+      "source_mrd": "KIS-WORK-DEC-SCR-001"
+    },
+    {
+      "anchor": "fact-vocabulary-complexity-large",
+      "id": "complexity:large",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-complexity-medium",
+      "id": "complexity:medium",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-complexity-small",
+      "id": "complexity:small",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-confidence-high",
+      "id": "confidence:high",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-confidence-low",
+      "id": "confidence:low",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-confidence-medium",
+      "id": "confidence:medium",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-delivery-stage-change-created",
+      "id": "delivery_stage:change_created",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-delivery-stage-ci-failed",
+      "id": "delivery_stage:ci_failed",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-delivery-stage-ci-passed",
+      "id": "delivery_stage:ci_passed",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-delivery-stage-ci-pending",
+      "id": "delivery_stage:ci_pending",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-delivery-stage-commissioning",
+      "id": "delivery_stage:commissioning",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-delivery-stage-complete",
+      "id": "delivery_stage:complete",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-delivery-stage-documentation",
+      "id": "delivery_stage:documentation",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-delivery-stage-implementing",
+      "id": "delivery_stage:implementing",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-delivery-stage-merged",
+      "id": "delivery_stage:merged",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-delivery-stage-none",
+      "id": "delivery_stage:none",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-delivery-stage-pr-open",
+      "id": "delivery_stage:pr_open",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-delivery-stage-review",
+      "id": "delivery_stage:review",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-disposition-accepted",
+      "id": "disposition:accepted",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-disposition-deferred",
+      "id": "disposition:deferred",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-disposition-mitigated",
+      "id": "disposition:mitigated",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-disposition-open",
+      "id": "disposition:open",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-disposition-rejected",
+      "id": "disposition:rejected",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-disposition-superseded",
+      "id": "disposition:superseded",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-documentation-impact-in-progress",
+      "id": "documentation_impact:in_progress",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-documentation-impact-none",
+      "id": "documentation_impact:none",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-documentation-impact-not-assessed",
+      "id": "documentation_impact:not_assessed",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-documentation-impact-planned",
+      "id": "documentation_impact:planned",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-documentation-impact-post-merge-complete",
+      "id": "documentation_impact:post_merge_complete",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-documentation-impact-pre-merge-complete",
+      "id": "documentation_impact:pre_merge_complete",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-effort-large",
+      "id": "effort:large",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-effort-medium",
+      "id": "effort:medium",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-effort-small",
+      "id": "effort:small",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-effort-tiny",
+      "id": "effort:tiny",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-live-verification-blocked",
+      "id": "live_verification:blocked",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-live-verification-failed",
+      "id": "live_verification:failed",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-live-verification-not-assessed",
+      "id": "live_verification:not_assessed",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-live-verification-not-required",
+      "id": "live_verification:not_required",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-live-verification-passed",
+      "id": "live_verification:passed",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-live-verification-pending",
+      "id": "live_verification:pending",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-origin-implementation",
+      "id": "origin:implementation",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-origin-operator",
+      "id": "origin:operator",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-origin-research",
+      "id": "origin:research",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-origin-review",
+      "id": "origin:review",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-origin-verification",
+      "id": "origin:verification",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-priority-critical",
+      "id": "priority:critical",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-priority-high",
+      "id": "priority:high",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-priority-low",
+      "id": "priority:low",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-priority-medium",
+      "id": "priority:medium",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-record-type-approval",
+      "id": "record_type:approval",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-record-type-assumption",
+      "id": "record_type:assumption",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-record-type-decision",
+      "id": "record_type:decision",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-record-type-defect",
+      "id": "record_type:defect",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-record-type-finding",
+      "id": "record_type:finding",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-record-type-hold",
+      "id": "record_type:hold",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-record-type-idea",
+      "id": "record_type:idea",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-record-type-research",
+      "id": "record_type:research",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-record-type-review-run",
+      "id": "record_type:review_run",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-record-type-risk",
+      "id": "record_type:risk",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-record-type-security-finding",
+      "id": "record_type:security_finding",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-record-type-specification-slice",
+      "id": "record_type:specification_slice",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-record-type-task",
+      "id": "record_type:task",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-severity-critical",
+      "id": "severity:critical",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-severity-high",
+      "id": "severity:high",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-severity-low",
+      "id": "severity:low",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-severity-medium",
+      "id": "severity:medium",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-status-active",
+      "id": "status:active",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-status-approved",
+      "id": "status:approved",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-status-blocked",
+      "id": "status:blocked",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-status-deferred",
+      "id": "status:deferred",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-status-done",
+      "id": "status:done",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-status-inbox",
+      "id": "status:inbox",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-status-on-hold",
+      "id": "status:on_hold",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-status-proposed",
+      "id": "status:proposed",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-status-ready",
+      "id": "status:ready",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-status-rejected",
+      "id": "status:rejected",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-status-superseded",
+      "id": "status:superseded",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-status-triage",
+      "id": "status:triage",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-verification-blocked",
+      "id": "verification:blocked",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-verification-failed",
+      "id": "verification:failed",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-verification-not-run",
+      "id": "verification:not_run",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-verification-passed",
+      "id": "verification:passed",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-vocabulary-verification-pending",
+      "id": "verification:pending",
+      "kind": "vocabulary_value",
+      "page": "020-work-field-and-vocabulary-reference.md",
+      "source_mrd": "KIS-WORK-SEM-REG-001"
+    },
+    {
+      "anchor": "fact-work-state-active",
+      "id": "active",
+      "kind": "work_state",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-work-state-approved",
+      "id": "approved",
+      "kind": "work_state",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-work-state-blocked",
+      "id": "blocked",
+      "kind": "work_state",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-work-state-deferred",
+      "id": "deferred",
+      "kind": "work_state",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-work-state-documentation",
+      "id": "documentation",
+      "kind": "work_state",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-work-state-done",
+      "id": "done",
+      "kind": "work_state",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-work-state-inbox",
+      "id": "inbox",
+      "kind": "work_state",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-work-state-on-hold",
+      "id": "on_hold",
+      "kind": "work_state",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-work-state-proposed",
+      "id": "proposed",
+      "kind": "work_state",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-work-state-ready",
+      "id": "ready",
+      "kind": "work_state",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-work-state-rejected",
+      "id": "rejected",
+      "kind": "work_state",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-work-state-review",
+      "id": "review",
+      "kind": "work_state",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-work-state-superseded",
+      "id": "superseded",
+      "kind": "work_state",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-work-state-triage",
+      "id": "triage",
+      "kind": "work_state",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    },
+    {
+      "anchor": "fact-work-state-verification",
+      "id": "verification",
+      "kind": "work_state",
+      "page": "003-work-lifecycle.md",
+      "source_mrd": "KIS-WORK-WRK-STM-001"
+    }
+  ],
+  "family": "work-management-spec",
+  "schema_version": 1
+}

--- a/generated/work-management-spec/manifest.json
+++ b/generated/work-management-spec/manifest.json
@@ -1,69 +1,74 @@
 {
-  "bundle_sha256": "8b8a399ab61249dc29ed05dd60b396895873d3cd0dacf9ff4bd18f2301eeef24",
+  "bundle_sha256": "05905aef37c966e3db810787ca7ea91dfa3aa5987a8746a250f4b3c13ed3dcb7",
   "contract": {
     "name": "kis-work-management-spec-build",
     "version": 2
   },
   "files": [
     {
-      "bytes": 1221,
+      "bytes": 1323,
       "path": "000-index.md",
-      "sha256": "db76a73fa77ae29c96b7b0069cb7e4fed087ae424319f00ed346675801ff3ae7"
+      "sha256": "3ada153de57665eaaf5ca229785961bdf3cd41345cf44ab95f788f0207cc38d2"
     },
     {
-      "bytes": 3398,
+      "bytes": 3471,
       "path": "001-specification.md",
-      "sha256": "4babc2503e9a01835ee7cfa930e16310c87a0cf0e9ceb13285010510cf0aae52"
+      "sha256": "2436f72f2eb6d65f70ad3e70699c18604dffad6dcfe4799de49fd4feb38b0c7a"
     },
     {
-      "bytes": 1615,
+      "bytes": 1660,
       "path": "002-work-management-domain-model.md",
-      "sha256": "50e0fc957c21bea509410923b27be3714f539bc8632f9b38a83dadfd62da86bf"
+      "sha256": "3e1b884f3c96b929bbebb969fcd7cfec3a1ed193bd1ada23216c04eb157e255d"
     },
     {
-      "bytes": 6249,
+      "bytes": 11553,
       "path": "003-work-lifecycle.md",
-      "sha256": "547c013e6452ce731f20f01bc37add53615efab64ea9f2807e487d5d4eb1632e"
+      "sha256": "2793987b9af053cb3f61a458ba3ac25ba86285a8c8cba1bf9c94967a5a7b75d3"
     },
     {
-      "bytes": 4086,
+      "bytes": 4131,
       "path": "004-work-operations.md",
-      "sha256": "7d369b2e7ecae92a77a944f4d784030f6744cee297a1b97c8646d359ecd03616"
+      "sha256": "433d1ef5604b59caccf23aa77d8e3e439988978682d92bbcc750d8c689bc9803"
     },
     {
-      "bytes": 3891,
+      "bytes": 4489,
       "path": "005-next-work-selection.md",
-      "sha256": "41bf5adcc8155b44b26da5a04549e45ae82c37bd50b040c4514354531d196bfe"
+      "sha256": "b764b7aa83f99c82f3e8a56dd4e0ba90f13c3d2fec54352a209889c6fdbfa28a"
     },
     {
-      "bytes": 2271,
+      "bytes": 2316,
       "path": "006-authority-and-reconciliation-policy.md",
-      "sha256": "9e5a7afa6a9fc414adbeb23ac4f108bdd1cf5de6c7079460a49f66174b0cfff4"
+      "sha256": "46c248795e8661790daca86d30da6a748969c45bcb740b6606922a5c5bc70fcd"
     },
     {
-      "bytes": 3110,
+      "bytes": 4427,
       "path": "007-provider-and-command-plane-boundary.md",
-      "sha256": "9afb42d237f15f4e5c248f7c21009867acbce528a2422f779ac89eb495421da5"
+      "sha256": "dcfecc74faedaee9db072987c5c9da1a60d92e00bbde081138624b06b67fa6d3"
     },
     {
-      "bytes": 1156,
+      "bytes": 1201,
       "path": "008-work-management-conformance.md",
-      "sha256": "af773553fe3916bcac3957c85a3afaeac6987fc326083cb2a7afecf9b8aaf94a"
+      "sha256": "7d8856a17dd4a3991746ee790a80a6ae72ca962bf52660475c3a70ec48d3018a"
     },
     {
-      "bytes": 18488,
+      "bytes": 24252,
       "path": "020-work-field-and-vocabulary-reference.md",
-      "sha256": "71261fc3475d1c33c9123ce5a128f80358407c0c1df690de619cae9249d8a122"
+      "sha256": "5a297db8a54089517449109a264641d08dbdc008c626b756566bfa76655ad988"
     },
     {
-      "bytes": 10832,
+      "bytes": 12887,
       "path": "021-work-project-configuration-reference.md",
-      "sha256": "ed3501718521c0a56c06a88cf50e4bd38f40634da43f7ad3d69b110f94e343fe"
+      "sha256": "b4293ed500a90f52a6226decefd5795afe3e5eebf2a5be9e374aa89b03394c54"
     },
     {
-      "bytes": 3398,
+      "bytes": 44744,
+      "path": "data/semantic-coverage.json",
+      "sha256": "6eec176727afc71831447dafde352078d62a1ae9ec657f28fc5f3dd4afda029b"
+    },
+    {
+      "bytes": 3471,
       "path": "specification.md",
-      "sha256": "4babc2503e9a01835ee7cfa930e16310c87a0cf0e9ceb13285010510cf0aae52"
+      "sha256": "2436f72f2eb6d65f70ad3e70699c18604dffad6dcfe4799de49fd4feb38b0c7a"
     }
   ],
   "generator": {
@@ -79,7 +84,7 @@
       },
       {
         "path": "src/kis_mcp_doc/work_management.py",
-        "sha256": "c08a68865007763fa63ba2c1971b6060c8483fa8f12e01d8425e5dc6bbaac78c"
+        "sha256": "540ca9c573dead69a5fce212262944e48ba866a5f924e787d1effbaa2fe1ca10"
       }
     ],
     "version": "0.1.0"

--- a/generated/work-management-spec/specification.md
+++ b/generated/work-management-spec/specification.md
@@ -46,4 +46,4 @@ The captured live GitHub Project evidence is observed. Inventory is complete, an
 
 ## Traceability
 
-See the [documentation index](000-index.md) and [build manifest](manifest.json) for exact source identities, MRD versions, hashes, and generated-file declarations.
+See the [documentation index](000-index.md), [semantic coverage](data/semantic-coverage.json), and [build manifest](manifest.json) for exact source identities, MRD versions, page/anchor mappings, hashes, and generated-file declarations.

--- a/src/kis_mcp_doc/render.py
+++ b/src/kis_mcp_doc/render.py
@@ -320,12 +320,14 @@ def _build_output_files(
     )
     root_page = _render_specification_root(config, ordered).encode("utf-8")
     reference_pages = _governance_reference_pages(ordered)
+    coverage = _governance_semantic_coverage(ordered)
     files: dict[str, bytes] = {
         "000-index.md": _render_corpus_index(config, ordered, litho_evidence, reference_pages).encode("utf-8"),
         "001-specification.md": root_page,
         config["output_file"]: root_page,
         "data/mrd-index.json": _json_bytes(_build_index(repository, documents)),
         "data/dependency-map.json": _json_bytes(_build_dependency_map(documents)),
+        "data/semantic-coverage.json": _json_bytes(coverage),
     }
     for index, document in enumerate(ordered):
         previous = None if index == 0 else ordered[index - 1]
@@ -338,6 +340,7 @@ def _build_output_files(
     if litho_evidence is not None:
         files["090-code-derived-analysis.md"] = _render_litho_page(config, litho_evidence).encode("utf-8")
         files["data/litho-evidence.json"] = _json_bytes(_normalized_litho_evidence(litho_evidence))
+    _validate_governance_semantic_coverage(files, coverage)
     return files
 
 
@@ -560,6 +563,7 @@ def _render_corpus_index(
         "",
         "- [MRD index](data/mrd-index.json)",
         "- [Dependency map](data/dependency-map.json)",
+        "- [Semantic coverage](data/semantic-coverage.json)",
     ])
     if litho_evidence is not None:
         lines.append("- [Litho evidence index](data/litho-evidence.json)")
@@ -604,7 +608,7 @@ def _render_specification_root(config: dict[str, Any], documents: list[dict[str,
         "",
         "## Traceability",
         "",
-        "See the [documentation index](000-index.md), [MRD index](data/mrd-index.json), [dependency map](data/dependency-map.json), and [build manifest](manifest.json) for exact source identities, hashes, and generated-file declarations.",
+        "See the [documentation index](000-index.md), [MRD index](data/mrd-index.json), [dependency map](data/dependency-map.json), [semantic coverage](data/semantic-coverage.json), and [build manifest](manifest.json) for exact source identities, page/anchor mappings, hashes, and generated-file declarations.",
         "",
     ])
     return "\n".join(lines)
@@ -699,21 +703,24 @@ def _governance_reference_pages(documents: list[dict[str, Any]]) -> dict[str, st
     lines = _reference_header("MRD applicability catalog", _document_page_name(applicability), applicability["content"]["heading"])
     lines.extend(["Use this catalog after the specification's minimum-sufficient selection process identifies the governed need. The table does not require one artifact per row.", "", "| Code | Name | Use when |", "|---|---|---|"])
     for item in applicability["content"]["type_applicability"]:
-        lines.append(f"| `{item['code']}` | {item['name']} | {item['use_when']} |")
+        lines.append(f"| <span id=\"fact-applicability-{_heading_anchor(item['code'])}\"></span>`{item['code']}` | {item['name']} | {item['use_when']} |")
+    lines.append("")
     lines.extend(["", "## Source and authority", "", f"This reference projects `{applicability['_mrd']['id']}` version `{applicability['_mrd']['version']}`. The MRD remains authoritative.", ""])
     applicability_page = "\n".join(lines)
 
     lines = _reference_header("Governed relationship vocabulary", _document_page_name(ownership), ownership["content"]["heading"])
     lines.extend(["Relationships preserve authority by expressing how one governed artifact relates to another without creating duplicate ownership.", "", "| Relationship | Meaning |", "|---|---|"])
     for item in ownership["content"]["relationship_catalog"]:
-        lines.append(f"| `{item['code']}` | {item['meaning']} |")
+        lines.append(f"| <span id=\"fact-relationship-{_heading_anchor(item['code'])}\"></span>`{item['code']}` | {item['meaning']} |")
+    lines.append("")
     lines.extend(["", "## Source and authority", "", f"This reference projects `{ownership['_mrd']['id']}` version `{ownership['_mrd']['version']}`. The MRD remains authoritative.", ""])
     relationship_page = "\n".join(lines)
 
     lines = _reference_header("Validation reason codes", _document_page_name(validation), validation["content"]["heading"])
     lines.extend(["Use these stable codes to diagnose validation failures without parsing human-readable error text.", ""])
     for code in validation["content"]["reason_codes"]:
-        lines.append(f"- `{code}`")
+        lines.append(f"- <span id=\"fact-reason-{_heading_anchor(code)}\"></span>`{code}`")
+    lines.append("")
     lines.extend(["", "## Source and authority", "", f"This reference projects `{validation['_mrd']['id']}` version `{validation['_mrd']['version']}`. The MRD remains authoritative.", ""])
     reason_page = "\n".join(lines)
 
@@ -792,6 +799,81 @@ def _heading_anchor(value: str) -> str:
     return "-".join(part for part in raw.split("-") if part)
 
 
+def _rule_anchor(rule_id: str) -> str:
+    return f"rule-{_heading_anchor(rule_id)}"
+
+
+def _governance_semantic_coverage(documents: list[dict[str, Any]]) -> dict[str, Any]:
+    entries: list[dict[str, Any]] = []
+    by_concern = {document["content"]["concern"]: document for document in documents}
+    for document in documents:
+        page = _document_page_name(document)
+        for rule in document["content"].get("rules", []):
+            entries.append({
+                "kind": "rule",
+                "id": rule["rule_id"],
+                "source_mrd": document["_mrd"]["id"],
+                "source_version": document["_mrd"]["version"],
+                "page": page,
+                "anchor": _rule_anchor(rule["rule_id"]),
+                "enforcement": rule["enforcement"],
+            })
+    for item in by_concern["applicability"]["content"]["type_applicability"]:
+        entries.append({"kind":"reference_fact","id":f"applicability:{item['code']}","source_mrd":by_concern["applicability"]["_mrd"]["id"],"page":"020-applicability-catalog.md","anchor":f"fact-applicability-{_heading_anchor(item['code'])}"})
+    for item in by_concern["ownership"]["content"]["relationship_catalog"]:
+        entries.append({"kind":"reference_fact","id":f"relationship:{item['code']}","source_mrd":by_concern["ownership"]["_mrd"]["id"],"page":"021-relationship-vocabulary.md","anchor":f"fact-relationship-{_heading_anchor(item['code'])}"})
+    for code in by_concern["validation"]["content"]["reason_codes"]:
+        entries.append({"kind":"reference_fact","id":f"reason:{code}","source_mrd":by_concern["validation"]["_mrd"]["id"],"page":"022-validation-reason-codes.md","anchor":f"fact-reason-{_heading_anchor(code)}"})
+    return {"schema_version":1,"family":"governance-spec","entries":sorted(entries,key=lambda item:(item["kind"],item["id"]))}
+
+
+def _validate_governance_semantic_coverage(files: dict[str, bytes], coverage: dict[str, Any]) -> None:
+    seen: set[tuple[str, str]] = set()
+    for entry in coverage["entries"]:
+        key = (entry["kind"], entry["id"])
+        if key in seen:
+            raise ValueError(f"duplicate Governance semantic coverage entry: {key}")
+        seen.add(key)
+        page = entry["page"]
+        if page not in files:
+            raise ValueError(f"Governance semantic coverage page does not exist: {page}")
+        marker = f'id="{entry["anchor"]}"'.encode("utf-8")
+        if marker not in files[page]:
+            raise ValueError(f"Governance semantic coverage anchor does not resolve: {page}#{entry['anchor']}")
+
+
+def _governance_ownership_diagram(content: dict[str, Any]) -> list[str]:
+    contract = content["ownership_contract"]
+    return [
+        "### Authority and ownership model", "",
+        "The diagram groups the four fields of the canonical ownership contract. Connector lines show contract composition only; they do not invent relationships between governed actors.", "",
+        "```mermaid", "flowchart TD",
+        '  contract["Canonical ownership contract"]',
+        f'  contract --> owner["Canonical owner count: {contract["canonical_owner_count"]}"]',
+        f'  contract --> nonowner["Non-owner posture: {contract["non_owner_posture"]}"]',
+        f'  contract --> derived["Derived posture: {contract["derived_posture"]}"]',
+        f'  contract --> conflict["Conflict posture: {contract["conflict_posture"]}"]',
+        "```", "",
+    ]
+
+
+def _governance_lifecycle_diagram(content: dict[str, Any]) -> list[str]:
+    lines = ["### Lifecycle diagram", "", "Each record mode is shown as its own canonical state machine. Only transitions declared by the lifecycle MRD are drawn.", "", "```mermaid", "flowchart LR"]
+    for lifecycle in content["lifecycles"]:
+        mode = _heading_anchor(lifecycle["record_mode"])
+        lines.append(f'  subgraph {mode}["{lifecycle["record_mode"]}"]')
+        for state in lifecycle["states"]:
+            node = f"{mode}_{_heading_anchor(state)}"
+            lines.append(f'    {node}["{state}"]')
+        for transition in lifecycle["transitions"]:
+            source = f"{mode}_{_heading_anchor(transition['from'])}"
+            target = f"{mode}_{_heading_anchor(transition['to'])}"
+            lines.append(f"    {source} --> {target}")
+        lines.append("  end")
+    lines.extend(["```", ""])
+    return lines
+
+
 def _format_count(value: int) -> str:
     words = ("zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine")
     return words[value] if 0 <= value < len(words) else str(value)
@@ -815,7 +897,7 @@ def _page_intro(content: dict[str, Any]) -> str:
 
 def _render_rule_statements(lines: list[str], rules: list[dict[str, Any]]) -> None:
     for rule in rules:
-        lines.extend([rule["statement"], ""])
+        lines.extend([f'<span id="{_rule_anchor(rule["rule_id"])}"></span>', rule["statement"], ""])
 
 
 def _render_rule_traceability(lines: list[str], rules: list[dict[str, Any]]) -> None:
@@ -886,6 +968,7 @@ def _render_applicability(lines: list[str], content: dict[str, Any]) -> None:
         lines.append(f"{index}. {step[0].upper() + step[1:]}.")
     lines.extend([
         "",
+        f'<span id="{_rule_anchor(rules[3]["rule_id"])}"></span>',
         rules[3]["statement"],
         "",
         "### Applicability reference",
@@ -910,6 +993,7 @@ def _render_ownership(lines: list[str], content: dict[str, Any]) -> None:
         "",
     ])
     _render_rule_statements(lines, rules[:3])
+    lines.extend(_governance_ownership_diagram(content))
     lines.extend([
         "### Canonical owner kinds",
         "",
@@ -1029,6 +1113,7 @@ def _render_provenance(lines: list[str], content: dict[str, Any]) -> None:
 
 
 def _render_lifecycle(lines: list[str], content: dict[str, Any]) -> None:
+    lines.extend(_governance_lifecycle_diagram(content))
     lines.extend([
         "### State machines",
         "",

--- a/src/kis_mcp_doc/work_management.py
+++ b/src/kis_mcp_doc/work_management.py
@@ -81,6 +81,106 @@ def _page_name(index: int, doc: dict[str, Any]) -> str:
     return f"{index:03d}-{slug}.md"
 
 
+def _anchor_token(value: str) -> str:
+    raw = "".join(character.lower() if character.isalnum() else "-" for character in value)
+    return "-".join(part for part in raw.split("-") if part)
+
+
+def _mermaid_token(value: str) -> str:
+    return _anchor_token(value).replace("-", "_")
+
+
+def _validate_work_semantic_coverage(files: dict[str, bytes], coverage: dict[str, Any]) -> None:
+    seen: set[tuple[str, str]] = set()
+    for entry in coverage["entries"]:
+        key = (entry["kind"], entry["id"])
+        if key in seen:
+            raise ValueError(f"duplicate Work semantic coverage entry: {key}")
+        seen.add(key)
+        page = entry["page"]
+        if page not in files:
+            raise ValueError(f"Work semantic coverage page does not exist: {page}")
+        marker = f'id="{entry["anchor"]}"'.encode("utf-8")
+        if marker not in files[page]:
+            raise ValueError(f"Work semantic coverage anchor does not resolve: {page}#{entry['anchor']}")
+
+
+def _work_status_delivery_diagram(content: dict[str, Any]) -> list[str]:
+    lines = [
+        "## Work status and delivery stage", "",
+        "Work Status and Delivery Stage are separate dimensions. The diagram shows the canonical Work lifecycle graph and Delivery Stage sequence independently; it does not map a work state to a delivery stage.", "",
+        "```mermaid", "flowchart LR",
+        '  subgraph work_status["Work Status"]',
+    ]
+    for state in content["states"]:
+        node = f"status_{_mermaid_token(state['token'])}"
+        label = state["label"] if state["project_status"] else f"{state['label']} (internal)"
+        lines.append(f'    {node}["{label}"]')
+    for source, targets in content["transitions"].items():
+        for target in targets:
+            lines.append(f"    status_{_mermaid_token(source)} --> status_{_mermaid_token(target)}")
+    lines.append("  end")
+    lines.append('  subgraph delivery_stage["Delivery Stage"]')
+    stages = content["delivery"]["stages"]
+    for stage in stages:
+        node = f"stage_{_mermaid_token(stage)}"
+        lines.append(f'    {node}["{stage}"]')
+    for first, second in zip(stages, stages[1:]):
+        lines.append(f"    stage_{_mermaid_token(first)} --> stage_{_mermaid_token(second)}")
+    lines.extend(["  end", "```", ""])
+    return lines
+
+
+def _work_authority_handoff_diagram(content: dict[str, Any]) -> list[str]:
+    authority = content["command_plane"]["field_authority"]
+    grouped: dict[tuple[str, str], list[str]] = {}
+    for field, contract in authority.items():
+        grouped.setdefault((contract["authority"], contract["direction"]), []).append(field)
+    lines = [
+        "## Authority and handoff flow", "",
+        "Each arrow is derived from the provider-boundary field-authority contract. Labels name the fields carried in that authority direction.", "",
+        "```mermaid", "flowchart LR",
+        '  command["Command"]', '  evidence["Evidence"]', '  handoff["Handoff"]',
+    ]
+    for index, ((owner, direction), fields) in enumerate(sorted(grouped.items())):
+        owner_node = f"owner_{index}"
+        lines.append(f'  {owner_node}["{owner}"] -->|"{len(fields)} field{"s" if len(fields) != 1 else ""}"| {direction}')
+    lines.extend(["```", "", "Diagram details:", ""])
+    for (owner, direction), fields in sorted(grouped.items()):
+        lines.append(f"- `{owner}` -> `{direction}`: {', '.join(sorted(fields))}.")
+    lines.append("")
+    return lines
+
+
+def _work_semantic_coverage(docs: list[dict[str, Any]]) -> dict[str, Any]:
+    pages = {_doc["_mrd"]["id"]: _page_name(index, _doc) for index, _doc in enumerate(docs, 2)}
+    by_id = {_doc["_mrd"]["id"]: _doc for _doc in docs}
+    entries: list[dict[str, Any]] = []
+    for doc in docs:
+        doc_id = doc["_mrd"]["id"]
+        entries.append({"kind":"mrd","id":doc_id,"source_mrd":doc_id,"source_version":doc["_mrd"]["version"],"page":pages[doc_id],"anchor":f"mrd-{_anchor_token(doc_id)}"})
+    domain = by_id["KIS-WORK-SEM-REG-001"]
+    for field in domain["content"]["fields"]:
+        entries.append({"kind":"field","id":field["id"],"source_mrd":domain["_mrd"]["id"],"page":"020-work-field-and-vocabulary-reference.md","anchor":f"fact-field-{_anchor_token(field['id'])}"})
+    for vocabulary in domain["content"]["vocabularies"]:
+        for value in vocabulary["values"]:
+            entries.append({"kind":"vocabulary_value","id":f"{vocabulary['id']}:{value['token']}","source_mrd":domain["_mrd"]["id"],"page":"020-work-field-and-vocabulary-reference.md","anchor":f"fact-vocabulary-{_anchor_token(vocabulary['id'])}-{_anchor_token(value['token'])}"})
+    lifecycle = by_id["KIS-WORK-WRK-STM-001"]
+    for state in lifecycle["content"]["states"]:
+        entries.append({"kind":"work_state","id":state["token"],"source_mrd":lifecycle["_mrd"]["id"],"page":pages[lifecycle["_mrd"]["id"]],"anchor":f"fact-work-state-{_anchor_token(state['token'])}"})
+    for stage in lifecycle["content"]["delivery"]["stages"]:
+        entries.append({"kind":"delivery_stage","id":stage,"source_mrd":lifecycle["_mrd"]["id"],"page":pages[lifecycle["_mrd"]["id"]],"anchor":f"fact-delivery-stage-{_anchor_token(stage)}"})
+    selection = by_id["KIS-WORK-DEC-SCR-001"]
+    for rule in selection["content"]["rules"]:
+        entries.append({"kind":"selection_rule","id":rule["id"],"source_mrd":selection["_mrd"]["id"],"page":pages[selection["_mrd"]["id"]],"anchor":f"fact-selection-rule-{_anchor_token(rule['id'])}"})
+    authority = by_id["KIS-WORK-CON-POL-001"]
+    for field in authority["content"]["github_project_schema"]["fields"]:
+        entries.append({"kind":"project_field","id":field["name"],"source_mrd":authority["_mrd"]["id"],"page":"021-work-project-configuration-reference.md","anchor":f"fact-project-field-{_anchor_token(field['name'])}"})
+    for view in authority["content"]["github_project_schema"]["views"]:
+        entries.append({"kind":"project_view","id":view["name"],"source_mrd":authority["_mrd"]["id"],"page":"021-work-project-configuration-reference.md","anchor":f"fact-project-view-{_anchor_token(view['name'])}"})
+    return {"schema_version":1,"family":"work-management-spec","entries":sorted(entries,key=lambda item:(item["kind"],item["id"]))}
+
+
 def _inline_value(value: Any) -> str | None:
     if value is None:
         return "None"
@@ -180,13 +280,14 @@ def _render_domain_reference(content: dict[str, Any]) -> list[str]:
                 details.append(f"vocabulary `{field['vocabulary']}`")
             meaning = f"{field['definition']} {field['population']}"
             rows.append([
-                field["name"],
+                f'<span id="fact-field-{_anchor_token(field["id"])}"></span>{field["name"]}',
                 meaning,
                 f"`{field['authority']}`",
                 f"`{field['direction']}`",
                 "; ".join(details),
             ])
         _append_table(lines, ["Field", "Meaning", "Authority", "Direction", "Details"], rows)
+        lines.append("")
 
     lines.extend([
         "## Authority rules",
@@ -211,10 +312,15 @@ def _render_domain_reference(content: dict[str, Any]) -> list[str]:
             "",
         ])
         rows = [
-            [value["label"], f"`{value['token']}`", value["definition"]]
+            [
+                f'<span id="fact-vocabulary-{_anchor_token(vocabulary["id"])}-{_anchor_token(value["token"])}"></span>{value["label"]}',
+                f"`{value['token']}`",
+                value["definition"],
+            ]
             for value in vocabulary["values"]
         ]
         _append_table(lines, ["Value", "Token", "Meaning"], rows)
+        lines.append("")
     return lines
 
 
@@ -253,14 +359,19 @@ def _render_lifecycle(content: dict[str, Any]) -> list[str]:
     lines = [
         "A work item moves through explicit states. Project-visible states describe the shared work queue, while internal states such as Review, Verification, and Documentation describe delivery activity without creating new GitHub Project status values.",
         "",
+    ]
+    lines.extend(_work_status_delivery_diagram(content))
+    lines.extend([
         "## State model",
         "",
-    ]
+    ])
     _append_table(
         lines,
         ["State", "Meaning", "GitHub Project status", "Token"],
         [[state["label"], state["definition"], "Yes" if state["project_status"] else "No", f"`{state['token']}`"] for state in content["states"]],
     )
+    lines.extend(f'<span id="fact-work-state-{_anchor_token(state["token"])}"></span>' for state in content["states"])
+    lines.append("")
 
     lines.extend([
         "## Transitions",
@@ -299,7 +410,10 @@ def _render_lifecycle(content: dict[str, Any]) -> list[str]:
         "",
         "Delivery is tracked separately from the work state. The configured delivery-stage sequence is:",
         "",
-        _code_list(content["delivery"]["stages"]),
+        ", ".join(
+            f'<span id="fact-delivery-stage-{_anchor_token(stage)}"></span>`{stage}`'
+            for stage in content["delivery"]["stages"]
+        ),
         "",
         f"The **{content['delivery']['stage_field']}** field stores that stage. **{content['delivery']['change_id_field']}**, **{content['delivery']['complexity_field']}**, and **{content['delivery']['risk_triggers_field']}** connect the work record to repository change governance. The sequence starts its governed change at `{content['delivery']['change_created_stage']}` and reaches `{content['delivery']['complete_stage']}` when delivery is complete.",
         "",
@@ -406,8 +520,9 @@ def _render_selection(content: dict[str, Any]) -> list[str]:
     _append_table(
         lines,
         ["Rule", "Kind", "Requirement", "Failure reason"],
-        [[f"`{rule['id']}`", f"`{rule['kind']}`", rule["definition"], f"`{rule['reason_code']}`" if rule["reason_code"] is not None else "None"] for rule in content["rules"]],
+        [[f'<span id="fact-selection-rule-{_anchor_token(rule["id"])}"></span>`{rule["id"]}`', f"`{rule['kind']}`", rule["definition"], f"`{rule['reason_code']}`" if rule["reason_code"] is not None else "None"] for rule in content["rules"]],
     )
+    lines.append("")
     return lines
 
 
@@ -452,8 +567,9 @@ def _render_authority_reference(content: dict[str, Any]) -> list[str]:
     _append_table(
         lines,
         ["Field", "Type", "Options"],
-        [[field["name"], f"`{field['type']}`", _text_list(field["options"]) if field["options"] else "Not applicable"] for field in schema["fields"]],
+        [[f'<span id="fact-project-field-{_anchor_token(field["name"])}"></span>{field["name"]}', f"`{field['type']}`", _text_list(field["options"]) if field["options"] else "Not applicable"] for field in schema["fields"]],
     )
+    lines.append("")
     lines.extend([
         "### Project views",
         "",
@@ -470,8 +586,9 @@ def _render_authority_reference(content: dict[str, Any]) -> list[str]:
         if view["sort_by"]:
             grouping_parts.append(f"sort by {_text_list(view['sort_by'])}")
         grouping = "; ".join(grouping_parts) or "None"
-        view_rows.append([view["name"], view["purpose"], f"`{view['layout']}`", view["filter"], grouping, _text_list(view["visible_fields"])])
+        view_rows.append([f'<span id="fact-project-view-{_anchor_token(view["name"])}"></span>{view["name"]}', view["purpose"], f"`{view['layout']}`", view["filter"], grouping, _text_list(view["visible_fields"])])
     _append_table(lines, ["View", "Purpose", "Layout", "Filter", "Grouping / sort", "Visible fields"], view_rows)
+    lines.append("")
 
     bindings = content["project_bindings"]
     lines.extend([
@@ -538,6 +655,9 @@ def _render_provider_boundary(content: dict[str, Any]) -> list[str]:
     lines = [
         "The command plane defines the work states and fields that KIS may change. The provider boundary observes and mutates GitHub Project only through the configured read and write models; provider state does not redefine repository-owned facts.",
         "",
+    ]
+    lines.extend(_work_authority_handoff_diagram(content))
+    lines.extend([
         "## Command-plane model",
         "",
         f"Claims use **{command['claim']['execution_owner_field']}** and {'expire automatically' if command['claim']['auto_expiry'] else 'do not expire automatically'}. The completion policy targets `{command['completion']['terminal_state']}` and {'requires' if command['completion']['require_no_active_claim_after_close'] else 'does not require'} the claim to be absent after close.",
@@ -550,7 +670,7 @@ def _render_provider_boundary(content: dict[str, Any]) -> list[str]:
         "",
         "The provider adapter uses the field authority defined by the Work Management domain model; it does not maintain a second authority table. See the [Work Management domain model](002-work-management-domain-model.md) and [field reference](020-work-field-and-vocabulary-reference.md).",
         "",
-    ]
+    ])
 
     queue = command["queue"]
     readiness = command["readiness"]
@@ -663,6 +783,8 @@ def render_document(
         '<div id="enable-section-numbers" />',
         "",
         _work_navigation(previous, following),
+        "",
+        f'<span id="mrd-{_anchor_token(doc["_mrd"]["id"])}"></span>',
         "",
     ]
     renderer = renderers.get(doc["_mrd"]["id"], _render_generic)
@@ -824,6 +946,9 @@ def build_work_management_spec(repo: WorkManagementRepository, output: Path, *, 
         reference_pages = _work_reference_pages(docs)
         for name,text in reference_pages.items():
             (staging/name).write_bytes(text.encode("utf-8"))
+        coverage = _work_semantic_coverage(docs)
+        (staging/'data').mkdir(parents=True, exist_ok=True)
+        (staging/'data/semantic-coverage.json').write_bytes((json.dumps(coverage, indent=2, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8"))
         index = [
             "<!-- GENERATED — DO NOT EDIT -->",
             f"# {config['title']} — documentation index",
@@ -844,6 +969,7 @@ def build_work_management_spec(repo: WorkManagementRepository, output: Path, *, 
             "",
             "## Traceability",
             "",
+            "- [Semantic coverage](data/semantic-coverage.json) — canonical MRD and fact-to-page/anchor mappings",
             "- [Build manifest](manifest.json) — exact MRD and generated-file hashes",
             "",
         ]
@@ -891,7 +1017,7 @@ def build_work_management_spec(repo: WorkManagementRepository, output: Path, *, 
             "",
             "## Traceability",
             "",
-            "See the [documentation index](000-index.md) and [build manifest](manifest.json) for exact source identities, MRD versions, hashes, and generated-file declarations.",
+            "See the [documentation index](000-index.md), [semantic coverage](data/semantic-coverage.json), and [build manifest](manifest.json) for exact source identities, MRD versions, page/anchor mappings, hashes, and generated-file declarations.",
             "",
         ]
         spec="\n".join(root); (staging/'001-specification.md').write_bytes(spec.encode("utf-8")); (staging/'specification.md').write_bytes(spec.encode("utf-8"))
@@ -900,6 +1026,7 @@ def build_work_management_spec(repo: WorkManagementRepository, output: Path, *, 
             for path in sorted(staging.rglob('*'))
             if path.is_file()
         }
+        _validate_work_semantic_coverage(bundle_files, coverage)
         files=file_declarations(bundle_files)
         mrds=[]
         for path in sorted(repo.mrd_root.glob('*.mrd.json')):

--- a/tests/test_governance_renderer.py
+++ b/tests/test_governance_renderer.py
@@ -6,6 +6,7 @@ import re
 import shutil
 from pathlib import Path
 
+import pytest
 import kis_mcp_doc.render as render_module
 from kis_mcp_doc.governance import GovernanceRepository, canonical_source_bytes
 from kis_mcp_doc.render import build_governance_spec, verify_governance_spec
@@ -512,3 +513,71 @@ def test_verifier_detects_generated_data_file_tampering(tmp_path: Path) -> None:
     result = verify_governance_spec(repo, PUBLICATION, output)
     assert result["status"] == "invalid"
     assert "GENERATED_FILE_HASH_MISMATCH" in {item["code"] for item in result["diagnostics"]}
+
+def test_governance_diagrams_are_derived_from_canonical_mrds(tmp_path: Path) -> None:
+    repo = GovernanceRepository(ROOT, MRD_ROOT)
+    output = tmp_path / "build"
+    build_governance_spec(repo, PUBLICATION, output)
+    documents = repo.load()
+    lifecycle = documents["KIS-KNOW-WRK-STM-001"]["content"]
+    page = (output / "008-lifecycle.md").read_text(encoding="utf-8")
+    assert "```mermaid" in page
+    expected_edges = {
+        f"{render_module._heading_anchor(machine['record_mode'])}_{render_module._heading_anchor(transition['from'])} --> {render_module._heading_anchor(machine['record_mode'])}_{render_module._heading_anchor(transition['to'])}"
+        for machine in lifecycle["lifecycles"]
+        for transition in machine["transitions"]
+    }
+    actual_edges = {
+        line.strip() for line in page.splitlines()
+        if " --> " in line and any(
+            line.strip().startswith(render_module._heading_anchor(machine["record_mode"]) + "_")
+            for machine in lifecycle["lifecycles"]
+        )
+    }
+    assert actual_edges == expected_edges
+    ownership = documents["KIS-KNOW-CON-POL-002"]["content"]["ownership_contract"]
+    ownership_page = (output / "004-authority-ownership-and-relationships.md").read_text(encoding="utf-8")
+    assert f'Canonical owner count: {ownership["canonical_owner_count"]}' in ownership_page
+    assert ownership["non_owner_posture"] in ownership_page
+    assert ownership["derived_posture"] in ownership_page
+    assert ownership["conflict_posture"] in ownership_page
+
+
+def test_governance_semantic_coverage_resolves_every_rule_and_reference_fact(tmp_path: Path) -> None:
+    repo = GovernanceRepository(ROOT, MRD_ROOT)
+    output = tmp_path / "build"
+    build_governance_spec(repo, PUBLICATION, output)
+    coverage = json.loads((output / "data/semantic-coverage.json").read_text(encoding="utf-8"))
+    entries = coverage["entries"]
+    keys = [(entry["kind"], entry["id"]) for entry in entries]
+    assert len(keys) == len(set(keys))
+    expected_rules = {
+        rule["rule_id"]
+        for document in repo.load().values()
+        for rule in document["content"].get("rules", [])
+    }
+    actual_rules = {entry["id"] for entry in entries if entry["kind"] == "rule"}
+    assert actual_rules == expected_rules
+    for entry in entries:
+        page = output / entry["page"]
+        assert page.is_file()
+        assert f'id="{entry["anchor"]}"' in page.read_text(encoding="utf-8")
+
+
+def test_governance_semantic_coverage_rejects_duplicate_and_unresolved_entries() -> None:
+    files = {"page.md": b'<span id="anchor-a"></span>'}
+    duplicate = {
+        "entries": [
+            {"kind": "rule", "id": "A", "page": "page.md", "anchor": "anchor-a"},
+            {"kind": "rule", "id": "A", "page": "page.md", "anchor": "anchor-a"},
+        ]
+    }
+    with pytest.raises(ValueError, match="duplicate Governance semantic coverage entry"):
+        render_module._validate_governance_semantic_coverage(files, duplicate)
+    broken = {
+        "entries": [
+            {"kind": "rule", "id": "A", "page": "page.md", "anchor": "missing"}
+        ]
+    }
+    with pytest.raises(ValueError, match="Governance semantic coverage anchor does not resolve"):
+        render_module._validate_governance_semantic_coverage(files, broken)

--- a/tests/test_work_management_spec.py
+++ b/tests/test_work_management_spec.py
@@ -3,6 +3,8 @@ import json
 import re
 import shutil
 
+import pytest
+import kis_mcp_doc.work_management as work_module
 from kis_mcp_doc.work_management import WorkManagementRepository, build_work_management_spec, verify_work_management_spec
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -226,3 +228,82 @@ def test_snapshot_pins_parent_revision_and_live_project_state():
     assert observation["schema_status"]["missing_options"]==[]
     assert observation["schema_status"]["missing_views"]==[]
     assert observation["schema_status"]["view_mismatches"]==[]
+
+
+def test_work_diagrams_preserve_independent_status_and_delivery_dimensions(tmp_path):
+    output = tmp_path / "build"
+    repo = WorkManagementRepository(ROOT)
+    build_work_management_spec(repo, output)
+    docs = repo.load()
+    lifecycle = docs["KIS-WORK-WRK-STM-001"]["content"]
+    page = (output / "003-work-lifecycle.md").read_text(encoding="utf-8")
+    assert "Work Status and Delivery Stage are separate dimensions" in page
+    assert 'subgraph work_status["Work Status"]' in page
+    assert 'subgraph delivery_stage["Delivery Stage"]' in page
+    actual_status_edges = {
+        line.strip() for line in page.splitlines()
+        if line.strip().startswith("status_") and " --> " in line
+    }
+    expected_status_edges = {
+        f"status_{work_module._mermaid_token(source)} --> status_{work_module._mermaid_token(target)}"
+        for source, targets in lifecycle["transitions"].items()
+        for target in targets
+    }
+    assert actual_status_edges == expected_status_edges
+    actual_stage_edges = {
+        line.strip() for line in page.splitlines()
+        if line.strip().startswith("stage_") and " --> " in line
+    }
+    expected_stage_edges = {
+        f"stage_{work_module._mermaid_token(first)} --> stage_{work_module._mermaid_token(second)}"
+        for first, second in zip(lifecycle["delivery"]["stages"], lifecycle["delivery"]["stages"][1:])
+    }
+    assert actual_stage_edges == expected_stage_edges
+    provider = (output / "007-provider-and-command-plane-boundary.md").read_text(encoding="utf-8")
+    assert "## Authority and handoff flow" in provider
+    authority = docs["KIS-WORK-CTR-SVC-001"]["content"]["command_plane"]["field_authority"]
+    grouped = {}
+    for field, contract in authority.items():
+        grouped.setdefault((contract["authority"], contract["direction"]), []).append(field)
+    for (owner, direction), fields in grouped.items():
+        assert f"- `{owner}` -> `{direction}`: {', '.join(sorted(fields))}." in provider
+
+
+def test_work_semantic_coverage_resolves_declared_facts(tmp_path):
+    output = tmp_path / "build"
+    repo = WorkManagementRepository(ROOT)
+    build_work_management_spec(repo, output)
+    coverage = json.loads((output / "data/semantic-coverage.json").read_text(encoding="utf-8"))
+    entries = coverage["entries"]
+    keys = [(entry["kind"], entry["id"]) for entry in entries]
+    assert len(keys) == len(set(keys))
+    docs = repo.load()
+    assert {entry["id"] for entry in entries if entry["kind"] == "mrd"} == set(docs)
+    lifecycle = docs["KIS-WORK-WRK-STM-001"]["content"]
+    assert {entry["id"] for entry in entries if entry["kind"] == "work_state"} == {
+        state["token"] for state in lifecycle["states"]
+    }
+    assert {entry["id"] for entry in entries if entry["kind"] == "delivery_stage"} == set(lifecycle["delivery"]["stages"])
+    for entry in entries:
+        page = output / entry["page"]
+        assert page.is_file()
+        assert f'id="{entry["anchor"]}"' in page.read_text(encoding="utf-8")
+
+
+def test_work_semantic_coverage_rejects_duplicate_and_unresolved_entries() -> None:
+    files = {"page.md": b'<span id="anchor-a"></span>'}
+    duplicate = {
+        "entries": [
+            {"kind": "field", "id": "A", "page": "page.md", "anchor": "anchor-a"},
+            {"kind": "field", "id": "A", "page": "page.md", "anchor": "anchor-a"},
+        ]
+    }
+    with pytest.raises(ValueError, match="duplicate Work semantic coverage entry"):
+        work_module._validate_work_semantic_coverage(files, duplicate)
+    broken = {
+        "entries": [
+            {"kind": "field", "id": "A", "page": "page.md", "anchor": "missing"}
+        ]
+    }
+    with pytest.raises(ValueError, match="Work semantic coverage anchor does not resolve"):
+        work_module._validate_work_semantic_coverage(files, broken)


### PR DESCRIPTION
Implements Change 012 for issue #20.

Adds source-derived Governance and Work Management Mermaid diagrams plus deterministic semantic coverage maps from canonical facts/rules to generated pages and anchors. Coverage generation fails closed for duplicate IDs, missing pages, and unresolved anchors. Existing textual specification/reference surfaces remain authoritative projections; diagrams do not create new authority or replace canonical prose/tables.

Verification: focused suites pass; full pytest passes (117 tests); canonical scripts/verify.ps1 passes; exact-commit verification passes for f772fa83e5d064f4a35f70d9ae559e80be6230c5. Protected Governance, Work Management, Documentation MRDs, contracts, and publication configs are unchanged.

Specialist review projectors were incomplete because evidence limits omitted required renderer/reference/test files; mandated manual exact-diff fallback completed with no additional findings.

Related issue: #20