### PR TITLE
013 — Task-Oriented Human Documentation

### DIFF
--- a/.work/changes/013-task-oriented-human-documentation/change.mrd.json
+++ b/.work/changes/013-task-oriented-human-documentation/change.mrd.json
@@ -1,0 +1,130 @@
+{
+  "_mrd": {
+    "schema_version": 1,
+    "id": "KIS-CHG013-WRK-WFL-001",
+    "title": "Task-Oriented Human Documentation",
+    "module": "change-013",
+    "class": "WRK",
+    "type": "WFL",
+    "layer": "L3",
+    "record_mode": "descriptive",
+    "status": "active",
+    "version": "1.0.0",
+    "dependencies": [
+      {"mrd_id": "KIS-DOC-CON-POL-001", "relationship": "depends_on"},
+      {"mrd_id": "KIS-DOC-CON-POL-002", "relationship": "depends_on"},
+      {"mrd_id": "KIS-DOC-SEM-REG-002", "relationship": "depends_on"}
+    ],
+    "provenance": {
+      "sources": [
+        {"source_id": "KIS-OPERATOR-DIRECTION-2026-08-26-HUMAN-DOCS", "kind": "operator_direction", "role": "approved_change_basis", "locator": "conversation:2026-08-26", "revision": "preparation-approved", "sha256": null},
+        {"source_id": "GH-ISSUE-22", "kind": "operator_approved_work_item", "role": "approved_change_basis", "locator": "github:NielPieterse0/kis-mcp-doc#22", "revision": "2026-08-26", "sha256": null},
+        {"source_id": "KIS-CHG012-WRK-WFL-001", "kind": "canonical_machine_readable_record", "role": "publication_capability_basis", "locator": ".work/changes/012-deterministic-diagrams-and-semantic-coverage/change.mrd.json", "revision": "1.0.0", "sha256": null}
+      ],
+      "source_fingerprint": null,
+      "fact_quality": "direct"
+    },    "supersedes": [],
+    "superseded_by": null
+  },
+  "content": {
+    "change_id": "013-task-oriented-human-documentation",
+    "work_item": {
+      "repository": "NielPieterse0/kis-mcp-doc",
+      "issue": 22,
+      "project": "NielPieterse0/1",
+      "record_id": "SPEC-013"
+    },
+    "outcome": "Prepare a governed implementation slice for task-oriented human documentation that complements existing Specification and generated-reference surfaces while preserving canonical fact ownership.",
+    "classification": {
+      "complexity": "large",
+      "risk_triggers": ["public_contract"],
+      "reason": "The future implementation will introduce a new reader-facing publication surface and must preserve authority, provenance, determinism, and separation from normative specification content."
+    },
+    "authority_model": [
+      "Canonical Governance and Work Management MRDs remain the sole owners of domain facts and requirements.",
+      "KIS-DOC-CON-POL-001 remains authoritative for documentation output classes and source-authority boundaries.",
+      "The publication kernel and family registry remain authoritative for shared deterministic publication mechanics and family discovery.",
+      "Task-oriented human documentation is downstream explanatory output and MUST NOT gain write-back or canonical fact ownership.",
+      "Specification and generated-reference surfaces remain the authoritative reader locations for exact normative and lookup material."
+    ],    "design_decisions": [
+      "D1: Treat Docs, Specification, and generated reference as distinct reader surfaces with explicit content-placement rules.",
+      "D2: Use Governance and Work Management as the first task-documentation reference domains.",
+      "D3: Human docs may explain concepts, workflows, examples, common operations, and troubleshooting, but factual claims must remain derivable from governed sources.",
+      "D4: Reuse the existing publication kernel, family registry, provenance, deterministic generation, diagrams, semantic coverage, stale/tamper detection, and verification paths.",
+      "D5: Avoid wholesale duplication of normative text; link to Specification/reference surfaces where exact rules or lookup facts belong.",
+      "D6: The existing governed human_documentation output class is sufficient; Change 013 registers two new families without changing the output-class contract.",
+      "D7: Only the publication-family registry changes canonically; Governance and Work Management MRDs remain untouched.",
+      "D8: Existing publication bundles are regenerated only because their manifests bind the family-registry hash; their reader-facing content remains unchanged."
+    ],
+    "requirements": [
+      "R1: The implementation plan MUST define an explicit Docs versus Specification versus generated-reference placement model.",
+      "R2: Human documentation MUST remain downstream of canonical MRDs and MUST NOT become a second fact owner.",
+      "R3: Every governed factual statement in human docs MUST be traceable to canonical source data or an existing governed publication projection.",
+      "R4: Exact normative requirements and lookup-heavy reference material SHOULD be linked rather than redundantly restated where duplication would create drift risk.",
+      "R5: Reader-oriented examples MUST be clearly identified and MUST NOT imply unsupported semantics.",
+      "R6: Human-documentation publication families MUST use the existing publication kernel/family registry rather than parallel mechanics.",
+      "R7: Determinism, provenance, stale/tamper detection, source traceability, accessibility, and existing verification guarantees MUST be retained.",
+      "R8: Governance and Work Management semantics MUST remain unchanged unless a later separately approved change explicitly authorizes such changes.",
+      "R9: Existing specification and generated-reference reader content MUST remain unchanged except for deterministic manifest updates caused by the family-registry revision."
+    ],
+    "implementation_plan": [
+      "P1: Reuse the already-governed human_documentation output class and register Governance Docs and Work Management Docs as distinct publication families.",
+      "P2: Add family-specific publication configs and a shared human-documentation renderer that consumes canonical domain MRDs without interpreting new semantics.",
+      "P3: Generate overview, concept/lifecycle, task/workflow, troubleshooting, and bounded example pages with source-traceability data.",
+      "P4: Route build/validate/verify through the existing publication kernel adapters and bind source, generator, registry, and output hashes in deterministic manifests.",
+      "P5: Regenerate pre-existing publication manifests required by the registry revision while preserving their reader-facing content byte-for-byte.",
+      "P6: Run focused, full, registry-wide, stale/tamper, link, and source-traceability verification plus specialist review before governed publication."
+    ],
+    "verification_criteria": [
+      "V1: Governance Docs and Work Management Docs are registered with output class human_documentation only.",
+      "V2: Generated docs are deterministic and every topic in source-traceability data resolves only to canonical MRDs in its registered domain.",
+      "V3: Generated docs link readers to existing specifications for exact normative/reference material and do not create a duplicate canonical authority.",
+      "V4: Tampering with a generated human-documentation file is detected by exact bundle verification.",
+      "V5: Direct diffs under mrd/governance/** and mrd/work-management/** remain empty.",
+      "V6: Existing Governance, Work Management, and Documentation Reference reader-facing publication files remain byte-identical; only their manifests may change from registry binding.",
+      "V7: Full repository tests and scripts/verify.ps1 pass with all registered publication families valid and current.",
+      "V8: Architecture, documentation, API-contract, and code-quality review find no authority inversion, invented semantics, or parallel publication mechanism."
+    ],
+    "tasks": [
+      {"id": "T0", "status": "done", "text": "Close Change 012 external work state and remove its merged clean worktree."},
+      {"id": "T1", "status": "done", "text": "Create GitHub issue 22 and the isolated governed Change 013 preparation records."},
+      {"id": "T2", "status": "done", "text": "Expand the governed scope after explicit implementation approval and register the two human-documentation families."},
+      {"id": "T3", "status": "done", "text": "Implement deterministic Governance and Work Management task-documentation generation, traceability, examples, and adapters."},
+      {"id": "T4", "status": "done", "text": "Regenerate affected publication bundles and prove existing reader-facing specification/reference content is unchanged."},
+      {"id": "T5", "status": "done", "text": "Run focused and full repository verification across all five registered publication families."},
+      {"id": "T6", "status": "in_progress", "text": "Complete specialist reviews, exact-commit verification, governed publication, CI, merge, reconciliation, and cleanup."}
+    ],
+    "risks": [
+      "Authority duplication: task docs can drift if they restate exact normative/reference content.",
+      "Audience mixing: one page can become unreadable if tutorial, concept, reference, and governance material are not separated.",
+      "Example invention: explanatory examples can imply unsupported behavior unless bounded by canonical semantics.",
+      "Publication sprawl: a new family can duplicate mechanics unless it is registered through the existing kernel."
+    ],
+    "explicit_exclusions": [
+      "Any change to canonical Governance or Work Management MRDs or their governed semantics.",
+      "Any change to the Documentation Reference Standard output-class contract or publication-kernel architecture contract.",
+      "Any independent publication mechanism outside the existing family registry, adapters, and kernel.",
+      "Any site/portal redesign, parent KIS change, or external-reference refresh."
+    ],
+    "closeout": {
+      "state": "implementation_verified_awaiting_exact_commit_and_publication",
+      "verification": [
+        "Focused human-documentation and publication-kernel tests passed.",
+        "Full repository verification passed with 123 tests and all five registered publication families valid and current.",
+        "git diff --check is clean after fixing generated index EOF whitespace at the generator.",
+        "Governance and Work Management canonical MRD diffs are empty.",
+        "Existing Governance, Work Management, and Documentation Reference reader-facing generated files are unchanged; only their deterministic manifests changed because the family-registry hash changed.",
+        "Generated human-documentation bundles include source traceability and exact stale/tamper verification."
+      ],
+      "reviews": [
+        "Architecture specialist review completed with no findings.",
+        "API-contract specialist review completed with informational observations only and no actionable findings.",
+        "Documentation specialist review reported two low list-marker findings; direct byte inspection proved both were false positives because generated indexes and generator both use hyphen list markers.",
+        "Automated code-quality review exhausted NVIDIA and Codex deadlines; the prescribed exact-diff manual fallback found only generated index EOF whitespace, which was fixed at the generator and reverified with a clean diff check and full repository verification."
+      ],
+      "publication": {"status": "pending_exact_commit_and_github_checks", "issue": 22},
+      "merge": null,
+      "unresolved": ["Exact-commit verification, GitHub publication, PR CI, merge, Work Management reconciliation, and worktree cleanup remain pending."]
+    }
+  }
+}

