### PR TITLE
Reconcile recent documentation change closeout

### DIFF
--- a/.work/changes/014-documentation-site-and-navigation/change.mrd.json
+++ b/.work/changes/014-documentation-site-and-navigation/change.mrd.json
@@ -1,24 +1,24 @@
 {
-  "_mrd": {"schema_version": 1, "id": "KIS-CHG014-WRK-WFL-001", "title": "Documentation Site and Navigation", "module": "change-014", "class": "WRK", "type": "WFL", "layer": "L3", "record_mode": "descriptive", "status": "active", "version": "1.0.0", "dependencies": [{"mrd_id": "KIS-DOC-SEM-REG-002", "relationship": "depends_on"}], "provenance": {"sources": [{"source_id": "GH-ISSUE-25", "kind": "operator_approved_work_item", "role": "approved_change_basis", "locator": "github:NielPieterse0/kis-mcp-doc#25", "revision": "2026-08-26", "sha256": null}], "source_fingerprint": null, "fact_quality": "direct"}, "supersedes": [], "superseded_by": null},
+  "_mrd": {"schema_version": 1, "id": "KIS-CHG014-WRK-WFL-001", "title": "Documentation Site and Navigation", "module": "change-014", "class": "WRK", "type": "WFL", "layer": "L3", "record_mode": "descriptive", "status": "done", "version": "1.0.0", "dependencies": [{"mrd_id": "KIS-DOC-SEM-REG-002", "relationship": "depends_on"}], "provenance": {"sources": [{"source_id": "GH-ISSUE-25", "kind": "operator_approved_work_item", "role": "approved_change_basis", "locator": "github:NielPieterse0/kis-mcp-doc#25", "revision": "2026-08-26", "sha256": null}], "source_fingerprint": null, "fact_quality": "direct"}, "supersedes": [], "superseded_by": null},
   "content": {
     "change_id": "014-documentation-site-and-navigation",
     "work_item": {"repository": "NielPieterse0/kis-mcp-doc", "issue": 25, "project": "NielPieterse0/1", "record_id": "SPEC-014"},
     "outcome": "Provide one reader-facing site over Docs, Specification, and generated reference while preserving existing publication families as source artifacts and authorities.",
     "classification": {"complexity": "large", "risk_triggers": ["public_contract"], "reason": "The change introduces a public reader route and navigation contract without changing domain semantics."},
     "authority_model": ["Canonical MRDs remain sole fact owners.", "The publication family registry remains the sole family discovery inventory.", "The site is a deterministic downstream aggregation and has no write-back authority."],
-    "requirements": [
-      "R1: The site MUST expose Docs, Specification, and relevant generated-reference surfaces from one entry point.",
-      "R2: Family and route discovery MUST derive from KIS-DOC-SEM-REG-002 and MUST NOT duplicate the family inventory.",
-      "R3: Governance and Work Management MUST have stable navigation, landing pages, breadcrumbs, and previous/next paths.",
-      "R4: Validation MUST detect broken links, orphan Markdown pages, duplicate routes, stale output, and tampering.",
-      "R5: The site MUST consume existing generated publication bundles without changing their semantic or output-class authority.",
-      "R6: Search, deployment, branding, and semantic changes are excluded from Change 014."
-    ],
+    "requirements": ["R1: The site MUST expose Docs, Specification, and relevant generated-reference surfaces from one entry point.", "R2: Family and route discovery MUST derive from KIS-DOC-SEM-REG-002 and MUST NOT duplicate the family inventory.", "R3: Governance and Work Management MUST have stable navigation, landing pages, breadcrumbs, and previous/next paths.", "R4: Validation MUST detect broken links, orphan Markdown pages, duplicate routes, stale output, and tampering.", "R5: The site MUST consume existing generated publication bundles without changing their semantic or output-class authority.", "R6: Search, deployment, branding, and semantic changes are excluded from Change 014."],
     "implementation_plan": ["P1: Add a presentation-only site config and deterministic site renderer.", "P2: Derive routes and navigation from registered families and their generated files.", "P3: Render static HTML with cross-link rewriting, breadcrumbs, and previous/next navigation.", "P4: Add exact build/validation/stale checks to CLI and canonical verification."],
     "verification_criteria": ["V1: All five registered family indexes are represented by deterministic routes.", "V2: Broken links and orphan pages fail validation.", "V3: Exact verification detects stale or tampered site bytes.", "V4: Full repository verification passes and canonical domain MRDs remain unchanged."],
-    "tasks": [{"id": "T1", "status": "done", "text": "Raise issue and governed change records."}, {"id": "T2", "status": "done", "text": "Implement registry-derived site and navigation."}, {"id": "T3", "status": "active", "text": "Verify, review, publish, merge, and reconcile."}],
+    "tasks": [{"id": "T1", "status": "done", "text": "Raise issue and governed change records."}, {"id": "T2", "status": "done", "text": "Implement registry-derived site and navigation."}, {"id": "T3", "status": "done", "text": "Verify, review, publish, merge, and reconcile."}],
     "risks": ["Route drift if a second family inventory is introduced.", "Broken cross-family links if source-relative links are not rewritten deterministically."],
     "explicit_exclusions": ["Search or ranking infrastructure.", "Hosting or deployment.", "Branding or visual redesign.", "Changes to governed Governance, Work Management, or Documentation semantics."],
-    "closeout": {"state": "implementation_complete", "verification": [], "reviews": [], "publication": {"status": "pending", "issue": 25, "pull_request": null}, "unresolved": []}
+    "closeout": {
+      "state": "post_merge_complete",
+      "verification": ["PR 28 merged the deterministic site and navigation implementation at head ac4f6a59a311870c85f95280d2eabbfd5606bc79 into main as a263d7d2e983a5de4085ed0652299176696287e7.", "Post-merge canonical verification on 2026-08-27 passed site validation and exact generated-output checks with no diagnostics."],
+      "reviews": ["Post-merge closeout audit found no unresolved site, navigation, authority, or generated-output findings."],
+      "publication": {"status": "merged", "issue": 25, "pull_request": 28},
+      "merge": {"approved_head": "ac4f6a59a311870c85f95280d2eabbfd5606bc79", "merge_commit": "a263d7d2e983a5de4085ed0652299176696287e7", "merged_at": "2026-08-26T20:34:06Z", "method": "merge"},
+      "unresolved": []
+    }
   }
 }

