### PR TITLE
Close Change 016 after Pages deployment

### DIFF
--- a/.work/changes/016-documentation-publication-hosting-and-release-integration/change.mrd.json
+++ b/.work/changes/016-documentation-publication-hosting-and-release-integration/change.mrd.json
@@ -8,7 +8,7 @@
     "type": "WFL",
     "layer": "L3",
     "record_mode": "descriptive",
-    "status": "active",
+    "status": "done",
     "version": "1.0.0",
     "dependencies": [{"source": "repo:.work/changes/015-documentation-search-and-knowledge-discovery/change.mrd.json", "relationship": "depends_on"}],
     "provenance": {"sources": [{"source_id": "GH-ISSUE-27", "kind": "operator_approved_work_item", "role": "approved_change_basis", "locator": "github:NielPieterse0/kis-mcp-doc#27", "revision": "2026-08-26", "sha256": null}], "source_fingerprint": null, "fact_quality": "direct"},
@@ -27,24 +27,25 @@
     "tasks": [
       {"id": "T1", "status": "done", "text": "Raise issue and governed change records."},
       {"id": "T2", "status": "done", "text": "Implement hosting path, deterministic release package, workflows, and verification."},
-      {"id": "T3", "status": "active", "text": "Verify, publish, merge, observe Pages deployment, and reconcile closeout."}
+      {"id": "T3", "status": "done", "text": "Verify, publish, merge, observe Pages deployment, and reconcile closeout."}
     ],
     "risks": ["Absolute site links can break under GitHub Pages project paths.", "Deployment workflows can bypass governed generation if they rebuild or transform content independently.", "Release archives can drift if ZIP metadata is not normalized."],
     "explicit_exclusions": ["Canonical semantic changes.", "Branding redesign.", "External search service.", "Custom-domain or DNS management."],
     "closeout": {
-      "state": "implementation_merged_deployment_follow_up_required",
+      "state": "post_merge_complete",
       "verification": [
         "Rebased Change 016 onto current main 399fab9859696bbac1766e80a36f13c734f1f04d before final verification.",
         "Full scripts/verify.ps1 passed locally through the Defender-safe Python path after rebasing and again on the final locally verified tree.",
         "The locally verified final tree 5a7db280bab1784b349717ffbcd75eeea987dfb2 exactly matched the GitHub PR head tree.",
         "GitHub Canonical Verification run 33084428692 succeeded on exact PR head e86c37cedc15726c16a25fafee12c182ea057226.",
         "PR 30 merged to main as d60687a4f764b0f0458b42fcfd0ac6409810772f.",
-        "Documentation Pages run 33084607163 completed its build job successfully, including canonical verification and Pages artifact upload; the deploy job then failed before a deployment was created."
+        "Documentation Pages run 33084607163 completed its build job successfully, including canonical verification and Pages artifact upload; the deploy job then failed because GitHub Pages was not enabled for the repository.",
+        "After GitHub Pages was enabled with GitHub Actions as the source, Documentation Pages run 33091758746 succeeded on exact main SHA 2f7a9182b91ddc29c9c84797f1e2091ef1ab1330, including governed verification, artifact upload, and deploy."
       ],
-      "reviews": ["GitHub Pages and release workflows use immutable action commit pins and consume only canonically verified generated documentation artifacts.", "Post-merge audit confirms the generated documentation build and release payload are valid; only the external Pages deployment step remains unresolved."],
-      "publication": {"status": "merged_deployment_follow_up_required", "issue": 27, "pull_request": 30, "approved_head": "e86c37cedc15726c16a25fafee12c182ea057226", "merge_commit": "d60687a4f764b0f0458b42fcfd0ac6409810772f", "pages_workflow_run": 33084607163},
+      "reviews": ["GitHub Pages and release workflows use immutable action commit pins and consume only canonically verified generated documentation artifacts.", "Post-merge audit confirms the generated documentation build, release payload, and GitHub Pages deployment are valid."],
+      "publication": {"status": "published", "issue": 27, "pull_request": 30, "approved_head": "e86c37cedc15726c16a25fafee12c182ea057226", "merge_commit": "d60687a4f764b0f0458b42fcfd0ac6409810772f", "pages_workflow_run": 33091758746},
       "merge": {"approved_head": "e86c37cedc15726c16a25fafee12c182ea057226", "merge_commit": "d60687a4f764b0f0458b42fcfd0ac6409810772f", "merged_at": "2026-08-27T14:51:49Z", "method": "merge"},
-      "unresolved": ["The first GitHub Pages deploy job failed after successful build, canonical verification, and artifact upload. The connected GitHub interface does not expose the repository Pages settings or deploy-step log needed to complete the external deployment diagnosis from this session."]
+      "unresolved": []
     }
   }
 }


### PR DESCRIPTION
Records successful GitHub Pages publication for Change 016 after enabling GitHub Actions as the Pages source. The record is moved to post_merge_complete, T3 is marked done, publication is marked published, workflow run 33091758746 is recorded, and unresolved deployment follow-up is cleared. No canonical documentation semantics or generated documentation bytes are changed.