--- a/.work/changes/013-task-oriented-human-documentation/scope.json
+++ b/.work/changes/013-task-oriented-human-documentation/scope.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": 4,
+  "change_id": "013-task-oriented-human-documentation",
+  "status": "active",
+  "branch": "change/013-task-oriented-human-documentation",
+  "worktree": ".work/worktrees/013-task-oriented-human-documentation",
+  "base": "main",
+  "outcome": "Implement registered task-oriented human-documentation publication families for Governance and Work Management using canonical MRDs and the existing publication kernel, without changing Governance or Work Management semantics.",
+  "owned_paths": [
+    ".work/changes/013-task-oriented-human-documentation/**",
+    "mrd/documentation/04-publication-family-registry.mrd.json",
+    "publication/governance-docs.json",
+    "publication/work-management-docs.json",
+    "src/kis_mcp_doc/human_docs.py",
+    "src/kis_mcp_doc/publication_adapters.py",
+    "generated/governance-docs/**",
+    "generated/work-management-docs/**",
+    "generated/governance-spec/**",
+    "generated/work-management-spec/**",
+    "generated/documentation-reference-standard/**",
+    "tests/test_human_docs.py",
+    "tests/test_publication_kernel.py",
+    "scripts/verify.ps1"
+  ],
+  "shared_paths": [],
+  "excluded_paths": [
+    "AGENTS.md",
+    "contracts/**",
+    "mrd/governance/**",
+    "mrd/work-management/**",
+    "mrd/documentation/01-reference-standard.mrd.json",
+    "mrd/documentation/02-reference-registry.mrd.json",
+    "mrd/documentation/03-publication-architecture.mrd.json",
+    "publication/governance-spec.json",
+    "publication/work-management-spec.json",
+    "publication/documentation-reference-standard.json",
+    "src/kis_mcp_doc/render.py",
+    "src/kis_mcp_doc/work_management.py",
+    "src/kis_mcp_doc/publication_kernel.py",
+    "evidence/**",
+    "C:/Projects/kis-mcp/**",
+    "C:/Projects/References/**"
+  ],  "dependencies": [
+    "008-documentation-reference-standard",
+    "010-hrd-reader-experience-and-reference-separation",
+    "011-publication-kernel-and-family-registry",
+    "012-deterministic-diagrams-and-semantic-coverage"
+  ],
+  "integration_owner": null,
+  "complexity": "large",
+  "risk_triggers": [
+    "public_contract"
+  ],
+  "base_evidence": {
+    "local_sha": "563bcfb56f6233b9711a39f6f49b8fbca82c467d",
+    "local_tree": "b5edac504260d77e6e3635026379277e06a36fc2",
+    "upstream_sha": "563bcfb56f6233b9711a39f6f49b8fbca82c467d",
+    "upstream_tree": "b5edac504260d77e6e3635026379277e06a36fc2",
+    "upstream_ref": "github:main",
+    "evidence_source": "verified_github_default",
+    "relation": "equal"
+  },
+  "work_management": {
+    "project_id": "kis-mcp",
+    "record_id": "SPEC-013",
+    "source_repository": "NielPieterse0/kis-mcp-doc",
+    "source_number": 22,
+    "source_kind": "issue",
+    "documentation_impact": "planned"
+  }
+}

--- a/generated/documentation-reference-standard/manifest.json
+++ b/generated/documentation-reference-standard/manifest.json
@@ -26,7 +26,7 @@
       "sha256": "0daffac7e07d744a752affde559c65708568fd2ce6fc95d7672185717145d3cc"
     }
   ],