--- a/.work/changes/015-documentation-search-and-knowledge-discovery/change.mrd.json
+++ b/.work/changes/015-documentation-search-and-knowledge-discovery/change.mrd.json
@@ -1,5 +1,5 @@
 {
-  "_mrd": {"schema_version": 1, "id": "KIS-CHG015-WRK-WFL-001", "title": "Documentation Search and Knowledge Discovery", "module": "change-015", "class": "WRK", "type": "WFL", "layer": "L3", "record_mode": "descriptive", "status": "active", "version": "1.0.0", "dependencies": [{"source": "repo:.work/changes/014-documentation-site-and-navigation/change.mrd.json", "relationship": "depends_on"}], "provenance": {"sources": [{"source_id": "GH-ISSUE-26", "kind": "operator_approved_work_item", "role": "approved_change_basis", "locator": "github:NielPieterse0/kis-mcp-doc#26", "revision": "2026-08-26", "sha256": null}], "source_fingerprint": null, "fact_quality": "direct"}, "supersedes": [], "superseded_by": null},
+  "_mrd": {"schema_version": 1, "id": "KIS-CHG015-WRK-WFL-001", "title": "Documentation Search and Knowledge Discovery", "module": "change-015", "class": "WRK", "type": "WFL", "layer": "L3", "record_mode": "descriptive", "status": "done", "version": "1.0.0", "dependencies": [{"source": "repo:.work/changes/014-documentation-site-and-navigation/change.mrd.json", "relationship": "depends_on"}], "provenance": {"sources": [{"source_id": "GH-ISSUE-26", "kind": "operator_approved_work_item", "role": "approved_change_basis", "locator": "github:NielPieterse0/kis-mcp-doc#26", "revision": "2026-08-26", "sha256": null}], "source_fingerprint": null, "fact_quality": "direct"}, "supersedes": [], "superseded_by": null},
   "content": {
     "change_id": "015-documentation-search-and-knowledge-discovery",
     "work_item": {"repository": "NielPieterse0/kis-mcp-doc", "issue": 26, "project": "NielPieterse0/1", "record_id": "SPEC-015"},
@@ -9,9 +9,16 @@
     "requirements": ["R1: Search MUST index only current governed site routes.", "R2: Search documents MUST retain stable IDs and source/family/surface provenance.", "R3: Ranking MUST be deterministic with stable tie-breaking.", "R4: Validation MUST reject stale site output, missing sources, duplicate routes, stale search output, and tampering.", "R5: The reader site MUST expose a static search surface without a network search dependency.", "R6: Hosting and deployment remain excluded."],
     "implementation_plan": ["P1: Build a deterministic static inverted index from Change 014 routes.", "P2: Add stable query ranking and traceable result envelopes.", "P3: Integrate the index into the generated site as a client-side search surface.", "P4: Add build/validate/exact verification to CLI and canonical verification."],
     "verification_criteria": ["V1: Search index covers current site source routes and no unregistered content.", "V2: Repeated queries return the same order.", "V3: Stale site and tampered search output are detected.", "V4: Full repository verification passes with canonical MRDs unchanged."],
-    "tasks": [{"id": "T1", "status": "done", "text": "Raise issue and governed change records."}, {"id": "T2", "status": "done", "text": "Implement deterministic search index and site discovery surface."}, {"id": "T3", "status": "active", "text": "Verify, review, publish, merge, and reconcile."}],
+    "tasks": [{"id": "T1", "status": "done", "text": "Raise issue and governed change records."}, {"id": "T2", "status": "done", "text": "Implement deterministic search index and site discovery surface."}, {"id": "T3", "status": "done", "text": "Verify, review, publish, merge, and reconcile."}],
     "risks": ["Ranking may imply authority if result provenance is hidden.", "Search may become stale if site freshness is not a prerequisite."],
     "explicit_exclusions": ["External search service.", "Semantic changes.", "Hosting or deployment."],
-    "closeout": {"state": "implementation_complete", "verification": [], "reviews": [], "publication": {"status": "pending", "issue": 26, "pull_request": null}, "unresolved": []}
+    "closeout": {
+      "state": "post_merge_complete",
+      "verification": ["PR 29 merged the deterministic search implementation at head 99ab12962cb6ce44a623357950c934cdf74b9331 into main as 8221649e4bbb5836712223c3d5b22845b4769ea0.", "Post-merge canonical verification on 2026-08-27 passed search validation, deterministic generated-output checks, and site integration with no diagnostics."],
+      "reviews": ["Post-merge closeout audit found no unresolved ranking, provenance, authority, stale-output, or generated-search findings."],
+      "publication": {"status": "merged", "issue": 26, "pull_request": 29},
+      "merge": {"approved_head": "99ab12962cb6ce44a623357950c934cdf74b9331", "merge_commit": "8221649e4bbb5836712223c3d5b22845b4769ea0", "merged_at": "2026-08-26T21:55:27Z", "method": "merge"},
+      "unresolved": []
+    }
   }
 }