-  "input_set_sha256": "59d3af152f7f9624883c20a2f770a53b21a83ccd3f317ac52514179c826cacaf",
+  "input_set_sha256": "a395b51f0e609b0ac9eb359a9a924054a849ddf95c7b88ac148e56adab5e3910",
   "inputs": [
     {
       "bytes": 5712,
@@ -49,9 +49,9 @@
       "sha256": "e266a4a60b6037129a106f5f7f977161cd01d69983560a8de790d7d9d6cf9c71"
     },
     {
-      "bytes": 4479,
+      "bytes": 6560,
       "path": "mrd/documentation/04-publication-family-registry.mrd.json",
-      "sha256": "e72c7546e6e02b13a384e4ce722a057e5fdae50ee8d0e099af4f1ac491775d17"
+      "sha256": "171891c0689908f5b074bd587266a22abf13d44a6aa98d35d08234b6cef1fcc9"
     },
     {
       "bytes": 3657,

--- a/generated/governance-docs/000-index.md
+++ b/generated/governance-docs/000-index.md
@@ -1,0 +1,16 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Governance Documentation
+
+Practical guidance for applying KIS governance
+
+Use these pages when you need to apply governance, not when you need the normative contract.
+The generated documentation explains canonical Governance MRDs without becoming a second authority.
+
+## Start here
+
+- [Understand authority and ownership](002-understand-authority.md)
+- [Apply governance to a change](003-apply-governance.md)
+- [Understand MRD lifecycle](004-mrd-lifecycle.md)
+- [Troubleshoot governance failures](005-troubleshooting.md)
+- [Governance examples](006-examples.md)
+- [Governance Specification](../governance-spec/001-specification.md) for normative rules and exact reference material

--- a/generated/governance-docs/002-understand-authority.md
+++ b/generated/governance-docs/002-understand-authority.md
@@ -1,0 +1,15 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Understand authority and ownership
+
+Ensure every governed fact has one canonical owner and every non-owning artifact preserves authority through explicit typed relationships instead of restating truth.
+
+A governed fact has one current canonical owner. Other artifacts may explain or project that fact, but they do not become another owner.
+
+## Working rule
+
+- Canonical owner count: **1**.
+- Non-owner posture: `reference_not_restate`.
+- Derived posture: `projection_only`.
+- Conflict posture: `surface_diagnostic_and_resolve_against_current_owner`.
+
+For the complete relationship vocabulary and normative requirements, see the [Governance Specification](../governance-spec/001-specification.md).

--- a/generated/governance-docs/003-apply-governance.md
+++ b/generated/governance-docs/003-apply-governance.md
@@ -1,0 +1,63 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Apply governance to a change
+
+Prescribe how kis-op applies the governance model when inspecting, planning, changing, validating, and presenting governed repository work.
+
+Follow the canonical phases in order. A phase can stop the change when its declared stop condition is met.
+
+## 1. Resolve Authority
+
+- load repository authority and active change scope.
+- identify canonical owners relevant to the request.
+
+Stop here when:
+- required authority cannot be resolved.
+
+## 2. Select Applicable Mrds
+
+- classify the actual governed needs.
+- apply the 47-type applicability contract.
+- select the minimum sufficient MRD set.
+
+Stop here when:
+- a required need has no representable type and no governed extension path.
+
+## 3. Resolve Relationships
+
+- bind dependencies and typed relationships.
+- detect duplicate ownership and authority conflicts.
+
+Stop here when:
+- required dependency or canonical owner is unresolved.
+
+## 4. Validate Governance
+
+- run structural and semantic governance validation.
+- surface stable reason codes for blocking failures.
+
+Stop here when:
+- blocking governance validation fails.
+
+## 5. Execute Bounded Change
+
+- work only inside the admitted change scope.
+- preserve parent KIS trust and Git authority.
+- avoid unrelated documentation or platform expansion.
+
+Stop here when:
+- requested mutation exceeds admitted scope or authority.
+
+## 6. Generate Review Surface
+
+- generate the HRD specification from validated MRDs.
+- preserve provenance and deterministic source bindings.
+
+Stop here when:
+- source validation or deterministic generation fails.
+
+## 7. Verify And Report
+
+- verify generated output is current and untampered.
+- report completion, gaps, deferrals, and diagnostics against the requested scope.
+
+Use the [Governance Specification](../governance-spec/001-specification.md) when you need exact MUST/SHOULD/MAY requirements or rule identifiers.

--- a/generated/governance-docs/004-mrd-lifecycle.md
+++ b/generated/governance-docs/004-mrd-lifecycle.md
@@ -1,0 +1,26 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Understand MRD lifecycle
+
+Define minimal lifecycle and mutability rules for each record mode.
+
+The lifecycle depends on the MRD record mode.
+
+## Prescriptive
+
+States: `draft`, `active`, `superseded`.
+
+Allowed transitions: `draft` → `active`, `active` → `superseded`.
+
+## Descriptive
+
+States: `created`, `retained`.
+
+Allowed transitions: `created` → `retained`.
+
+## Meta
+
+States: `generated`, `replaced`.
+
+Allowed transitions: `generated` → `replaced`.
+
+See the [Governance Specification](../governance-spec/001-specification.md) for lifecycle requirements and lineage rules.

--- a/generated/governance-docs/005-troubleshooting.md
+++ b/generated/governance-docs/005-troubleshooting.md
@@ -1,0 +1,51 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Troubleshoot governance failures
+
+Use canonical stop conditions and validation evidence to decide what must be fixed before work continues.
+
+## Common blocking situations
+
+- required authority cannot be resolved.
+- a required need has no representable type and no governed extension path.
+- required dependency or canonical owner is unresolved.
+- blocking governance validation fails.
+- requested mutation exceeds admitted scope or authority.
+- source validation or deterministic generation fails.
+
+## Validation evidence
+
+Validation uses stable reason codes. Do not infer past a blocking diagnostic.
+
+- `MRD_SCHEMA_INVALID`
+- `MRD_RULE_ID_DUPLICATE`
+- `MRD_GOVERNANCE_CONCERN_MISSING`
+- `MRD_GOVERNANCE_CONCERN_DUPLICATE`
+- `MRD_ID_CLASS_TYPE_MISMATCH`
+- `MRD_CLASS_UNKNOWN`
+- `MRD_TYPE_INVALID`
+- `MRD_CATALOG_COUNT_MISMATCH`
+- `MRD_LAYER_INVALID`
+- `MRD_DEPENDENCY_UNRESOLVED`
+- `MRD_DEPENDENCY_LAYER_VIOLATION`
+- `MRD_DEPENDENCY_CYCLE`
+- `MRD_DEPENDENCY_DUPLICATE`
+- `MRD_SOURCE_UNRESOLVED`
+- `MRD_SOURCE_FINGERPRINT_MISMATCH`
+- `MRD_SOURCE_HASH_MISMATCH`
+- `MRD_NORMATIVE_INFERENCE_PROHIBITED`
+- `MRD_RECORD_MODE_INVALID`
+- `MRD_STATUS_INVALID`
+- `MRD_EVD_RECORD_MODE_INVALID`
+- `MRD_META_RECORD_MODE_INVALID`
+- `MRD_SUPERSESSION_UNRESOLVED`
+- `MRD_CLASS_CATALOG_MISMATCH`
+- `MRD_LAYER_CATALOG_MISMATCH`
+- `MRD_RECORD_MODE_CATALOG_MISMATCH`
+- `MRD_META_FACT_QUALITY_INVALID`
+- `MRD_VALIDATION_CONTRACT_MISMATCH`
+- `MRD_APPLICABILITY_CATALOG_MISMATCH`
+- `MRD_RELATIONSHIP_UNKNOWN`
+- `MRD_OPERATOR_BEHAVIOR_INVALID`
+- `MRD_ENFORCEMENT_BINDING_INVALID`
+
+Use the [Governance Specification](../governance-spec/001-specification.md) to resolve a reason code against its normative validation contract.

--- a/generated/governance-docs/006-examples.md
+++ b/generated/governance-docs/006-examples.md
@@ -1,0 +1,18 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Governance examples
+
+These examples illustrate the canonical workflow; they do not add governance semantics.
+
+## Example: govern a repository change
+
+1. Resolve repository authority and the active change scope.
+2. Select only the MRDs required by the governed needs.
+3. Resolve dependencies, ownership, and typed relationships.
+4. Run structural and semantic governance validation.
+5. Execute only inside the admitted scope.
+6. Generate the review surface from validated authority.
+7. Verify generated output and report remaining gaps or diagnostics.
+
+If any canonical phase declares a blocking stop condition, stop the example at that phase rather than inferring authority.
+
+For exact requirements behind each phase, use the [Governance Specification](../governance-spec/001-specification.md).

--- a/generated/governance-docs/data/source-traceability.json
+++ b/generated/governance-docs/data/source-traceability.json
@@ -1,0 +1,36 @@
+{
+  "output_class": "human_documentation",
+  "topics": [
+    {
+      "page": "002-understand-authority.md",
+      "source_mrds": [
+        "KIS-KNOW-CON-POL-002"
+      ]
+    },
+    {
+      "page": "003-apply-governance.md",
+      "source_mrds": [
+        "KIS-KNOW-WRK-WFL-001"
+      ]
+    },
+    {
+      "page": "004-mrd-lifecycle.md",
+      "source_mrds": [
+        "KIS-KNOW-WRK-STM-001"
+      ]
+    },
+    {
+      "page": "005-troubleshooting.md",
+      "source_mrds": [
+        "KIS-KNOW-WRK-WFL-001",
+        "KIS-KNOW-EVL-TST-001"
+      ]
+    },
+    {
+      "page": "006-examples.md",
+      "source_mrds": [
+        "KIS-KNOW-WRK-WFL-001"
+      ]
+    }
+  ]
+}

--- a/generated/governance-docs/manifest.json
+++ b/generated/governance-docs/manifest.json
@@ -1,0 +1,125 @@
+{
+  "bundle_sha256": "017b3c828c24a8b49c1e6a73e9e5bde22fc583d62c8d70babf16c35f804eae96",
+  "contract": {
+    "name": "kis-human-documentation-build",
+    "version": 1
+  },
+  "family_id": "governance-docs",
+  "files": [
+    {
+      "bytes": 718,
+      "path": "000-index.md",
+      "sha256": "b7d8ff6a01ae892fa3ef8d5fb660fcc82a23864305858c69af1b83512635e2d9"
+    },
+    {
+      "bytes": 734,
+      "path": "002-understand-authority.md",
+      "sha256": "23da8a7492417709bcabb898da54686e91a287af44946b3b35eeba146fab106e"
+    },
+    {
+      "bytes": 1923,
+      "path": "003-apply-governance.md",
+      "sha256": "199da9ddd101b6853125724ada62a77a7450fb5272aebc89008cec2466bac8c0"
+    },
+    {
+      "bytes": 620,
+      "path": "004-mrd-lifecycle.md",
+      "sha256": "64e5119d478cbd0574ac9bad62623f6bf52e61833028de6a2ab4f4626cd34b9f"
+    },
+    {
+      "bytes": 1737,
+      "path": "005-troubleshooting.md",
+      "sha256": "09c1b9fbc342eefe4f5756825234e5c84b4a474eacadbf6fd56574bf2bcbc01c"
+    },
+    {
+      "bytes": 832,
+      "path": "006-examples.md",
+      "sha256": "b3158b673ce25a2ef061370d602e7fefafbc3d81c03e5ac263f7126f66f3eacd"
+    },
+    {
+      "bytes": 666,
+      "path": "data/source-traceability.json",
+      "sha256": "98220bc89ab63ac9d4ea7179ce6f7e9baf860d96ef6df4f3bea817e24431e860"
+    }
+  ],
+  "generator": {
+    "algorithm": "human-docs-v1",
+    "name": "kis-mcp-doc"
+  },
+  "inputs": {
+    "source_files": [
+      {
+        "bytes": 5712,
+        "path": "mrd/documentation/01-reference-standard.mrd.json",
+        "sha256": "da30a9f44828194a6b0b1e382c39936ae3d07705521dd6c07af60286b5133dc1"
+      },
+      {
+        "bytes": 6560,
+        "path": "mrd/documentation/04-publication-family-registry.mrd.json",
+        "sha256": "171891c0689908f5b074bd587266a22abf13d44a6aa98d35d08234b6cef1fcc9"
+      },
+      {
+        "bytes": 406,
+        "path": "publication/governance-docs.json",
+        "sha256": "88a80997db6c431473f1fc819e87e1dd084a73597c51de0b951c3dbf981b002c"
+      },
+      {
+        "bytes": 17941,
+        "path": "src/kis_mcp_doc/human_docs.py",
+        "sha256": "36fd13f6695f50f4d190516c33b23bf5b9a00571985634f5c5d155acbc857dce"
+      },
+      {
+        "bytes": 6152,
+        "path": "src/kis_mcp_doc/publication_adapters.py",
+        "sha256": "276df0de30dc879204ebffcf0eaf14f6ce2f1c6c24e5318562bd5cd9534822a0"
+      },
+      {
+        "bytes": 12471,
+        "path": "mrd/governance/01-classification.mrd.json",
+        "sha256": "848951c422a256b44f1b85a82c4ab39d3d05c4c877b77e2608bc5bee373587ec"
+      },
+      {
+        "bytes": 2988,
+        "path": "mrd/governance/02-layering.mrd.json",
+        "sha256": "866fa74d0c5b4101a48924e0f244a77ce1c7e595dc9e1210fe364036bfb2036e"
+      },
+      {
+        "bytes": 2615,
+        "path": "mrd/governance/03-dependencies.mrd.json",
+        "sha256": "dd0176b040a40e55fdf68d35cab88908dd4bed20151a1cee0ea3eb3a329f7a8c"
+      },
+      {
+        "bytes": 4438,
+        "path": "mrd/governance/04-provenance.mrd.json",
+        "sha256": "0ef650015753adb96d7fdc850d5dd2d0c55dba54fedebb5f6b6d34d0edbe2093"
+      },
+      {
+        "bytes": 3244,
+        "path": "mrd/governance/05-lifecycle.mrd.json",
+        "sha256": "6f3a17f123a882d3c112f1de2f03d6f3e3e13b7dfed7112684d0142a11c9ae7e"
+      },
+      {
+        "bytes": 7981,
+        "path": "mrd/governance/06-validation.mrd.json",
+        "sha256": "7760bc372bd223d31a9019f2133f99e81aa73bc50101383e18ef6ce1057bf3e4"
+      },
+      {
+        "bytes": 15162,
+        "path": "mrd/governance/07-applicability.mrd.json",
+        "sha256": "921432f1e483dbb1cee5860d5570cf75f8a1faa2ce097e8c10008e51e135645f"
+      },
+      {
+        "bytes": 5229,
+        "path": "mrd/governance/08-ownership.mrd.json",
+        "sha256": "59344ac7e280bf7ea51307a03972a7b93b4d4cd64e3d0378fe4f6ba1fe32de76"
+      },
+      {
+        "bytes": 6534,
+        "path": "mrd/governance/09-kis-op-behavior.mrd.json",
+        "sha256": "5e9ba131e1c5f37f7e2e934ab0f2b3e8e03a61617cda5ef054ec7c81015f564d"
+      }
+    ]
+  },
+  "output_class": "human_documentation",
+  "traceability_topics": 5
+}

--- a/generated/governance-spec/manifest.json
+++ b/generated/governance-spec/manifest.json
@@ -247,9 +247,9 @@
         "sha256": "e266a4a60b6037129a106f5f7f977161cd01d69983560a8de790d7d9d6cf9c71"
       },
       {
-        "bytes": 4479,
+        "bytes": 6560,
         "path": "mrd/documentation/04-publication-family-registry.mrd.json",
-        "sha256": "e72c7546e6e02b13a384e4ce722a057e5fdae50ee8d0e099af4f1ac491775d17"
+        "sha256": "171891c0689908f5b074bd587266a22abf13d44a6aa98d35d08234b6cef1fcc9"
       },
       {
         "bytes": 403,

--- a/generated/work-management-docs/000-index.md
+++ b/generated/work-management-docs/000-index.md
@@ -1,0 +1,15 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Work Management Documentation
+
+Practical guidance for planning, executing, and closing governed work
+
+Use these pages to operate the governed Work system. Exact state, field, and provider contracts remain in the Work Management Specification and generated reference.
+
+## Start here
+
+- [Move work through its lifecycle](002-work-lifecycle.md)
+- [Use Work Management operations](003-work-operations.md)
+- [Complete governed work](004-complete-work.md)
+- [Troubleshoot work state](005-troubleshooting.md)
+- [Work Management examples](006-examples.md)
+- [Work Management Specification](../work-management-spec/001-specification.md) for normative and exact reference material

--- a/generated/work-management-docs/002-work-lifecycle.md
+++ b/generated/work-management-docs/002-work-lifecycle.md
@@ -1,0 +1,32 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Move work through its lifecycle
+
+Define Work states, transitions, readiness, claims, delivery stages, completion gates, and guards.
+
+Work Status and Delivery Stage are separate dimensions. Change one only through its owning authority.
+
+## Work states
+
+- **Inbox** (`inbox`): Captured work not yet triaged.
+- **Triage** (`triage`): Work being classified.
+- **Proposed** (`proposed`): Work proposed for approval.
+- **Approved** (`approved`): Accepted work not yet admitted to Ready.
+- **Ready** (`ready`): Executable queue state subject to readiness guards.
+- **Active** (`active`): Claimed execution state.
+- **Review** (`review`): Internal delivery state for review activity.
+- **Verification** (`verification`): Internal delivery state for verification activity.
+- **Documentation** (`documentation`): Internal delivery state for documentation reconciliation.
+- **Blocked** (`blocked`): Execution cannot proceed because a blocker is present.
+- **On Hold** (`on_hold`): Intentionally paused pending a review trigger.
+- **Deferred** (`deferred`): Postponed for later reconsideration.
+- **Rejected** (`rejected`): Not accepted for execution in current form.
+- **Superseded** (`superseded`): Replaced by newer authoritative work.
+- **Done** (`done`): Required completion gates are satisfied.
+
+## Before work becomes Ready
+
+- Required Project fields: Record Type, Priority, Effort, Documentation Impact.
+- Required issue sections: Outcome, Acceptance criteria.
+- Dependencies must be understood.
+
+See the [Work Management Specification](../work-management-spec/001-specification.md) for every allowed transition and guard.

--- a/generated/work-management-docs/003-work-operations.md
+++ b/generated/work-management-docs/003-work-operations.md
@@ -1,0 +1,86 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Use Work Management operations
+
+Define the bounded Work Management operations and their implementation surfaces.
+
+Choose the operation that matches the intended lifecycle action; mutation authority is bounded by the command plane.
+
+## Capture Work
+
+Capture one bounded source record into Work without duplicating source identity.
+
+Implementation surface: `project_management_reconcile`. Effect: `external_or_local_change`.
+
+## Create Work
+
+Create or reconcile one new Work record through the configured provider boundary.
+
+Implementation surface: `project_management_reconcile`. Effect: `external_or_local_change`.
+
+## Take Next Work
+
+Select the next eligible Ready item and establish its execution claim.
+
+Implementation surface: `project_management_take_next_work`. Effect: `external_or_local_change`.
+
+## Claim Work
+
+Establish one execution owner after revision and state guards pass.
+
+Implementation surface: `project_management_claim_work`. Effect: `external_or_local_change`.
+
+## Release Work
+
+Clear an execution claim through the bounded command plane.
+
+Implementation surface: `project_management_release_work`. Effect: `external_or_local_change`.
+
+## Hold Work
+
+Move work to On Hold only with the required review trigger.
+
+Implementation surface: `project_management_hold_work`. Effect: `external_or_local_change`.
+
+## Defer Work
+
+Move work to Deferred only with the required review trigger.
+
+Implementation surface: `project_management_defer_work`. Effect: `external_or_local_change`.
+
+## Complete Work
+
+Complete work only after configured completion and evidence guards pass.
+
+Implementation surface: `project_management_complete_work`. Effect: `external_or_local_change`.
+
+## Readiness
+
+Evaluate deterministic queue eligibility and readiness evidence.
+
+Implementation surface: `project_management_next_work`. Effect: `read_only`.
+
+## Assignment Packet
+
+Bind execution to a generation-specific work packet and reservation fence.
+
+Implementation surface: `coordinator_work_packet`. Effect: `local_change`.
+
+## Verification
+
+Evaluate repository/source verification evidence for the exact delivery identity.
+
+Implementation surface: `project_management_merge_readiness`. Effect: `read_only_or_external_evidence`.
+
+## Commissioning
+
+Track post-merge live verification separately from source verification.
+
+Implementation surface: `issue_419_commissioning`. Effect: `external_or_local_change`.
+
+## Authority Revision
+
+Retain provider/Git revision evidence used for optimistic concurrency and traceability.
+
+Implementation surface: `project_management_inventory`. Effect: `read_only`.
+
+For operation contracts and typed errors, use the [Work Management Specification](../work-management-spec/001-specification.md).

--- a/generated/work-management-docs/004-complete-work.md
+++ b/generated/work-management-docs/004-complete-work.md
@@ -1,0 +1,18 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Complete governed work
+
+Completion is evidence-gated; merge is not the same as Done.
+
+A change can move through repository delivery, merge, documentation reconciliation, and commissioning before Work reaches Done.
+
+## Delivery stages
+
+`none` → `change_created` → `implementing` → `pr_open` → `review` → `ci_pending` → `ci_failed` → `ci_passed` → `merged` → `documentation` → `commissioning` → `complete`
+
+## Completion checks
+
+- Terminal Work state: `done`.
+- Required post-merge documentation reconciliation must be complete when its guard applies.
+- Source verification and live verification remain separate evidence domains.
+
+See the [Work Management Specification](../work-management-spec/001-specification.md) for exact completion guards.

--- a/generated/work-management-docs/005-troubleshooting.md
+++ b/generated/work-management-docs/005-troubleshooting.md
@@ -1,0 +1,31 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Troubleshoot work state
+
+Use guards, authority, and typed errors instead of forcing a state transition.
+
+## Guards
+
+- `approval-before-active` → `approval_incomplete`: Reject activation when the record requires approval and approval is incomplete.
+- `completion-no-active-claim` → `active_claim_present`: When configured, reject completion while an execution claim remains.
+- `completion-documentation-due` → `documentation_reconciliation_due`: Required post-merge documentation reconciliation must be completed before Done.
+- `completion-documentation-due-advisory` → `documentation_reconciliation_advisory_due`: Advisory post-merge documentation reconciliation may complete with an explicit advisory reason.
+- `completion-documentation-unrecorded` → `documentation_reconciliation_unrecorded`: Required post-merge documentation milestone must be recorded before Done.
+- `completion-documentation-unrecorded-advisory` → `documentation_reconciliation_advisory_incomplete`: Advisory documentation reconciliation may complete without a recorded post-merge milestone, with an explicit advisory reason.
+- `completion-documentation-incomplete` → `documentation_incomplete`: Required documentation impact must be complete before Done.
+- `completion-documentation-incomplete-advisory` → `documentation_advisory_incomplete`: Advisory documentation may complete while incomplete, with an explicit advisory reason.
+
+## Provider boundary
+
+Live Project evidence was observed; inventory is complete; the configured Project schema is ready with no field, option, type, or view drift in the captured evidence.
+
+Typed errors:
+- `provider_unavailable`
+- `project_not_commissioned`
+- `inventory_incomplete`
+- `conflict`
+- `invalid_transition`
+- `not_found`
+- `invalid_request`
+- `internal`
+
+Use the [Work Management Specification](../work-management-spec/001-specification.md) for exact field authority and recovery semantics.

--- a/generated/work-management-docs/006-examples.md
+++ b/generated/work-management-docs/006-examples.md
@@ -1,0 +1,17 @@
+<!-- GENERATED — DO NOT EDIT -->
+# Work Management examples
+
+These examples compose canonical operations and states; they do not create new transitions or authority.
+
+## Example: take and complete ready work
+
+1. Confirm the item satisfies Ready metadata and dependency requirements.
+2. Use `take_next_work` or `claim_work` to establish the execution claim.
+3. Perform the governed repository change while Work remains evidence-linked to its delivery stage.
+4. Run source verification for the exact delivery identity.
+5. After merge, complete required documentation reconciliation and any required commissioning.
+6. Use `complete_work` only after the completion guards are satisfied.
+
+If a guard rejects a transition, resolve its reason code instead of forcing the state.
+
+For exact transitions, guards, fields, and operation contracts, use the [Work Management Specification](../work-management-spec/001-specification.md).

--- a/generated/work-management-docs/data/source-traceability.json
+++ b/generated/work-management-docs/data/source-traceability.json
@@ -1,0 +1,38 @@
+{
+  "output_class": "human_documentation",
+  "topics": [
+    {
+      "page": "002-work-lifecycle.md",
+      "source_mrds": [
+        "KIS-WORK-WRK-STM-001"
+      ]
+    },
+    {
+      "page": "003-work-operations.md",
+      "source_mrds": [
+        "KIS-WORK-WRK-WFL-001"
+      ]
+    },
+    {
+      "page": "004-complete-work.md",
+      "source_mrds": [
+        "KIS-WORK-WRK-STM-001"
+      ]
+    },
+    {
+      "page": "005-troubleshooting.md",
+      "source_mrds": [
+        "KIS-WORK-WRK-STM-001",
+        "KIS-WORK-WRK-WFL-001",
+        "KIS-WORK-CTR-SVC-001"
+      ]
+    },
+    {
+      "page": "006-examples.md",
+      "source_mrds": [
+        "KIS-WORK-WRK-STM-001",
+        "KIS-WORK-WRK-WFL-001"
+      ]
+    }
+  ]
+}

--- a/generated/work-management-docs/manifest.json
+++ b/generated/work-management-docs/manifest.json
@@ -1,0 +1,115 @@
+{
+  "bundle_sha256": "0cc94a71603f82ca00d2680d1dbf73673a29b386b26d601c59eda6ecd2d240cd",
+  "contract": {
+    "name": "kis-human-documentation-build",
+    "version": 1
+  },
+  "family_id": "work-management-docs",
+  "files": [
+    {
+      "bytes": 708,
+      "path": "000-index.md",
+      "sha256": "647517d8b1cc3a198939fb7c7fed6f933869f9dfaea2b78e445d9222e29dce71"
+    },
+    {
+      "bytes": 1656,
+      "path": "002-work-lifecycle.md",
+      "sha256": "06ea7bfda15172482408478c89a0e6f627a9b99a2988eea3e72638bca83c8379"
+    },
+    {
+      "bytes": 2757,
+      "path": "003-work-operations.md",
+      "sha256": "913b85de3c010ab375c39a5a7cf14b2d78558e25e762471977ed9e4c3c281ca9"
+    },
+    {
+      "bytes": 803,
+      "path": "004-complete-work.md",
+      "sha256": "e484ca393f5c767238c38a2803c55f3aa576179d5bb60da4bebec419ddce4e43"
+    },
+    {
+      "bytes": 1961,
+      "path": "005-troubleshooting.md",
+      "sha256": "8f2008352054eb022238a5b3388e924bdc62aa6db6d1a9680ea75fe7e3f8398b"
+    },
+    {
+      "bytes": 925,
+      "path": "006-examples.md",
+      "sha256": "6c691f0e5432a253e8e91281f94922cfe7706e2049c7c10ad6796cc2507194ea"
+    },
+    {
+      "bytes": 723,
+      "path": "data/source-traceability.json",
+      "sha256": "b728a374828476383dfdeff4fe9711a2624f8907a978f15d78072ce91b98a9bb"
+    }
+  ],
+  "generator": {
+    "algorithm": "human-docs-v1",
+    "name": "kis-mcp-doc"
+  },
+  "inputs": {
+    "source_files": [
+      {
+        "bytes": 5712,
+        "path": "mrd/documentation/01-reference-standard.mrd.json",
+        "sha256": "da30a9f44828194a6b0b1e382c39936ae3d07705521dd6c07af60286b5133dc1"
+      },
+      {
+        "bytes": 6560,
+        "path": "mrd/documentation/04-publication-family-registry.mrd.json",
+        "sha256": "171891c0689908f5b074bd587266a22abf13d44a6aa98d35d08234b6cef1fcc9"
+      },
+      {
+        "bytes": 444,
+        "path": "publication/work-management-docs.json",
+        "sha256": "e32eb2e43fbb379eab936b9e8e9a672af7c9eeed3febe89335b384d611c219ab"
+      },
+      {
+        "bytes": 17941,
+        "path": "src/kis_mcp_doc/human_docs.py",
+        "sha256": "36fd13f6695f50f4d190516c33b23bf5b9a00571985634f5c5d155acbc857dce"
+      },
+      {
+        "bytes": 6152,
+        "path": "src/kis_mcp_doc/publication_adapters.py",
+        "sha256": "276df0de30dc879204ebffcf0eaf14f6ce2f1c6c24e5318562bd5cd9534822a0"
+      },
+      {
+        "bytes": 33211,
+        "path": "mrd/work-management/01-reg.mrd.json",
+        "sha256": "54f93adedfa74ccd8411a4c38bde91851ba1eddb1869ecf9301263f935336603"
+      },
+      {
+        "bytes": 9690,
+        "path": "mrd/work-management/02-stm.mrd.json",
+        "sha256": "60b2622666654ea2b0332c4720fe0bc70a902cab7ded3ba955737727f8b8d9a1"
+      },
+      {
+        "bytes": 5482,
+        "path": "mrd/work-management/03-wfl.mrd.json",
+        "sha256": "ad5cbeb8e675aa1edbcd670db83ebe4b59f3d6e09407a5ec62b81285156c9367"
+      },
+      {
+        "bytes": 5443,
+        "path": "mrd/work-management/04-scr.mrd.json",
+        "sha256": "934dc44aa1c173b09cb0e9185678a53703b4740dc7d6a5163b2853caf83b6b4e"
+      },
+      {
+        "bytes": 20109,
+        "path": "mrd/work-management/05-pol.mrd.json",
+        "sha256": "d83e7341af76952a3ca66c75bca0ec5407156d24237601677d8e71346b98d85f"
+      },
+      {
+        "bytes": 9077,
+        "path": "mrd/work-management/06-svc.mrd.json",
+        "sha256": "948f9370ec4c751085131bda230d469c23c2ec379a8004cfbfb92b01d4a1d1d5"
+      },
+      {
+        "bytes": 1922,
+        "path": "mrd/work-management/07-tst.mrd.json",
+        "sha256": "db8f93cd8aa889d29ed95a97375e78aa38a4a277ae3cd8e3f1bb1feb7302d894"
+      }
+    ]
+  },
+  "output_class": "human_documentation",
+  "traceability_topics": 5
+}

--- a/generated/work-management-spec/manifest.json
+++ b/generated/work-management-spec/manifest.json
@@ -160,9 +160,9 @@
         "sha256": "e266a4a60b6037129a106f5f7f977161cd01d69983560a8de790d7d9d6cf9c71"
       },
       {
-        "bytes": 4479,
+        "bytes": 6560,
         "path": "mrd/documentation/04-publication-family-registry.mrd.json",
-        "sha256": "e72c7546e6e02b13a384e4ce722a057e5fdae50ee8d0e099af4f1ac491775d17"
+        "sha256": "171891c0689908f5b074bd587266a22abf13d44a6aa98d35d08234b6cef1fcc9"
       },
       {
         "bytes": 3657,

--- a/mrd/documentation/04-publication-family-registry.mrd.json
+++ b/mrd/documentation/04-publication-family-registry.mrd.json
@@ -9,7 +9,7 @@
     "layer": "L1",
     "record_mode": "prescriptive",
     "status": "active",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "dependencies": [
       {
         "mrd_id": "KIS-DOC-CON-POL-002",
@@ -45,16 +45,24 @@
           "locator": ".work/changes/010-hrd-reader-experience-and-reference-separation/change.mrd.json",
           "revision": "1.1.0",
           "sha256": "c7050f80722400a481a35b1a26979f16c88b5b88b879101f5337cb80ebce739d"
+        },
+        {
+          "source_id": "GH-ISSUE-22",
+          "kind": "operator_approved_work_item",
+          "role": "human_documentation_family_adoption",
+          "locator": "github:NielPieterse0/kis-mcp-doc#22",
+          "revision": "2026-08-26",
+          "sha256": null
         }
       ],
-      "source_fingerprint": "sha256:dbdadfe5335334920b10cdda767424425997945ec1c96f17fcca469eff83a865",
+      "source_fingerprint": "sha256:fa01de8f4d733421a5488fd76a5c01a3eff6de215e8ce0a1393b427740178a81",
       "fact_quality": "direct"
     },
     "supersedes": [],
     "superseded_by": null
   },
   "content": {
-    "registry_version": "1.0.0",
+    "registry_version": "1.1.0",
     "adapter_protocol_version": 1,
     "families": [
       {
@@ -121,6 +129,44 @@
           "validate": "references-validate",
           "build": "references-build",
           "verify": "references-check-generated"
+        }
+      },
+      {
+        "id": "governance-docs",
+        "title": "Governance Documentation",
+        "semantic_owner": "KIS-KNOW-CON-POL-002",
+        "mrd_root": "mrd/governance",
+        "publication_config": "publication/governance-docs.json",
+        "output": "generated/governance-docs",
+        "output_classes": ["human_documentation"],
+        "adapter": {
+          "validate": "kis_mcp_doc.publication_adapters:validate_governance_docs",
+          "build": "kis_mcp_doc.publication_adapters:build_governance_docs",
+          "verify": "kis_mcp_doc.publication_adapters:verify_governance_docs"
+        },
+        "legacy_commands": {
+          "validate": "publications-validate --family governance-docs",
+          "build": "publications-build --family governance-docs",
+          "verify": "publications-check-generated --family governance-docs"
+        }
+      },
+      {
+        "id": "work-management-docs",
+        "title": "Work Management Documentation",
+        "semantic_owner": "KIS-WORK-CON-POL-001",
+        "mrd_root": "mrd/work-management",
+        "publication_config": "publication/work-management-docs.json",
+        "output": "generated/work-management-docs",
+        "output_classes": ["human_documentation"],
+        "adapter": {
+          "validate": "kis_mcp_doc.publication_adapters:validate_work_management_docs",
+          "build": "kis_mcp_doc.publication_adapters:build_work_management_docs",
+          "verify": "kis_mcp_doc.publication_adapters:verify_work_management_docs"
+        },
+        "legacy_commands": {
+          "validate": "publications-validate --family work-management-docs",
+          "build": "publications-build --family work-management-docs",
+          "verify": "publications-check-generated --family work-management-docs"
         }
       }
     ]