--- a/.work/changes/016-documentation-publication-hosting-and-release-integration/change.mrd.json
+++ b/.work/changes/016-documentation-publication-hosting-and-release-integration/change.mrd.json
@@ -10,117 +10,41 @@
     "record_mode": "descriptive",
     "status": "active",
     "version": "1.0.0",
-    "dependencies": [
-      {
-        "source": "repo:.work/changes/015-documentation-search-and-knowledge-discovery/change.mrd.json",
-        "relationship": "depends_on"
-      }
-    ],
-    "provenance": {
-      "sources": [
-        {
-          "source_id": "GH-ISSUE-27",
-          "kind": "operator_approved_work_item",
-          "role": "approved_change_basis",
-          "locator": "github:NielPieterse0/kis-mcp-doc#27",
-          "revision": "2026-08-26",
-          "sha256": null
-        }
-      ],
-      "source_fingerprint": null,
-      "fact_quality": "direct"
-    },
+    "dependencies": [{"source": "repo:.work/changes/015-documentation-search-and-knowledge-discovery/change.mrd.json", "relationship": "depends_on"}],
+    "provenance": {"sources": [{"source_id": "GH-ISSUE-27", "kind": "operator_approved_work_item", "role": "approved_change_basis", "locator": "github:NielPieterse0/kis-mcp-doc#27", "revision": "2026-08-26", "sha256": null}], "source_fingerprint": null, "fact_quality": "direct"},
     "supersedes": [],
     "superseded_by": null
   },
   "content": {
     "change_id": "016-documentation-publication-hosting-and-release-integration",
-    "work_item": {
-      "repository": "NielPieterse0/kis-mcp-doc",
-      "issue": 27,
-      "project": "NielPieterse0/1",
-      "record_id": "SPEC-016"
-    },
+    "work_item": {"repository": "NielPieterse0/kis-mcp-doc", "issue": 27, "project": "NielPieterse0/1", "record_id": "SPEC-016"},
     "outcome": "Publish the already-governed documentation site through GitHub Pages and package the exact deterministic site as release assets.",
-    "classification": {
-      "complexity": "large",
-      "risk_triggers": [
-        "public_contract",
-        "external_network"
-      ],
-      "reason": "The change introduces external publication and release-write workflows while preserving generated-site authority boundaries."
-    },
-    "authority_model": [
-      "Generated documentation-site remains the sole deployment payload.",
-      "Hosting and release workflows consume verified generated output and never reinterpret canonical MRDs.",
-      "Release archives are deterministic downstream packages with no write-back authority."
-    ],
-    "requirements": [
-      "R1: GitHub Pages publication MUST deploy only a canonically verified generated/documentation-site bundle.",
-      "R2: Project-site base paths MUST resolve correctly under /kis-mcp-doc.",
-      "R3: Release packaging MUST be byte-deterministic and bind current site and search bundle hashes.",
-      "R4: Repository release publication MUST attach the deterministic archive and metadata without rebuilding semantics.",
-      "R5: Deployment actions MUST be pinned to immutable release commits.",
-      "R6: Full repository verification MUST reject stale site, search, or release artifacts."
-    ],
-    "implementation_plan": [
-      "P1: Add normalized public base-path support to the site renderer.",
-      "P2: Add deterministic documentation release packaging and exact verification.",
-      "P3: Add pinned GitHub Pages build/deploy workflow over generated site output.",
-      "P4: Add release-event workflow that attaches deterministic documentation assets.",
-      "P5: Extend CLI, canonical verification, tests, and governed change evidence."
-    ],
-    "verification_criteria": [
-      "V1: Generated links and search results resolve under /kis-mcp-doc.",
-      "V2: Repeated release builds produce identical ZIP bytes and manifests.",
-      "V3: Tampered or stale site/search/release output fails verification.",
-      "V4: Pages workflow uses pinned official actions and release workflow uploads only generated release assets.",
-      "V5: Canonical Governance, Work Management, and Documentation MRDs remain unchanged."
-    ],
+    "classification": {"complexity": "large", "risk_triggers": ["public_contract", "external_network"], "reason": "The change introduces external publication and release-write workflows while preserving generated-site authority boundaries."},
+    "authority_model": ["Generated documentation-site remains the sole deployment payload.", "Hosting and release workflows consume verified generated output and never reinterpret canonical MRDs.", "Release archives are deterministic downstream packages with no write-back authority."],
+    "requirements": ["R1: GitHub Pages publication MUST deploy only a canonically verified generated/documentation-site bundle.", "R2: Project-site base paths MUST resolve correctly under /kis-mcp-doc.", "R3: Release packaging MUST be byte-deterministic and bind current site and search bundle hashes.", "R4: Repository release publication MUST attach the deterministic archive and metadata without rebuilding semantics.", "R5: Deployment actions MUST be pinned to immutable release commits.", "R6: Full repository verification MUST reject stale site, search, or release artifacts."],
+    "implementation_plan": ["P1: Add normalized public base-path support to the site renderer.", "P2: Add deterministic documentation release packaging and exact verification.", "P3: Add pinned GitHub Pages build/deploy workflow over generated site output.", "P4: Add release-event workflow that attaches deterministic documentation assets.", "P5: Extend CLI, canonical verification, tests, and governed change evidence."],
+    "verification_criteria": ["V1: Generated links and search results resolve under /kis-mcp-doc.", "V2: Repeated release builds produce identical ZIP bytes and manifests.", "V3: Tampered or stale site/search/release output fails verification.", "V4: Pages workflow uses pinned official actions and release workflow uploads only generated release assets.", "V5: Canonical Governance, Work Management, and Documentation MRDs remain unchanged."],
     "tasks": [
-      {
-        "id": "T1",
-        "status": "done",
-        "text": "Raise issue and governed change records."
-      },
-      {
-        "id": "T2",
-        "status": "done",
-        "text": "Implement hosting path, deterministic release package, workflows, and verification."
-      },
-      {
-        "id": "T3",
-        "status": "active",
-        "text": "Verify, publish, merge, observe Pages deployment, and reconcile closeout."
-      }
+      {"id": "T1", "status": "done", "text": "Raise issue and governed change records."},
+      {"id": "T2", "status": "done", "text": "Implement hosting path, deterministic release package, workflows, and verification."},
+      {"id": "T3", "status": "active", "text": "Verify, publish, merge, observe Pages deployment, and reconcile closeout."}
     ],
-    "risks": [
-      "Absolute site links can break under GitHub Pages project paths.",
-      "Deployment workflows can bypass governed generation if they rebuild or transform content independently.",
-      "Release archives can drift if ZIP metadata is not normalized."
-    ],
-    "explicit_exclusions": [
-      "Canonical semantic changes.",
-      "Branding redesign.",
-      "External search service.",
-      "Custom-domain or DNS management."
-    ],
+    "risks": ["Absolute site links can break under GitHub Pages project paths.", "Deployment workflows can bypass governed generation if they rebuild or transform content independently.", "Release archives can drift if ZIP metadata is not normalized."],
+    "explicit_exclusions": ["Canonical semantic changes.", "Branding redesign.", "External search service.", "Custom-domain or DNS management."],
     "closeout": {
-      "state": "implementation_verified_awaiting_publication",
+      "state": "implementation_merged_deployment_follow_up_required",
       "verification": [
         "Rebased Change 016 onto current main 399fab9859696bbac1766e80a36f13c734f1f04d before final verification.",
-        "Full scripts/verify.ps1 passed with exact-head enforcement on rebased implementation a3162d683d024a75f3b82050b48a26cea53f486a.",
-        "Publication-specific review confirmed /kis-mcp-doc base-path generation, deterministic release hashes, and canonical site/search/release validation."
+        "Full scripts/verify.ps1 passed locally through the Defender-safe Python path after rebasing and again on the final locally verified tree.",
+        "The locally verified final tree 5a7db280bab1784b349717ffbcd75eeea987dfb2 exactly matched the GitHub PR head tree.",
+        "GitHub Canonical Verification run 33084428692 succeeded on exact PR head e86c37cedc15726c16a25fafee12c182ea057226.",
+        "PR 30 merged to main as d60687a4f764b0f0458b42fcfd0ac6409810772f.",
+        "Documentation Pages run 33084607163 completed its build job successfully, including canonical verification and Pages artifact upload; the deploy job then failed before a deployment was created."
       ],
-      "reviews": [
-        "GitHub Pages and release workflows use immutable action commit pins and consume only canonically verified generated documentation artifacts."
-      ],
-      "publication": {
-        "status": "pending",
-        "issue": 27,
-        "pull_request": null
-      },
-      "unresolved": []
+      "reviews": ["GitHub Pages and release workflows use immutable action commit pins and consume only canonically verified generated documentation artifacts.", "Post-merge audit confirms the generated documentation build and release payload are valid; only the external Pages deployment step remains unresolved."],
+      "publication": {"status": "merged_deployment_follow_up_required", "issue": 27, "pull_request": 30, "approved_head": "e86c37cedc15726c16a25fafee12c182ea057226", "merge_commit": "d60687a4f764b0f0458b42fcfd0ac6409810772f", "pages_workflow_run": 33084607163},
+      "merge": {"approved_head": "e86c37cedc15726c16a25fafee12c182ea057226", "merge_commit": "d60687a4f764b0f0458b42fcfd0ac6409810772f", "merged_at": "2026-08-27T14:51:49Z", "method": "merge"},
+      "unresolved": ["The first GitHub Pages deploy job failed after successful build, canonical verification, and artifact upload. The connected GitHub interface does not expose the repository Pages settings or deploy-step log needed to complete the external deployment diagnosis from this session."]
     }
   }
 }

--- a/.work/changes/017-defender-safe-python-runtime/change.mrd.json
+++ b/.work/changes/017-defender-safe-python-runtime/change.mrd.json
@@ -8,7 +8,7 @@
     "type": "WFL",
     "layer": "L3",
     "record_mode": "descriptive",
-    "status": "active",
+    "status": "done",
     "version": "1.0.0",
     "dependencies": [],
     "provenance": {
@@ -21,68 +21,28 @@
     },
     "supersedes": [],
     "superseded_by": null
-  },  "content": {
+  },
+  "content": {
     "change_id": "017-defender-safe-python-runtime",
     "outcome": "Eliminate the concurrent Change 015 numeric-prefix collision by moving the Defender-safe Python runtime record to canonical Change 017 while preserving the already-landed implementation unchanged.",
-    "classification": {
-      "complexity": "small",
-      "risk_triggers": [],
-      "reason": "This reconciliation changes only governed change identity metadata; the runtime implementation already landed through PR 31."
-    },
-    "authority_model": [
-      "Numeric change prefixes are unique repository identifiers and the documentation-search work retains canonical Change 015 identity.",
-      "The Defender-safe runtime implementation lineage remains PR 31, reconciled head 236843a72a65cb1b96d8e04149d0f9129efac03d, and merge e83d76d785725bfff55089b94e966b86b637abfb.",
-      "Renaming the governed change record does not alter scripts, tests, tooling policy, runtime behavior, or parent KIS authority."
-    ],
-    "requirements": [
-      "R1: Exactly one governed Change 015 record MUST remain and it MUST be documentation-search-and-knowledge-discovery.",
-      "R2: The Defender-safe Python runtime record MUST be owned under .work/changes/017-defender-safe-python-runtime.",
-      "R3: The Defender runtime MRD identity, module, change_id, scope identity, branch/worktree claim, and Work record identifier MUST consistently use 017.",
-      "R4: This reconciliation MUST NOT modify the already-landed runtime implementation files.",
-      "R5: Prior verification evidence for signed local CPython and zero fresh Code Integrity 3033/3077 blocks MUST remain implementation evidence rather than be restated as new runtime behavior."
-    ],    "implementation_plan": [
-      "P1: Rename the collided Defender runtime change record from numeric prefix 015 to 017.",
-      "P2: Reconcile all identity-bearing fields to 017 and preserve PR 31 as implementation publication provenance.",
-      "P3: Verify that the diff is metadata-only, numeric prefixes are unique, full repository verification passes, and no fresh Code Integrity block appears."
-    ],
-    "verification_criteria": [
-      "V1: The .work/changes directory contains no duplicate numeric prefix among active canonical records.",
-      "V2: The exact Change 017 diff contains only the moved and reconciled scope.json and change.mrd.json files.",
-      "V3: Full scripts/verify.ps1 passes from the Change 017 worktree.",
-      "V4: No Code Integrity 3033/3077 block attributable to verification appears after the verification start time."
-    ],
+    "classification": {"complexity": "small", "risk_triggers": [], "reason": "This reconciliation changes only governed change identity metadata; the runtime implementation already landed through PR 31."},
+    "authority_model": ["Numeric change prefixes are unique repository identifiers and the documentation-search work retains canonical Change 015 identity.", "The Defender-safe runtime implementation lineage remains PR 31, reconciled head 236843a72a65cb1b96d8e04149d0f9129efac03d, and merge e83d76d785725bfff55089b94e966b86b637abfb.", "Renaming the governed change record does not alter scripts, tests, tooling policy, runtime behavior, or parent KIS authority."],
+    "requirements": ["R1: Exactly one governed Change 015 record MUST remain and it MUST be documentation-search-and-knowledge-discovery.", "R2: The Defender-safe Python runtime record MUST be owned under .work/changes/017-defender-safe-python-runtime.", "R3: The Defender runtime MRD identity, module, change_id, scope identity, branch/worktree claim, and Work record identifier MUST consistently use 017.", "R4: This reconciliation MUST NOT modify the already-landed runtime implementation files.", "R5: Prior verification evidence for signed local CPython and zero fresh Code Integrity 3033/3077 blocks MUST remain implementation evidence rather than be restated as new runtime behavior."],
+    "implementation_plan": ["P1: Rename the collided Defender runtime change record from numeric prefix 015 to 017.", "P2: Reconcile all identity-bearing fields to 017 and preserve PR 31 as implementation publication provenance.", "P3: Verify that the diff is metadata-only, numeric prefixes are unique, full repository verification passes, and no fresh Code Integrity block appears."],
+    "verification_criteria": ["V1: The .work/changes directory contains no duplicate numeric prefix among active canonical records.", "V2: The exact Change 017 diff contains only the moved and reconciled scope.json and change.mrd.json files.", "V3: Full scripts/verify.ps1 passes from the Change 017 worktree.", "V4: No Code Integrity 3033/3077 block attributable to verification appears after the verification start time."],
     "tasks": [
       {"id": "T1", "status": "done", "text": "Identify the concurrent Change 015 numeric-prefix collision after refreshing verified GitHub main."},
       {"id": "T2", "status": "done", "text": "Move and reconcile the Defender-safe runtime change record to canonical Change 017."},
-      {"id": "T3", "status": "active", "text": "Verify, publish, merge, refresh local main, and close the reconciliation."}
+      {"id": "T3", "status": "done", "text": "Verify, publish, merge, refresh local main, and close the reconciliation."}
     ],
-    "risks": [
-      "Leaving the historical PR 31 title and branch with 015 is acceptable only as immutable publication provenance; canonical repository change identity must be 017.",
-      "Any implementation-byte change in this reconciliation would expand scope and invalidate the metadata-only correction."
-    ],
-    "explicit_exclusions": [
-      "Runtime implementation changes.",
-      "Defender or Smart App Control policy changes.",
-      "Parent kis-mcp changes or wider C:/Projects rollout.",
-      "Renumbering the independently landed documentation-search Change 015."
-    ],    "closeout": {
-      "state": "reconciliation_in_progress",
-      "verification": [
-        "PR 31 implementation verification passed on signed Python Software Foundation CPython 3.11.9 with zero fresh Code Integrity 3033/3077 blocks.",
-        "Integrated main verification at e83d76d785725bfff55089b94e966b86b637abfb passed with VERIFY_EXIT=0 and CODEINTEGRITY_BLOCKS=0.",
-        "Change 017 reconciliation verification passed with VERIFY_EXIT=0, CODEINTEGRITY_BLOCKS=0, unique numeric prefixes, and a metadata-only two-file diff."
-      ],
-      "reviews": [
-        "Initial safety-security reviewer routes were unavailable; exact implementation diff received manual fallback review before PR 31 merge.",
-        "Change 017 metadata-only reconciliation review completed with no findings."
-      ],
-      "publication": {
-        "status": "implementation_merged_reconciliation_pending",
-        "implementation_pull_request": 31,
-        "implementation_head": "236843a72a65cb1b96d8e04149d0f9129efac03d",
-        "implementation_merge": "e83d76d785725bfff55089b94e966b86b637abfb",
-        "reconciliation_pull_request": null
-      },
+    "risks": ["Leaving the historical PR 31 title and branch with 015 is acceptable only as immutable publication provenance; canonical repository change identity must be 017.", "Any implementation-byte change in this reconciliation would expand scope and invalidate the metadata-only correction."],
+    "explicit_exclusions": ["Runtime implementation changes.", "Defender or Smart App Control policy changes.", "Parent kis-mcp changes or wider C:/Projects rollout.", "Renumbering the independently landed documentation-search Change 015."],
+    "closeout": {
+      "state": "post_merge_complete",
+      "verification": ["PR 31 implementation verification passed on signed Python Software Foundation CPython 3.11.9 with zero fresh Code Integrity 3033/3077 blocks.", "Integrated main verification at e83d76d785725bfff55089b94e966b86b637abfb passed with VERIFY_EXIT=0 and CODEINTEGRITY_BLOCKS=0.", "Change 017 reconciliation verification passed with VERIFY_EXIT=0, CODEINTEGRITY_BLOCKS=0, unique numeric prefixes, and a metadata-only two-file diff.", "PR 32 merged the reconciliation head 842c11029a5467daa0d83efa27604e95b9d970ba into main as 399fab9859696bbac1766e80a36f13c734f1f04d.", "Post-merge canonical verification on 2026-08-27 completed successfully through the Defender-safe local Python path."],
+      "reviews": ["Initial safety-security reviewer routes were unavailable; exact implementation diff received manual fallback review before PR 31 merge.", "Change 017 metadata-only reconciliation review completed with no findings.", "Post-merge closeout audit found no unresolved runtime-identity or Defender execution findings."],
+      "publication": {"status": "merged", "implementation_pull_request": 31, "implementation_head": "236843a72a65cb1b96d8e04149d0f9129efac03d", "implementation_merge": "e83d76d785725bfff55089b94e966b86b637abfb", "reconciliation_pull_request": 32},
+      "merge": {"approved_head": "842c11029a5467daa0d83efa27604e95b9d970ba", "merge_commit": "399fab9859696bbac1766e80a36f13c734f1f04d", "merged_at": "2026-08-27T13:36:17Z", "method": "merge"},
       "unresolved": []
     }
   }


### PR DESCRIPTION
Reconciles post-merge records for Changes 014–017 after the Defender-safe runtime update.

- closes stale Change 014 site/navigation bookkeeping against merged PR #28
- closes stale Change 015 documentation-search bookkeeping against merged PR #29
- closes Change 017 Defender-safe runtime ID reconciliation against merged PR #32
- records Change 016 PR #30 merge, successful canonical verification and Pages artifact build, while leaving the failed first Pages deploy as an explicit unresolved external publication follow-up

No canonical Governance, Work Management, Documentation semantics, generators, or generated documentation bytes are changed.