--- a/publication/governance-docs.json
+++ b/publication/governance-docs.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "title": "Governance Documentation",
+  "subtitle": "Practical guidance for applying KIS governance",
+  "version": "1.0.0",
+  "status": "draft",
+  "source_glob": "mrd/governance/*.mrd.json",
+  "specification": "generated/governance-spec/001-specification.md",
+  "documentation_reference": {
+    "output_class": "human_documentation",
+    "policy_mrd": "KIS-DOC-CON-POL-001"
+  }
+}

--- a/publication/work-management-docs.json
+++ b/publication/work-management-docs.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "title": "Work Management Documentation",
+  "subtitle": "Practical guidance for planning, executing, and closing governed work",
+  "version": "1.0.0",
+  "status": "draft",
+  "source_glob": "mrd/work-management/*.mrd.json",
+  "specification": "generated/work-management-spec/001-specification.md",
+  "documentation_reference": {
+    "output_class": "human_documentation",
+    "policy_mrd": "KIS-DOC-CON-POL-001"
+  }
+}

--- a/scripts/verify.ps1
+++ b/scripts/verify.ps1
@@ -20,10 +20,11 @@ if ($env:KIS_EXACT_SHA) {
     }
 }
 
+$PublicationRegistryPath = Join-Path $RepositoryRoot 'mrd\documentation\04-publication-family-registry.mrd.json'
+$PublicationRegistry = Get-Content -LiteralPath $PublicationRegistryPath -Raw | ConvertFrom-Json
 $AllowedGeneratedMarkdownPrefixes = @(
-    'generated/governance-spec/',
-    'generated/work-management-spec/',
-    'generated/documentation-reference-standard/'
+    $PublicationRegistry.content.families |
+        ForEach-Object { ($_.output.TrimEnd('/') + '/').Replace('\', '/') }
 )
 $TrackedMarkdown = @(& git -C $RepositoryRoot ls-files '*.md')
 $UnexpectedMarkdown = @(

--- a/src/kis_mcp_doc/human_docs.py
+++ b/src/kis_mcp_doc/human_docs.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from .publication_kernel import (
+    bundle_manifest_fields,
+    exact_bundle_diagnostics,
+    file_declarations,
+    write_bundle,
+)
+
+_POLICY = "mrd/documentation/01-reference-standard.mrd.json"
+_REGISTRY = "mrd/documentation/04-publication-family-registry.mrd.json"
+_GENERATOR = "src/kis_mcp_doc/human_docs.py"
+_ADAPTERS = "src/kis_mcp_doc/publication_adapters.py"
+_OUTPUT_CLASS = "human_documentation"
+
+
+def _json_bytes(value: object) -> bytes:
+    return (json.dumps(value, indent=2, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return value
+
+
+def _docs(root: Path, family: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    base = root / family["mrd_root"]
+    documents = [_load_json(path) for path in sorted(base.glob("*.mrd.json"))]
+    return {doc["_mrd"]["id"]: doc for doc in documents}
+
+
+def _config(root: Path, family: dict[str, Any]) -> dict[str, Any]:
+    config = _load_json(root / family["publication_config"])
+    policy = _load_json(root / _POLICY)
+    classes = {item["class"] for item in policy["content"]["output_classes"]}
+    if _OUTPUT_CLASS not in classes:
+        raise ValueError("human_documentation output class is not governed")
+    reference = config.get("documentation_reference", {})
+    if reference.get("output_class") != _OUTPUT_CLASS:
+        raise ValueError("human documentation publication must declare human_documentation output class")
+    if set(family.get("output_classes", [])) != {_OUTPUT_CLASS}:
+        raise ValueError("human documentation family must register only human_documentation")
+    return config
+
+
+def _source_declarations(root: Path, family: dict[str, Any]) -> list[dict[str, Any]]:
+    paths = [
+        root / _POLICY,
+        root / _REGISTRY,
+        root / family["publication_config"],
+        root / _GENERATOR,
+        root / _ADAPTERS,
+    ]
+    paths.extend(sorted((root / family["mrd_root"]).glob("*.mrd.json")))
+    declarations: list[dict[str, Any]] = []
+    for path in paths:
+        payload = path.read_bytes()
+        declarations.append({
+            "path": path.relative_to(root).as_posix(),
+            "sha256": hashlib.sha256(payload).hexdigest(),
+            "bytes": len(payload),
+        })
+    return declarations
+
+
+def _header(title: str, subtitle: str) -> list[str]:
+    return ["<!-- GENERATED — DO NOT EDIT -->", f"# {title}", "", subtitle, ""]
+
+
+def _spec_link(config: dict[str, Any]) -> str:
+    spec = Path(config["specification"])
+    return f"../{spec.parent.name}/{spec.name}"
+
+
+def _governance_pages(config: dict[str, Any], docs: dict[str, dict[str, Any]]) -> tuple[dict[str, bytes], dict[str, Any]]:
+    ownership = docs["KIS-KNOW-CON-POL-002"]["content"]
+    lifecycle = docs["KIS-KNOW-WRK-STM-001"]["content"]
+    workflow = docs["KIS-KNOW-WRK-WFL-001"]["content"]
+    validation = docs["KIS-KNOW-EVL-TST-001"]["content"]
+    spec = _spec_link(config)
+    overview = _header(config["title"], config["subtitle"])
+    overview += [
+        "Use these pages when you need to apply governance, not when you need the normative contract.",
+        "The generated documentation explains canonical Governance MRDs without becoming a second authority.",
+        "",
+        "## Start here",
+        "",
+        "- [Understand authority and ownership](002-understand-authority.md)",
+        "- [Apply governance to a change](003-apply-governance.md)",
+        "- [Understand MRD lifecycle](004-mrd-lifecycle.md)",
+        "- [Troubleshoot governance failures](005-troubleshooting.md)",
+        "- [Governance examples](006-examples.md)",
+        f"- [Governance Specification]({spec}) for normative rules and exact reference material",
+    ]
+    authority = _header("Understand authority and ownership", ownership["purpose"])
+    contract = ownership["ownership_contract"]
+    authority += [
+        "A governed fact has one current canonical owner. Other artifacts may explain or project that fact, but they do not become another owner.",
+        "",
+        "## Working rule",
+        "",
+        f"- Canonical owner count: **{contract['canonical_owner_count']}**.",
+        f"- Non-owner posture: `{contract['non_owner_posture']}`.",
+        f"- Derived posture: `{contract['derived_posture']}`.",
+        f"- Conflict posture: `{contract['conflict_posture']}`.",
+        "",
+        f"For the complete relationship vocabulary and normative requirements, see the [Governance Specification]({spec}).",
+    ]
+    applying = _header("Apply governance to a change", workflow["purpose"])
+    applying += ["Follow the canonical phases in order. A phase can stop the change when its declared stop condition is met.", ""]
+    for phase in sorted(workflow["phases"], key=lambda item: item["order"]):
+        applying += [f"## {phase['order']}. {phase['name'].replace('_', ' ').title()}", ""]
+        applying += [f"- {action}." for action in phase["required_actions"]]
+        if phase["stop_when"]:
+            applying += ["", "Stop here when:"] + [f"- {condition}." for condition in phase["stop_when"]]
+        applying += [""]
+    applying += [f"Use the [Governance Specification]({spec}) when you need exact MUST/SHOULD/MAY requirements or rule identifiers."]
+
+    life = _header("Understand MRD lifecycle", lifecycle["purpose"])
+    life += ["The lifecycle depends on the MRD record mode.", ""]
+    for machine in lifecycle["lifecycles"]:
+        transitions = ", ".join(f"`{item['from']}` → `{item['to']}`" for item in machine["transitions"])
+        life += [f"## {machine['record_mode'].title()}", "", f"States: {', '.join(f'`{state}`' for state in machine['states'])}.", "", f"Allowed transitions: {transitions}.", ""]
+    life += [f"See the [Governance Specification]({spec}) for lifecycle requirements and lineage rules."]
+
+    trouble = _header("Troubleshoot governance failures", "Use canonical stop conditions and validation evidence to decide what must be fixed before work continues.")
+    trouble += ["## Common blocking situations", ""]
+    stops = [condition for phase in workflow["phases"] for condition in phase["stop_when"]]
+    trouble += [f"- {condition}." for condition in stops]
+    trouble += ["", "## Validation evidence", "", "Validation uses stable reason codes. Do not infer past a blocking diagnostic.", ""]
+    trouble += [f"- `{code}`" for code in validation["reason_codes"]]
+    trouble += ["", f"Use the [Governance Specification]({spec}) to resolve a reason code against its normative validation contract."]
+
+    examples = _header("Governance examples", "These examples illustrate the canonical workflow; they do not add governance semantics.")
+    examples += [
+        "## Example: govern a repository change",
+        "",
+        "1. Resolve repository authority and the active change scope.",
+        "2. Select only the MRDs required by the governed needs.",
+        "3. Resolve dependencies, ownership, and typed relationships.",
+        "4. Run structural and semantic governance validation.",
+        "5. Execute only inside the admitted scope.",
+        "6. Generate the review surface from validated authority.",
+        "7. Verify generated output and report remaining gaps or diagnostics.",
+        "",
+        "If any canonical phase declares a blocking stop condition, stop the example at that phase rather than inferring authority.",
+        "",
+        f"For exact requirements behind each phase, use the [Governance Specification]({spec}).",
+    ]
+    files = {
+        "000-index.md": ("\n".join(overview) + "\n").encode(),
+        "002-understand-authority.md": ("\n".join(authority) + "\n").encode(),
+        "003-apply-governance.md": ("\n".join(applying) + "\n").encode(),
+        "004-mrd-lifecycle.md": ("\n".join(life) + "\n").encode(),
+        "005-troubleshooting.md": ("\n".join(trouble) + "\n").encode(),
+        "006-examples.md": ("\n".join(examples) + "\n").encode(),
+    }
+    traceability = {
+        "output_class": _OUTPUT_CLASS,
+        "topics": [
+            {"page": "002-understand-authority.md", "source_mrds": ["KIS-KNOW-CON-POL-002"]},
+            {"page": "003-apply-governance.md", "source_mrds": ["KIS-KNOW-WRK-WFL-001"]},
+            {"page": "004-mrd-lifecycle.md", "source_mrds": ["KIS-KNOW-WRK-STM-001"]},
+            {"page": "005-troubleshooting.md", "source_mrds": ["KIS-KNOW-WRK-WFL-001", "KIS-KNOW-EVL-TST-001"]},
+            {"page": "006-examples.md", "source_mrds": ["KIS-KNOW-WRK-WFL-001"]},
+        ],
+    }
+    files["data/source-traceability.json"] = _json_bytes(traceability)
+    return files, traceability
+
+
+def _work_pages(config: dict[str, Any], docs: dict[str, dict[str, Any]]) -> tuple[dict[str, bytes], dict[str, Any]]:
+    lifecycle = docs["KIS-WORK-WRK-STM-001"]["content"]
+    operations = docs["KIS-WORK-WRK-WFL-001"]["content"]
+    boundary = docs["KIS-WORK-CTR-SVC-001"]["content"]
+    spec = _spec_link(config)
+    overview = _header(config["title"], config["subtitle"])
+    overview += [
+        "Use these pages to operate the governed Work system. Exact state, field, and provider contracts remain in the Work Management Specification and generated reference.",
+        "",
+        "## Start here",
+        "",
+        "- [Move work through its lifecycle](002-work-lifecycle.md)",
+        "- [Use Work Management operations](003-work-operations.md)",
+        "- [Complete governed work](004-complete-work.md)",
+        "- [Troubleshoot work state](005-troubleshooting.md)",
+        "- [Work Management examples](006-examples.md)",
+        f"- [Work Management Specification]({spec}) for normative and exact reference material",
+    ]
+    life = _header("Move work through its lifecycle", lifecycle["purpose"])
+    life += ["Work Status and Delivery Stage are separate dimensions. Change one only through its owning authority.", "", "## Work states", ""]
+    for state in lifecycle["states"]:
+        life += [f"- **{state['label']}** (`{state['token']}`): {state['definition']}"]
+    life += ["", "## Before work becomes Ready", ""]
+    life += [f"- Required Project fields: {', '.join(lifecycle['readiness']['required_project_fields'])}."]
+    life += [f"- Required issue sections: {', '.join(lifecycle['readiness']['required_issue_sections'])}."]
+    life += ["- Dependencies must be understood." if lifecycle["readiness"]["requires_dependencies_understood"] else "- Dependency understanding is not required."]
+    life += ["", f"See the [Work Management Specification]({spec}) for every allowed transition and guard."]
+    ops = _header("Use Work Management operations", operations["purpose"])
+    ops += ["Choose the operation that matches the intended lifecycle action; mutation authority is bounded by the command plane.", ""]
+    for operation in operations["operations"]:
+        ops += [f"## {operation['id'].replace('_', ' ').title()}", "", operation["definition"], "", f"Implementation surface: `{operation['implementation_surface']}`. Effect: `{operation['effect']}`.", ""]
+    ops += [f"For operation contracts and typed errors, use the [Work Management Specification]({spec})."]
+
+    complete = _header("Complete governed work", "Completion is evidence-gated; merge is not the same as Done.")
+    complete += [
+        "A change can move through repository delivery, merge, documentation reconciliation, and commissioning before Work reaches Done.",
+        "",
+        "## Delivery stages",
+        "",
+        " → ".join(f"`{stage}`" for stage in lifecycle["delivery"]["stages"]),
+        "",
+        "## Completion checks",
+        "",
+        f"- Terminal Work state: `{lifecycle['completion']['terminal_state']}`.",
+        "- Required post-merge documentation reconciliation must be complete when its guard applies.",
+        "- Source verification and live verification remain separate evidence domains.",
+        "",
+        f"See the [Work Management Specification]({spec}) for exact completion guards.",
+    ]
+    trouble = _header("Troubleshoot work state", "Use guards, authority, and typed errors instead of forcing a state transition.")
+    trouble += ["## Guards", ""]
+    for guard in lifecycle["guards"]:
+        trouble += [f"- `{guard['id']}` → `{guard['reason_code']}`: {guard['definition']}"]
+    trouble += ["", "## Provider boundary", "", boundary["provider_contract"]["live_observation"], ""]
+    trouble += ["Typed errors:"] + [f"- `{error}`" for error in operations["typed_errors"]]
+    trouble += ["", f"Use the [Work Management Specification]({spec}) for exact field authority and recovery semantics."]
+
+    examples = _header("Work Management examples", "These examples compose canonical operations and states; they do not create new transitions or authority.")
+    examples += [
+        "## Example: take and complete ready work",
+        "",
+        "1. Confirm the item satisfies Ready metadata and dependency requirements.",
+        "2. Use `take_next_work` or `claim_work` to establish the execution claim.",
+        "3. Perform the governed repository change while Work remains evidence-linked to its delivery stage.",
+        "4. Run source verification for the exact delivery identity.",
+        "5. After merge, complete required documentation reconciliation and any required commissioning.",
+        "6. Use `complete_work` only after the completion guards are satisfied.",
+        "",
+        "If a guard rejects a transition, resolve its reason code instead of forcing the state.",
+        "",
+        f"For exact transitions, guards, fields, and operation contracts, use the [Work Management Specification]({spec}).",
+    ]
+
+    files = {
+        "000-index.md": ("\n".join(overview) + "\n").encode(),
+        "002-work-lifecycle.md": ("\n".join(life) + "\n").encode(),
+        "003-work-operations.md": ("\n".join(ops) + "\n").encode(),
+        "004-complete-work.md": ("\n".join(complete) + "\n").encode(),
+        "005-troubleshooting.md": ("\n".join(trouble) + "\n").encode(),
+        "006-examples.md": ("\n".join(examples) + "\n").encode(),
+    }
+    traceability = {
+        "output_class": _OUTPUT_CLASS,
+        "topics": [
+            {"page": "002-work-lifecycle.md", "source_mrds": ["KIS-WORK-WRK-STM-001"]},
+            {"page": "003-work-operations.md", "source_mrds": ["KIS-WORK-WRK-WFL-001"]},
+            {"page": "004-complete-work.md", "source_mrds": ["KIS-WORK-WRK-STM-001"]},
+            {"page": "005-troubleshooting.md", "source_mrds": ["KIS-WORK-WRK-STM-001", "KIS-WORK-WRK-WFL-001", "KIS-WORK-CTR-SVC-001"]},
+            {"page": "006-examples.md", "source_mrds": ["KIS-WORK-WRK-STM-001", "KIS-WORK-WRK-WFL-001"]},
+        ],
+    }
+    files["data/source-traceability.json"] = _json_bytes(traceability)
+    return files, traceability
+
+
+def _expected_bundle(root: Path, family: dict[str, Any], kind: str) -> tuple[dict[str, bytes], dict[str, Any]]:
+    config = _config(root, family)
+    documents = _docs(root, family)
+    if kind == "governance":
+        files, traceability = _governance_pages(config, documents)
+    elif kind == "work-management":
+        files, traceability = _work_pages(config, documents)
+    else:
+        raise ValueError(f"unknown human documentation kind: {kind}")
+    manifest = {
+        "contract": {"name": "kis-human-documentation-build", "version": 1},
+        "family_id": family["id"],
+        "output_class": _OUTPUT_CLASS,
+        "generator": {"name": "kis-mcp-doc", "algorithm": "human-docs-v1"},
+        "inputs": {"source_files": _source_declarations(root, family)},
+        "traceability_topics": len(traceability["topics"]),
+        "files": file_declarations(files),
+        **bundle_manifest_fields(files),
+    }
+    return files, manifest
+
+
+def validate_human_docs_family(root: Path, family: dict[str, Any], kind: str) -> dict[str, Any]:
+    try:
+        config = _config(root, family)
+        documents = _docs(root, family)
+        if not documents:
+            raise ValueError("human documentation family has no canonical MRD sources")
+        if Path(config["source_glob"]).parent.as_posix() != family["mrd_root"]:
+            raise ValueError("human documentation source_glob does not match registered MRD root")
+        _expected_bundle(root, family, kind)
+    except (KeyError, OSError, ValueError, json.JSONDecodeError) as error:
+        return {"status": "invalid", "diagnostics": [{"code": "HUMAN_DOCUMENTATION_INVALID", "message": str(error)}]}
+    return {"status": "valid", "diagnostics": []}
+
+
+def build_human_docs_family(
+    root: Path,
+    family: dict[str, Any],
+    kind: str,
+    *,
+    output: Path | None = None,
+    replace: bool = False,
+) -> dict[str, Any]:
+    validation = validate_human_docs_family(root, family, kind)
+    if validation["status"] != "valid":
+        raise ValueError(validation["diagnostics"][0]["message"])
+    files, manifest = _expected_bundle(root, family, kind)
+    target = Path(output) if output is not None else root / family["output"]
+    write_bundle(target, files, manifest, replace=replace)
+    return manifest
+
+
+def verify_human_docs_family(root: Path, family: dict[str, Any], kind: str) -> dict[str, Any]:
+    validation = validate_human_docs_family(root, family, kind)
+    if validation["status"] != "valid":
+        return validation
+    try:
+        files, manifest = _expected_bundle(root, family, kind)
+        diagnostics = exact_bundle_diagnostics(
+            root / family["output"], files, manifest, code_prefix="HUMAN_DOCUMENTATION"
+        )
+    except (KeyError, OSError, ValueError, json.JSONDecodeError) as error:
+        diagnostics = [{"code": "HUMAN_DOCUMENTATION_VERIFY_FAILED", "message": str(error)}]
+    return {"status": "invalid" if diagnostics else "valid", "diagnostics": diagnostics}

--- a/src/kis_mcp_doc/publication_adapters.py
+++ b/src/kis_mcp_doc/publication_adapters.py
@@ -10,6 +10,7 @@ from .documentation_reference import (
     verify_documentation_reference_standard,
 )
 from .governance import GovernanceRepository
+from .human_docs import build_human_docs_family, validate_human_docs_family, verify_human_docs_family
 from .render import build_governance_spec, validate_governance_publication, verify_governance_spec
 from .work_management import (
     WorkManagementRepository,
@@ -114,3 +115,31 @@ def build_documentation_reference(root: Path, family: dict[str, Any], *, output:
 
 def verify_documentation_reference(root: Path, family: dict[str, Any]) -> dict[str, Any]:
     return verify_documentation_reference_standard(DocumentationReferenceRepository(root), root / family["output"])
+
+
+def validate_governance_docs(root: Path, family: dict[str, Any]) -> dict[str, Any]:
+    semantic = GovernanceRepository(root, root / family["mrd_root"]).validate()
+    docs = validate_human_docs_family(root, family, "governance")
+    return _combined_validation(semantic, docs)
+
+
+def build_governance_docs(root: Path, family: dict[str, Any], *, output: Path | None = None, replace: bool = False) -> dict[str, Any]:
+    return build_human_docs_family(root, family, "governance", output=output, replace=replace)
+
+
+def verify_governance_docs(root: Path, family: dict[str, Any]) -> dict[str, Any]:
+    return verify_human_docs_family(root, family, "governance")
+
+
+def validate_work_management_docs(root: Path, family: dict[str, Any]) -> dict[str, Any]:
+    semantic = WorkManagementRepository(root, root / family["mrd_root"]).validate()
+    docs = validate_human_docs_family(root, family, "work-management")
+    return _combined_validation(semantic, docs)
+
+
+def build_work_management_docs(root: Path, family: dict[str, Any], *, output: Path | None = None, replace: bool = False) -> dict[str, Any]:
+    return build_human_docs_family(root, family, "work-management", output=output, replace=replace)
+
+
+def verify_work_management_docs(root: Path, family: dict[str, Any]) -> dict[str, Any]:
+    return verify_human_docs_family(root, family, "work-management")

--- a/tests/test_human_docs.py
+++ b/tests/test_human_docs.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from pathlib import Path
+
+from kis_mcp_doc.governance import GovernanceRepository
+from kis_mcp_doc.human_docs import (
+    build_human_docs_family,
+    validate_human_docs_family,
+    verify_human_docs_family,
+)
+from kis_mcp_doc.publication_kernel import PublicationFamilyRegistry
+from kis_mcp_doc.work_management import WorkManagementRepository
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _family(family_id: str) -> dict:
+    return PublicationFamilyRegistry(ROOT).family(family_id)
+
+
+def test_human_documentation_families_are_registered_separately_from_specs() -> None:
+    registry = PublicationFamilyRegistry(ROOT)
+    assert registry.validate() == {"status": "valid", "diagnostics": []}
+    governance = registry.family("governance-docs")
+    work = registry.family("work-management-docs")
+    assert governance["output_classes"] == ["human_documentation"]
+    assert work["output_classes"] == ["human_documentation"]
+
+
+def test_governance_docs_are_deterministic_and_source_derived(tmp_path: Path) -> None:
+    family = _family("governance-docs")
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    a = build_human_docs_family(ROOT, family, "governance", output=first)
+    b = build_human_docs_family(ROOT, family, "governance", output=second)
+    assert a == b
+    assert {p.relative_to(first).as_posix(): p.read_bytes() for p in first.rglob("*") if p.is_file()} == {
+        p.relative_to(second).as_posix(): p.read_bytes() for p in second.rglob("*") if p.is_file()
+    }
+    docs = GovernanceRepository(ROOT, ROOT / "mrd/governance").load()
+    workflow = docs["KIS-KNOW-WRK-WFL-001"]["content"]
+    page = (first / "003-apply-governance.md").read_text(encoding="utf-8")
+    for phase in workflow["phases"]:
+        assert phase["name"].replace("_", " ").title() in page
+        for action in phase["required_actions"]:
+            assert action in page
+    assert "Governance Specification" in page
+
+
+def test_work_docs_are_deterministic_and_preserve_state_authority(tmp_path: Path) -> None:
+    family = _family("work-management-docs")
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    build_human_docs_family(ROOT, family, "work-management", output=first)
+    build_human_docs_family(ROOT, family, "work-management", output=second)
+    assert {p.relative_to(first).as_posix(): p.read_bytes() for p in first.rglob("*") if p.is_file()} == {
+        p.relative_to(second).as_posix(): p.read_bytes() for p in second.rglob("*") if p.is_file()
+    }
+    docs = WorkManagementRepository(ROOT).load()
+    lifecycle = docs["KIS-WORK-WRK-STM-001"]["content"]
+    page = (first / "002-work-lifecycle.md").read_text(encoding="utf-8")
+    assert "Work Status and Delivery Stage are separate dimensions" in page
+    for state in lifecycle["states"]:
+        assert state["label"] in page
+        assert f"`{state['token']}`" in page
+    complete = (first / "004-complete-work.md").read_text(encoding="utf-8")
+    for stage in lifecycle["delivery"]["stages"]:
+        assert f"`{stage}`" in complete
+
+
+def test_human_docs_traceability_points_only_to_canonical_mrds(tmp_path: Path) -> None:
+    for family_id, kind in (("governance-docs", "governance"), ("work-management-docs", "work-management")):
+        family = _family(family_id)
+        output = tmp_path / family_id
+        build_human_docs_family(ROOT, family, kind, output=output)
+        trace = json.loads((output / "data/source-traceability.json").read_text(encoding="utf-8"))
+        source_ids = set(_family_source_ids(family))
+        assert trace["output_class"] == "human_documentation"
+        assert all(set(topic["source_mrds"]) <= source_ids for topic in trace["topics"])
+
+
+def _family_source_ids(family: dict) -> list[str]:
+    return [json.loads(path.read_text(encoding="utf-8"))["_mrd"]["id"] for path in sorted((ROOT / family["mrd_root"]).glob("*.mrd.json"))]
+
+
+def test_human_docs_links_resolve_against_repository(tmp_path: Path) -> None:
+    for family_id, kind in (("governance-docs", "governance"), ("work-management-docs", "work-management")):
+        family = _family(family_id)
+        output = tmp_path / family_id
+        build_human_docs_family(ROOT, family, kind, output=output)
+        for page in output.glob("*.md"):
+            text = page.read_text(encoding="utf-8")
+            for target in re.findall(r"\]\(([^)#]+)", text):
+                if "://" in target:
+                    continue
+                if target.startswith("../"):
+                    resolved = ROOT / "generated" / family_id / target
+                else:
+                    resolved = page.parent / target
+                assert resolved.resolve().exists(), f"broken link in {page.name}: {target}"
+
+
+def test_human_docs_verifier_detects_tampering(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    shutil.copytree(ROOT, root, ignore=shutil.ignore_patterns(".git", ".venv", ".work"))
+    family = PublicationFamilyRegistry(root).family("governance-docs")
+    output = root / family["output"]
+    shutil.rmtree(output)
+    build_human_docs_family(root, family, "governance")
+    assert verify_human_docs_family(root, family, "governance")["status"] == "valid"
+    (output / "000-index.md").write_text("tampered\n", encoding="utf-8")
+    result = verify_human_docs_family(root, family, "governance")
+    assert result["status"] == "invalid"
+    assert any(item["code"] == "HUMAN_DOCUMENTATION_GENERATED_FILE_CONTENT_MISMATCH" for item in result["diagnostics"])

--- a/tests/test_publication_kernel.py
+++ b/tests/test_publication_kernel.py
@@ -27,10 +27,16 @@ def test_registry_discovers_all_governed_publication_families_and_output_classes
     assert registry.validate() == {"status": "valid", "diagnostics": []}
     families = registry.load()["content"]["families"]
     assert [family["id"] for family in families] == [
-        "governance-spec", "work-management-spec", "documentation-reference-standard"
+        "governance-spec",
+        "work-management-spec",
+        "documentation-reference-standard",
+        "governance-docs",
+        "work-management-docs",
     ]
     assert families[0]["output_classes"] == ["human_readable_specification", "generated_reference"]
     assert families[1]["output_classes"] == ["human_readable_specification", "generated_reference"]
+    assert families[3]["output_classes"] == ["human_documentation"]
+    assert families[4]["output_classes"] == ["human_documentation"]
     assert registry.load()["content"]["adapter_protocol_version"] == 1
 
 
@@ -187,7 +193,11 @@ def test_registered_publication_verification_covers_every_family() -> None:
     result = verify_registered_publications(ROOT)
     assert result["status"] == "valid"
     assert set(result["families"]) == {
-        "governance-spec", "work-management-spec", "documentation-reference-standard"
+        "governance-spec",
+        "work-management-spec",
+        "documentation-reference-standard",
+        "governance-docs",
+        "work-management-docs",
     }
     assert all(item["status"] == "valid" for item in result["families"].values())
 


### PR DESCRIPTION
Implements Change 013; tracked by issue #22.

- registers Governance Docs and Work Management Docs as `human_documentation` publication families
- derives task-oriented pages deterministically from canonical MRDs
- preserves specification/reference authority boundaries
- adds source traceability and exact stale/tamper verification
- preserves existing specification/reference reader content; only manifests change where the family-registry hash changes
- full repository verification passes with 123 tests and all five publication families valid/current

Frozen head: `5336ce1310c7ab5c1ef47a491b2f286595c2344b`.